### PR TITLE
docs(process): require branch-first for all changes; drop lightweight bypass

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ related:
 
 ## 核心原则（不可违反）
 
-1. **分支先行**：所有改动（含文档、错别字、依赖补丁）必须先从 `main` checkout 新分支再动手；禁止在 `main` 上直接编辑或 commit 未合入的改动。理由：PR 是本项目强制的 codex review 触发点，绕过分支即绕过 review。细节见 [`docs/dev/process/commit-and-branch.md`](docs/dev/process/commit-and-branch.md)。
+1. **分支先行**：所有改动（含文档、错别字、依赖补丁）必须先从 `main` checkout 新分支再动手；禁止在 `main` 上直接编辑或 commit 未合入的改动。理由：① PR 是 codex review / ultrareview 反馈与作者回应的承载窗口（review 本身手动触发，但 diff、评论、决策记录都挂在 PR 上）；② 分支隔离让每次改动独立可回滚、强制范围收敛；③ 为未来分支保护、自动化 CI/review hook、required reviewers 留出落点。细节见 [`docs/dev/process/commit-and-branch.md`](docs/dev/process/commit-and-branch.md)。
 2. **文档先行**：新模块没进 `docs/dev/spec/` 不接受 PR；架构级改动没进 `docs/dev/adr/` 不接受 PR。
 3. **TDD 强制**：先 spec → 先 failing test → 再 impl。细节见 [`docs/dev/process/tdd.md`](docs/dev/process/tdd.md)。
 4. **契约先行**：跨层交互必须走 `docs/dev/spec/` 定义的接口。新增能力先改 spec，再改代码。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 title: AGENTS.md（agent-nexus 项目规则）
 type: root
 status: active
-summary: 项目特有协作规则入口，叠加在全局 ~/.claude/CLAUDE.md 之上，定义七条不可违反的核心原则与 PR 三问
+summary: 项目特有协作规则入口，叠加在全局 ~/.claude/CLAUDE.md 之上，定义九条不可违反的核心原则与 PR 三问
 tags: [workflow, tdd, code-review, subagent, commit]
 related:
   - root/CONTRIBUTING
@@ -18,14 +18,15 @@ related:
 
 ## 核心原则（不可违反）
 
-1. **文档先行**：新模块没进 `docs/dev/spec/` 不接受 PR；架构级改动没进 `docs/dev/adr/` 不接受 PR。
-2. **TDD 强制**：先 spec → 先 failing test → 再 impl。细节见 [`docs/dev/process/tdd.md`](docs/dev/process/tdd.md)。
-3. **契约先行**：跨层交互必须走 `docs/dev/spec/` 定义的接口。新增能力先改 spec，再改代码。
-4. **Code review 不走过场**：每个 PR 必须过 codex review（大变更走 ultrareview）。流程见 [`docs/dev/process/code-review.md`](docs/dev/process/code-review.md)。
-5. **Subagent 优先**：探索类、长研究类任务优先派发子代理，主 session 只做收敛与决策。细节见 [`docs/dev/process/subagent-usage.md`](docs/dev/process/subagent-usage.md)。
-6. **范围收敛**：每个 PR 只做一件事，禁止"顺手重构"无关代码。
-7. **Conventional Commits**：所有提交遵循 [`docs/dev/process/commit-and-branch.md`](docs/dev/process/commit-and-branch.md)。
-8. **作废文档物化到归档目录**：Superseded ADR 和明确 Deprecated 的文档必须住在 `docs/dev/adr/deprecated/` 或 `docs/_deprecated/`——路径本身就是"别当事实"的信号。active 路径下的文档（含 placeholder）可直接 `Read`；归档路径的文档由 hook 拦截，必须走 `scripts/docs-read --force`。详见下文"读文档的防污染规则"。
+1. **分支先行**：所有改动（含文档、错别字、依赖补丁）必须先从 `main` checkout 新分支再动手；禁止在 `main` 上直接编辑或 commit 未合入的改动。理由：PR 是本项目强制的 codex review 触发点，绕过分支即绕过 review。细节见 [`docs/dev/process/commit-and-branch.md`](docs/dev/process/commit-and-branch.md)。
+2. **文档先行**：新模块没进 `docs/dev/spec/` 不接受 PR；架构级改动没进 `docs/dev/adr/` 不接受 PR。
+3. **TDD 强制**：先 spec → 先 failing test → 再 impl。细节见 [`docs/dev/process/tdd.md`](docs/dev/process/tdd.md)。
+4. **契约先行**：跨层交互必须走 `docs/dev/spec/` 定义的接口。新增能力先改 spec，再改代码。
+5. **Code review 不走过场**：每个 PR 必须过 codex review（大变更走 ultrareview）。流程见 [`docs/dev/process/code-review.md`](docs/dev/process/code-review.md)。
+6. **Subagent 优先**：探索类、长研究类任务优先派发子代理，主 session 只做收敛与决策。细节见 [`docs/dev/process/subagent-usage.md`](docs/dev/process/subagent-usage.md)。
+7. **范围收敛**：每个 PR 只做一件事，禁止"顺手重构"无关代码。
+8. **Conventional Commits**：所有提交遵循 [`docs/dev/process/commit-and-branch.md`](docs/dev/process/commit-and-branch.md)。
+9. **作废文档物化到归档目录**：Superseded ADR 和明确 Deprecated 的文档必须住在 `docs/dev/adr/deprecated/` 或 `docs/_deprecated/`——路径本身就是"别当事实"的信号。active 路径下的文档（含 placeholder）可直接 `Read`；归档路径的文档由 hook 拦截，必须走 `scripts/docs-read --force`。详见下文"读文档的防污染规则"。
 
 ## 读文档的防污染规则
 

--- a/docs/dev/process/code-review.md
+++ b/docs/dev/process/code-review.md
@@ -97,7 +97,8 @@ Ultrareview 的反馈响应规则同上。
 - 把 codex review 当橡皮图章（"它说 OK 就 OK"）
 - PR 作者自己审自己（除非单人仓库且已跑过 codex）
 - 合并有未回应反馈的 PR
-- 跳过 review 直接合并（除非是轻量路径白名单内的改动）
+- 跳过 review 直接合并（不存在"太小就不 review"的例外）
+- 在 `main` 上直接 commit，绕过分支 / PR / review（见 `commit-and-branch.md`"分支先行"）
 
 ## 反模式速查
 

--- a/docs/dev/process/commit-and-branch.md
+++ b/docs/dev/process/commit-and-branch.md
@@ -71,6 +71,12 @@ BREAKING CHANGE: session key 从 (platform, channelId, userId) 改为
 
 ## 分支策略
 
+### 分支先行（硬性要求）
+
+一切改动——代码、文档、脚本、配置——必须先从 `main` checkout 新分支再动手。**禁止在 `main` 上直接编辑或 commit 未合入的改动**。即便是单行错别字也走分支 → PR → review → squash merge。
+
+理由：PR 是本项目强制的 codex review 触发点。跳过分支 = 跳过 review。
+
 ### 分支命名
 
 ```
@@ -89,7 +95,7 @@ BREAKING CHANGE: session key 从 (platform, channelId, userId) 改为
 
 ### 主分支
 
-- `main`：当前稳定分支。直接向 `main` push 的权限保留给维护者。
+- `main`：当前稳定分支。只接受来自 feature 分支的 squash merge PR，**任何人（包括维护者）不得在 `main` 上直接编写或 commit 未经 PR 的改动**。
 - 本阶段（单人 + 文档）不设置额外保护分支。
 - MVP 发版后会新增 `release/*` 分支与 tag 策略，届时本文件补充。
 

--- a/docs/dev/process/commit-and-branch.md
+++ b/docs/dev/process/commit-and-branch.md
@@ -75,7 +75,12 @@ BREAKING CHANGE: session key 从 (platform, channelId, userId) 改为
 
 一切改动——代码、文档、脚本、配置——必须先从 `main` checkout 新分支再动手。**禁止在 `main` 上直接编辑或 commit 未合入的改动**。即便是单行错别字也走分支 → PR → review → squash merge。
 
-理由：PR 是本项目强制的 codex review 触发点。跳过分支 = 跳过 review。
+理由（详见 `workflow.md`「分支先行（不可跳过）」）：
+
+- PR 是 review 反馈与作者回应的承载窗口（codex review 当前手动触发，记录挂 PR 上）
+- 分支隔离 → 单次改动可独立 revert / abandon
+- 分支命名强制范围收敛
+- 为未来分支保护、自动化 CI/review hook 留落点
 
 ### 分支命名
 

--- a/docs/dev/process/workflow.md
+++ b/docs/dev/process/workflow.md
@@ -2,7 +2,7 @@
 title: 开发流程（workflow）
 type: process
 status: active
-summary: 从想法到合并的主路径；何时需要 ADR/spec/TDD、完成定义、轻量路径白名单
+summary: 从想法到合并的主路径；分支先行、何时需要 ADR/spec/TDD、完成定义
 tags: [workflow, process]
 related:
   - root/AGENTS
@@ -14,7 +14,7 @@ related:
 
 # 开发流程（workflow）
 
-定义"从想法到合并"的完整路径。所有代码改动都走此流程，除非命中下文"轻量路径"白名单。
+定义"从想法到合并"的完整路径。所有代码与文档改动都走此流程，没有例外——包括错别字、注释、依赖补丁升级。
 
 ## 主路径
 
@@ -23,28 +23,37 @@ related:
  │
  ├─> 1. 开 Issue 说明问题与目标
  │
- ├─> 2. 判断是否需要 ADR
+ ├─> 2. 从 main checkout 新分支（命名见 commit-and-branch.md）
+ │     后续所有 ADR/spec/test/impl 的改动都落在这条分支上
+ │
+ ├─> 3. 判断是否需要 ADR
  │     ├─ 是 → 写 ADR（docs/dev/adr/）→ 评审 → 状态标为 Accepted
  │     └─ 否 → 跳过
  │
- ├─> 3. 判断是否需要 spec
+ ├─> 4. 判断是否需要 spec
  │     ├─ 是 → 写或改 spec（docs/dev/spec/）→ 评审
  │     └─ 否 → 跳过
  │
- ├─> 4. 写 failing test（TDD，见 process/tdd.md）
+ ├─> 5. 写 failing test（TDD，见 process/tdd.md）
  │
- ├─> 5. 写最小实现让测试变绿
+ ├─> 6. 写最小实现让测试变绿
  │
- ├─> 6. 按需 refactor（保持测试绿）
+ ├─> 7. 按需 refactor（保持测试绿）
  │
- ├─> 7. 自查清单（见 process/code-review.md）
+ ├─> 8. 自查清单（见 process/code-review.md）
  │
- ├─> 8. Codex review（大变更额外跑 ultrareview）
+ ├─> 9. Codex review（大变更额外跑 ultrareview）
  │
- ├─> 9. 人类 review（如果有协作者）
+ ├─> 10. 人类 review（如果有协作者）
  │
- └─> 10. Merge（遵循 commit-and-branch.md 的合并策略）
+ └─> 11. Merge（遵循 commit-and-branch.md 的合并策略）
 ```
+
+## 分支先行（不可跳过）
+
+- 一切改动必须在从 `main` checkout 的新分支上进行，包括纯文档、错别字、依赖补丁升级。
+- 禁止在 `main` 上直接编辑、commit 或累积未 PR 的改动。
+- 即便是"一行改动"，也走 分支 → PR → review → squash merge 的完整链路。原因：本项目把 PR 作为强制的 codex review 触发点，绕过分支就绕过了 review。
 
 ## 何时需要 ADR
 
@@ -64,16 +73,16 @@ related:
 
 只改单一模块内部实现、不影响外部契约的，不需要改 spec。
 
-## 轻量路径（可跳过 ADR/spec/TDD）
+## 可跳过 ADR / spec / TDD 的情形
 
-以下改动允许直接走"改 → 自查 → review → merge"：
+流程主路径的每一步都保留，但以下改动允许在该步"判断为不需要"后直接跳过，而**分支、PR、review、squash merge 不可跳过**：
 
-- 文档错别字、链接修复、术语统一
-- 依赖的补丁版本升级（无 breaking change）
-- 代码注释修改
-- 本地开发脚本的小调整（不影响 CI）
+- 文档错别字、链接修复、术语统一 → 跳过 ADR / spec / test
+- 依赖的补丁版本升级（无 breaking change） → 跳过 ADR / spec；是否需要 test 看风险
+- 代码注释修改 → 跳过 ADR / spec / test
+- 本地开发脚本的小调整（不影响 CI） → 跳过 ADR / spec；是否需要 test 看风险
 
-轻量路径仍然需要 Conventional Commit 且 PR 必须范围收敛。
+上述改动同样需要独立分支、Conventional Commit 和 PR 范围收敛。
 
 ## 完成定义（Definition of Done）
 
@@ -97,6 +106,7 @@ related:
 
 ## 反模式
 
+- **在 `main` 上直接实现 / commit**（违反"分支先行"，绕过 PR 与 codex review）
 - 先写实现再补测试（违反 TDD，见 `process/tdd.md`）
 - 先写实现再补 spec（违反"契约先行"）
 - ADR 写完就开始写代码，跳过评审

--- a/docs/dev/process/workflow.md
+++ b/docs/dev/process/workflow.md
@@ -53,7 +53,14 @@ related:
 
 - 一切改动必须在从 `main` checkout 的新分支上进行，包括纯文档、错别字、依赖补丁升级。
 - 禁止在 `main` 上直接编辑、commit 或累积未 PR 的改动。
-- 即便是"一行改动"，也走 分支 → PR → review → squash merge 的完整链路。原因：本项目把 PR 作为强制的 codex review 触发点，绕过分支就绕过了 review。
+- 即便是"一行改动"，也走 分支 → PR → review → squash merge 的完整链路。
+
+理由：
+
+1. **PR 是 review 的承载窗口**：codex review / ultrareview 当前由作者手动触发（见 `code-review.md`），但 diff 展示、评论、反馈与作者回应、决策记录都挂在 PR 上。直接在 `main` commit 等于把这些都丢掉。
+2. **分支隔离**：每次改动独立、可单独 revert、可 abandon；不会把半成品和别人的工作搅在一起。
+3. **强制范围收敛**：分支命名（`<type>/<short-description>`）本身就是"这次只做这一件事"的承诺，与"PR 单一关注点"形成双约束。
+4. **为未来留位**：分支保护规则、PR 触发的 CI、自动 review hook、required reviewers——都需要"分支 → PR"已经是默认习惯才能挂上去。
 
 ## 何时需要 ADR
 


### PR DESCRIPTION
## Summary

修复协作流程漏洞：原 `workflow.md` 主路径中没有"先开分支"的显式步骤，agent 容易在 `main` 上直接动手；原"轻量路径"白名单允许跳过 review，与"PR 是 codex review 强制触发点"的约定冲突。

- `workflow.md`：主路径插入 step 2「从 main checkout 新分支」；新增「分支先行（不可跳过）」小节；将原"轻量路径"改写为"可跳过 ADR/spec/TDD 的情形"，明确分支/PR/review/squash merge 不可跳过；反模式补「在 main 上直接实现/commit」
- `commit-and-branch.md`：「分支策略」开头加「分支先行（硬性要求）」；主分支描述禁止任何人在 `main` 上直接编辑/commit
- `code-review.md`：删除"轻量路径白名单"例外；禁止条目加"在 main 上直接 commit 绕过分支/PR/review"
- `AGENTS.md`：核心原则新增 #1「分支先行」，原 1-8 顺延为 2-9；frontmatter「七条」→「九条」

## PR 三问

1. **对应哪条 ADR？** N/A — 流程文档调整，不涉及架构决策
2. **对应哪个 spec？** N/A — 不涉及模块契约
3. **对应哪些测试？** N/A — 纯文档/流程规则；执行靠 reviewer 把关与未来可能补的 hook（独立 PR）

## Test plan

- [ ] 本仓库后续 PR 验证：作者从 main 直接编辑被 reviewer 打回
- [ ] grep 确认无残留"轻量路径"措辞（已 grep 通过）

🤖 Generated with [Claude Code](https://claude.com/claude-code)