### PR TITLE
ci(claude): pin claude-code-action to v1.0.88

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,7 +34,9 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        # TODO: unpin to @v1 once anthropics/claude-code-action#1187 is merged.
+        # v1.0.89+ crashes with ENOENT when CLAUDE.md is a symlink (we have CLAUDE.md -> AGENTS.md).
+        uses: anthropics/claude-code-action@v1.0.88
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           assignee_trigger: "Sentixxx"


### PR DESCRIPTION
## Summary

PR #25 合入后 action 在 PR 上跑直接 fail：

```
Restoring .claude, .mcp.json, .claude.json, .gitmodules, .ripgreprc,
CLAUDE.md, CLAUDE.local.md, .husky from origin/main (PR head is untrusted)
Error: Action failed with error: ENOENT: no such file or directory, symlink
```

定位：本仓库 `CLAUDE.md` 是 symlink → `AGENTS.md`，正好踩 anthropics/claude-code-action 已知 bug。

- 上游 issue：[anthropics/claude-code-action#1187](https://github.com/anthropics/claude-code-action/issues/1187) — `cpSync crashes with ENOENT when sensitive paths are symlinks`
- v1.0.89 起把 PR head 当不可信，复制 sensitive paths 时 `cpSync` 没处理 symlink 源 → crash
- 修复 PR [#1186](https://github.com/anthropics/claude-code-action/pull/1186) 仍未合
- 上游官方 workaround：钉版本到 `v1.0.88`

本 PR 把 `uses: anthropics/claude-code-action@v1` 改成 `@v1.0.88`，并加 TODO 注释，等 #1187 合并后再 unpin。

## 三问

1. **对应哪条 ADR？** N/A — 第三方 action 版本钉死，无架构决策。
2. **对应哪个 spec？** N/A — CI 基础设施。
3. **对应哪些测试？** N/A — workflow 由 GHA 解析器校验语法；行为只能在 merge 后触发实际事件 smoke test。

## Test plan

合入后：

- [ ] Sentixxx 在某个 PR 上 `@claude` 评论 → action 不再 ENOENT，正常进入 Claude 处理流程
- [ ] Sentixxx 自指派 issue → 同上
- [ ] action 日志里不应再出现 `Restoring ... ENOENT: no such file or directory, symlink`

## 已知边界

- 钉死的 v1.0.88 不会自动收上游的 bug fix / feature；需要定期回看 #1187 / #1186 状态决定何时 unpin。
- 如果上游修复后行为有破坏性变化，unpin 时要重新过 Test plan。
