### PR TITLE
fix(dev): tsx watch 子命令必须在前，--conditions 在后

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -11,7 +11,7 @@
     "build": "tsc --build",
     "typecheck": "tsc --build",
     "test": "vitest run",
-    "dev": "tsx --conditions=development watch src/index.ts"
+    "dev": "tsx watch --conditions=development src/index.ts"
   },
   "dependencies": {
     "@agent-nexus/agent-claudecode": "workspace:*",


### PR DESCRIPTION
## 问题

PR #40 合入的 dev script 参数顺序错误：

```
tsx --conditions=development watch src/index.ts
```

tsx 把 `watch` 解析为脚本路径（不是子命令），报 `ERR_MODULE_NOT_FOUND: Cannot find module '.../cli/watch'`。

## 修复

```
tsx watch --conditions=development src/index.ts
```

`watch` 是 tsx 的子命令，必须紧接 `tsx`；Node.js flag `--conditions` 放在子命令之后。已验证（没有 dist 产物时进程照常启动，确认走的是 src）。

## 对应哪条 ADR？

无需 ADR。

## 对应哪个 spec？

N/A。

## 对应哪些测试？

`pnpm test` 39 个测试全绿。