### PR TITLE
docs: 补充 Discord bot 申请步骤

### DIFF
--- a/docs/product/README.md
+++ b/docs/product/README.md
@@ -1,8 +1,8 @@
 ---
 title: 产品文档中心
 type: index
-status: placeholder
-summary: 面向使用者的文档中心；本阶段仅占位，等 MVP 可运行后填写
+status: active
+summary: 面向使用者的文档中心；已补齐 Discord 起步文档，其他章节继续完善
 tags: [product, navigation]
 related:
   - root/README
@@ -13,7 +13,7 @@ related:
 
 # 产品文档中心
 
-> **状态**：占位。本阶段（文档与规范骨架）尚无可用产物，本中心所有文档均为骨架，**等 MVP 可运行后填写**。
+> **状态**：部分可用。当前先补齐 Discord 申请与使用起步文档，其他章节继续分批完善。
 
 ## 本中心的定位
 
@@ -24,11 +24,11 @@ related:
 - 在 Discord 里怎么用？支持哪些命令？
 - 出问题怎么查？
 
-## 为什么现在不写
+## 为什么暂不全写
 
-- 还没有可用的可执行文件，写"怎么装"没意义
-- Slash command 集合、配置项、错误提示都尚未定型
-- 过早的产品文档必然变成过时内容，误导用户
+- 仍有部分使用流程和命令集合未冻结
+- 先把已经稳定的入口、配置和申请步骤写清楚，避免散落在代码注释和 README 里
+- 其余内容按实际反馈补齐，避免一次性写出过时文档
 
 ## 本中心 vs `dev/` vs `ops/`
 
@@ -36,15 +36,15 @@ related:
 |---|---|
 | "我要改代码" | [`../dev/`](../dev/) |
 | "我要部署维护" | [`../ops/`](../ops/) |
-| "我要使用" | 本中心（占位中） |
+| "我要使用" | 本中心 |
 
-## 占位文件清单
+## 文档清单
 
-- [`user-guide.md`](user-guide.md) — 入门与使用指南
-- [`platforms/discord.md`](platforms/discord.md) — Discord 专属使用手册
-- [`faq.md`](faq.md) — 常见问题
+- [`user-guide.md`](user-guide.md) — 入门与使用指南（仍在补充）
+- [`platforms/discord.md`](platforms/discord.md) — Discord 专属使用手册（已补齐申请步骤）
+- [`faq.md`](faq.md) — 常见问题（仍在补充）
 
-## 填写时机
+## 继续补齐的触发条件
 
 本中心在下列里程碑后开始填写：
 

--- a/docs/product/platforms/discord.md
+++ b/docs/product/platforms/discord.md
@@ -1,8 +1,8 @@
 ---
 title: Discord 使用手册
 type: product
-status: placeholder
-summary: Discord 侧的注册、权限、slash command、错误提示手册；等 MVP 后填写
+status: active
+summary: Discord bot 申请、邀请、权限与基础使用步骤
 tags: [product, discord, user-guide]
 related:
   - product/user-guide
@@ -11,33 +11,32 @@ related:
   - dev/spec/security/README
 ---
 
-# Discord 使用手册（占位）
+# Discord 使用手册
 
-> **状态**：占位。等 MVP 可运行后填写。
+这页只写 Discord 侧最先要做的事：申请 bot、拿到 token、邀请进测试 server。
 
-## 将包含的章节（规划）
+## 申请 Discord Bot
 
-- **注册 Discord Application**：创建 app、拿 client id、bot token
-- **配置 scope 与权限**：`bot` / `applications.commands` / `message_content` / 具体 permissions 数值
-- **把 bot 加入 server**：OAuth2 URL
-- **在 channel 里使用**：at mention、DM、thread
-- **Slash command 列表**：MVP 预计包含
-  - `/start` — 启动新会话（绑定当前 channel）
-  - `/end` — 结束当前会话
-  - `/reset` — 重置会话（保留历史）
-  - `/budget` — 查看预算使用
-  - `/resume` — 熔断后恢复
-- **消息切片提示**：遇到长输出的提示文本
-- **常见错误提示**：用户侧会看到的错误消息解释
+1. 打开 [Discord Developer Portal](https://discord.com/developers/applications)，创建一个新的 Application。
+2. 进入应用后，在 `Bot` 页面创建 Bot User，并复制 `Bot Token`。
+3. 立刻把 token 记到本机密钥文件里，不要发到频道、Issue 或截图里。
+4. 在 `Bot` 页面打开 `MESSAGE CONTENT INTENT`。不打开的话，bot 读不到普通消息内容。
+5. 在 `Installation` 或 `OAuth2` 的邀请配置里，至少选择 `bot` 和 `applications.commands` 两个 scope。
+6. 按实际部署模式勾选最小权限。MVP 常见是 `Send Messages`、`Read Message History`，如果要在 thread 里工作，再按需要加 thread 相关权限。
+7. 复制生成的邀请链接，把 bot 拉进测试 server。
+8. 回到本地配置，把 `bot user id` 和 `Bot Token` 填到 agent-nexus 需要的位置。
 
-## 为什么现在不写
+## 验证是否申请成功
 
-Slash command 集合、消息格式、错误模板都还没确定（见 `dev/spec/platform-adapter.md` §"发送映射"）。过早写会误导用户。
+- bot 出现在 server 成员列表里
+- portal 里 `Bot Token` 已生成并可用
+- `MESSAGE CONTENT INTENT` 已开启
+- 用 `@bot ping` 或 slash command 能收到响应
 
-## 参考规范
+## 参考
 
-本手册在填写时必须与以下开发 spec 对齐：
+本文按下面两类资料整理：
 
-- [`../../dev/spec/platform-adapter.md`](../../dev/spec/platform-adapter.md)
-- [`../../dev/spec/message-protocol.md`](../../dev/spec/message-protocol.md)
-- [`../../dev/spec/security.md`](../../dev/spec/security/README.md)（allowlist 的使用面）
+- [Discord 官方：Building your first Discord Bot](https://docs.discord.com/developers/quick-start/getting-started)
+- [Discord 官方：OAuth2 and Permissions](https://docs.discord.com/developers/platform/oauth2-and-permissions)
+- [知乎参考文章](https://zhuanlan.zhihu.com/p/1999598055972947248)

--- a/docs/product/user-guide.md
+++ b/docs/product/user-guide.md
@@ -18,7 +18,7 @@ related:
 
 - **快速上手**：5 分钟从零到可用
 - **安装**：各平台安装方式
-- **配置 Discord bot**：注册、token、scope、加入 server
+- **配置 Discord bot**：见 [`platforms/discord.md`](platforms/discord.md) 的申请、邀请和权限步骤
 - **配置 Anthropic**：API key / 订阅
 - **配置 allowlist**：允许哪些 Discord user 使用
 - **启动与停止**：命令、自启动、日志位置


### PR DESCRIPTION
## 变更内容
- 补充 `docs/product/platforms/discord.md`：Discord bot 申请、token、scope、邀请 server、基础验证步骤
- 更新 `docs/product/README.md`：将产品文档中心从纯占位改为部分可用
- 更新 `docs/product/user-guide.md`：把 Discord 配置入口指向专门文档

## PR 三问
1. 对应哪条 ADR？
   - ADR-0001（IM 平台选择 Discord）是背景约束；本 PR 不改决策，只补面向使用者的操作文档。
2. 对应哪个 spec？
   - 无直接 spec 变更；本 PR 只是把现有平台选择和安全约束落到产品文档。
3. 对应哪些测试？
   - `git diff --check`
   - 目视检查 Markdown 链接和 frontmatter 变更

## 说明
- 文档内容参考 Discord 官方安装与 OAuth2 权限说明，以及用户提供的参考文章。
- 本 PR 不涉及代码或行为变更。