### PR TITLE
docs(process): tighten subagent-usage 反例 for audit-class tasks

### DIFF
--- a/docs/dev/process/subagent-usage.md
+++ b/docs/dev/process/subagent-usage.md
@@ -175,7 +175,14 @@ review / plan / simplify 类 agent 不适用该模板——产出结构不同。
 
 > 派一个 Explore 扫遍 `docs/dev/` 下 40 份 markdown，逐文件审计矛盾、缺失、stale。
 
-正确做法：派 3 个并行 Explore，分别审计 `adr/` + `architecture/` / `spec/` 核心三件套 + `agent-backends/` / `spec/infra/` + `spec/security/` + `standards/` + `testing/`，主 session 再做一次跨分区收敛。
+正确做法：派 ≥2 个并行 `general-purpose`（**不是 Explore**——Explore 优化"快速查找"，不擅穷举判定），按目录或维度切片（如 `adr/` + `architecture/` / `spec/` 核心三件套 + `agent-backends/` / `spec/infra/` + `spec/security/` + `standards/` + `testing/`），主 session 再做一次跨分区收敛。
+
+派发 prompt 还要满足两点，否则即使并行也会漏报：
+
+1. **要求逐文件 enumerate + 三态判定**（违反 / 合规 / 不适用），不允许"找够显著的就停"——审计类任务的产出必须能让主 session 看出子代理是不是漏看了
+2. **不在 prompt 里替子代理预设范围豁免**（"不要审计 X / 跳过 Y"），除非能指向具体 ADR / docs 章节解释豁免依据；脑补豁免会让子代理永远看不到那块
+
+收敛阶段同样关键：**verify（核对子代理报的对不对）和 sweep（看它没说的有没有问题）都要做**，不能只 verify。
 
 ### 串行不可避免的场景
 


### PR DESCRIPTION
## Summary

把 `docs/dev/process/subagent-usage.md` §任务拆分与并行派发的 §反例 段扩写，加入今天 doc-ownership audit 暴露的三条失败维度，让"派单 Explore 扫全 docs"反例从单一根因升级为完整反例 + 修复方向。

源事件：今天对 `docs/dev/` 做 doc-ownership audit，派 1 个 `Explore` + prompt 里自设"元层豁免"，只找到 3 条违反；同期外部审视（issue #20）按穷举式扫描发现 ~25 条，漏报 ~20 条。三条根因：
- `Explore` 优化"快速查找"，不擅穷举判定 → 应该用 `general-purpose`
- 自设"不要审计 X" 豁免无 ADR / docs 背书，缩窄子代理观测面
- 主 session 收敛只 verify（核对子代理说的对不对），没 sweep（看它没说的有没有问题）

详细复盘见 issue #20 [comment](https://github.com/moesin-lab/agent-nexus/issues/20#issuecomment-4321726898) 与同步沉淀的 auto-memory `feedback_audit_dispatch`。

## 三问

1. **对应哪条 ADR？** N/A——既有 process 文件的反例段细化，不引入新决策
2. **对应哪个 spec？** N/A——纯 process 文档
3. **对应哪些测试？** N/A——文档-only 改动，验证靠 reviewer 阅读

## 注

`subagent-usage.md` 自身（line 52-178）按 doc-ownership 严格判定属于 process 混 standards 本体（已在 issue #20 补充发现 #1 列出），整体待后续 cleanup PR 拆分。本 PR **不**触碰那个边界问题——只在现有结构里就近加内容，让在拆分前的窗口期至少把今天的教训记下来。