### PR TITLE
fix(dev): conditional exports 让 dev 模式直接吃源码，消除隐式重建步

### DIFF
--- a/docs/dev/process/workflow.md
+++ b/docs/dev/process/workflow.md
@@ -106,6 +106,13 @@ related:
 - **同会话连续修复链**：同一会话内连续暴露的 bug，若 scope 差距不大、同主题、且新问题在当前 PR 合并前无法独立验证（典型：A 不修就跑不到 B 的代码路径），**应叠在当前分支继续提交（首选）或开 stacked PR 声明 `base=<当前 PR 分支>`（次选）**，禁止机械地从 `main` 拉并行 PR。判据：在新开分支前先问"这个新 fix 在当前 PR 合并前能独立 run 通 / 独立合并吗？"——答否就不该并行。"范围收敛"管的是无关顺手改，本条管的是有关连环修；两者互补不冲突。
 - **失败时暂停**：如果某一步发现前提不成立（ADR 前提错了、spec 里某字段设计不对），**回到上一步**而不是绕过。
 
+## 本地开发
+
+`pnpm dev` 直接热重启，改任意 internal package 的 `src/` 文件后**无需手动 `pnpm -r build`**。
+
+- dev 模式走 `tsx --conditions=development watch`，internal package 的 `exports.development` 条件指向各自 `src/index.ts`
+- `pnpm test` / `pnpm build` / `pnpm -r typecheck` 不带 `development` 条件，仍走 `dist/`，行为不变
+
 ## 反模式
 
 - **在 `main` 上直接实现 / commit**（违反"分支先行"，绕过 PR 与 codex review）

--- a/packages/agent/claudecode/package.json
+++ b/packages/agent/claudecode/package.json
@@ -7,6 +7,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "development": "./src/index.ts",
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
     }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -11,7 +11,7 @@
     "build": "tsc --build",
     "typecheck": "tsc --build",
     "test": "vitest run",
-    "dev": "tsx src/index.ts"
+    "dev": "tsx --conditions=development watch src/index.ts"
   },
   "dependencies": {
     "@agent-nexus/agent-claudecode": "workspace:*",

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -7,6 +7,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "development": "./src/index.ts",
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
     }

--- a/packages/platform/discord/package.json
+++ b/packages/platform/discord/package.json
@@ -7,6 +7,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "development": "./src/index.ts",
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
     }

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -7,6 +7,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "development": "./src/index.ts",
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
     }


### PR DESCRIPTION
## 对应哪条 ADR？

无需 ADR——属于 dev tooling 配置调整，不涉及架构决策。

## 对应哪个 spec？

N/A（内部开发体验改进，不涉及对外接口）

## 对应哪些测试？

`pnpm test` 39 个测试全绿，行为与改前一致。vitest 默认不带 `development` 条件，不会被串扰。

---

## 问题

`pnpm dev` 跑的是 `tsx packages/cli/src/index.ts`，但 internal package 的 `exports` 只有 `import` 条件指向 `dist/`。改了 src 后忘 build，dev 进程还在吃旧产物，调试信号与根因之间多了一步——这是 PR #32 连续踩坑的根因（见 issue #37）。

## 改动

**四个 internal package**（`@agent-nexus/{protocol,daemon,agent-claudecode,platform-discord}`）的 `exports` 加 `development` 条件：

```jsonc
"exports": {
  ".": {
    "development": "./src/index.ts",  // 新增
    "import": "./dist/index.js",
    "types": "./dist/index.d.ts"
  }
}
```

**CLI dev script** 改为：

```
tsx --conditions=development watch src/index.ts
```

- `--conditions=development`：激活 development 条件，tsx 直接解析 `.ts` 源文件
- `watch`：任意 src 改动自动重启，无需手动触发

**`docs/dev/process/workflow.md`**：新增"本地开发"节，说明 `pnpm dev` 无需手动 build。

## 验收

- [x] 修任意 internal package 的 src 文件后 `pnpm dev` 立即生效，无需 `pnpm -r build`
- [x] `pnpm test`（vitest）全绿，行为不变（不带 development 条件，仍走 dist）
- [x] `pnpm build` / `pnpm -r typecheck` 不受影响
- [x] workflow.md 更新 dev 流程说明

Closes #37