### PR TITLE
ci: add claude-code-action workflow with OAuth + Sentixxx-only gating

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,37 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,22 +1,24 @@
 name: Claude Code
 
 on:
+  issues:
+    types: [assigned]
   issue_comment:
     types: [created]
   pull_request_review_comment:
     types: [created]
-  issues:
-    types: [opened, assigned]
   pull_request_review:
     types: [submitted]
 
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      github.event.sender.login == 'Sentixxx' && (
+        (github.event_name == 'issues' && github.event.assignee.login == 'Sentixxx') ||
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude'))
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -35,3 +37,4 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          assignee_trigger: "Sentixxx"

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ __pycache__/
 venv/
 .pnp.*
 .yarn/
+*.tsbuildinfo
 
 # Test / coverage
 coverage/


### PR DESCRIPTION
## Summary

- 接入官方 `anthropics/claude-code-action@v1`，让我们能在 issue / PR 上调用 Claude Code。
- 认证走 Pro/Max 订阅 OAuth token（`secrets.CLAUDE_CODE_OAUTH_TOKEN`），不消耗 API 额度。
- 收紧触发面：
  - **Issue**：Sentixxx 把 issue 指派给 Sentixxx 才触发（`assignee_trigger: "Sentixxx"` + `if` 双层卡）。
  - **PR**：Sentixxx 在 issue/PR 评论、PR 行内 review comment、PR review body 里 `@claude` 才触发。
- 外层 `github.event.sender.login == 'Sentixxx'` 兜底，所有路径只允许 Sentixxx 作为 actor，避免 public repo 下任意访客触发吃订阅额度。

## 三问

1. **对应哪条 ADR？** N/A — 仅接入第三方 GitHub Action，无架构决策。
2. **对应哪个 spec？** N/A — CI 基础设施，不属于 daemon / platform / agent 任一模块。
3. **对应哪些测试？** N/A — workflow 由 GitHub Actions 解析器校验语法；行为只能在 merge 后通过实际触发做 smoke test。

## Test plan

合入后逐条手动验证：

- [ ] Sentixxx 把自己指派给一个 issue → action 触发，Claude 回复
- [ ] Sentixxx 在 PR 评论里写 `@claude review this` → action 触发
- [ ] Sentixxx 在 PR 行内 review comment 里 `@claude` → action 触发
- [ ] 非 Sentixxx 用户做以上操作 → action **不**触发（看 Actions tab，应该被 `if` 直接 skip）
- [ ] Sentixxx 指派 issue 给**别人**（assignee != Sentixxx）→ action 不触发

## 已知边界

- `secrets.CLAUDE_CODE_OAUTH_TOKEN` 必须先在仓库 secrets 里配好，否则 action 启动即失败。本 PR 不附带 secret 写入。
- OAuth token 会过期，过期后需要本地 `claude setup-token` 重新生成并更新 secret。
- 高频 `@claude` 会消耗个人订阅额度，必要时再加 rate limit。
