### PR TITLE
fix(agent-claudecode): 串通 SessionConfig.timeoutMs + 默认 60s→300s 对齐 spec

### DIFF
--- a/packages/agent/claudecode/src/index.test.ts
+++ b/packages/agent/claudecode/src/index.test.ts
@@ -243,6 +243,44 @@ describe('createClaudeCodeRuntime.sendInput', () => {
     expect(args[toolsIdx + 1]).toBe('Read,Grep');
   });
 
+  it('per-session timeoutMs 进 execa timeout 选项（不被 runtime 默认覆盖）', async () => {
+    const lines = [
+      JSON.stringify({ type: 'system', subtype: 'init', session_id: 'sid-t', cwd: '/x' }),
+      JSON.stringify({
+        type: 'assistant',
+        message: { content: [{ type: 'text', text: 'ok' }] },
+      }),
+      JSON.stringify({
+        type: 'result',
+        stop_reason: 'end_turn',
+        usage: { input_tokens: 1, output_tokens: 1, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
+        total_cost_usd: 0.001,
+      }),
+    ];
+    mockedExeca.mockReturnValueOnce(
+      makeMockSubproc(lines) as unknown as ReturnType<typeof execa>,
+    );
+
+    const runtime = createClaudeCodeRuntime({
+      claudeBin: 'claude',
+      allowedTools: ['Bash'],
+      defaultWorkingDir: '/x',
+      logger: fakeLogger,
+      perInputTimeoutMs: 99_999, // runtime 兜底，不该被使用
+    });
+    const session = runtime.startSession(sessionKey, {
+      sessionId: 'sess-timeout',
+      workingDir: '/x',
+      toolWhitelist: ['Bash'],
+      timeoutMs: 123_456, // per-session 显式值，应当胜出
+    });
+
+    await runtime.sendInput(session, { type: 'user_message', text: 'hi', traceId: 't-timeout' });
+
+    const opts = mockedExeca.mock.calls[0]![2] as { timeout?: number };
+    expect(opts.timeout).toBe(123_456);
+  });
+
   it('execa throw → emit error + turn_finished{error}', async () => {
     mockedExeca.mockImplementationOnce(() => {
       throw new Error('spawn failed');

--- a/packages/agent/claudecode/src/index.test.ts
+++ b/packages/agent/claudecode/src/index.test.ts
@@ -35,7 +35,7 @@ const sessionConfig: SessionConfig = {
   sessionId: 'sess-1',
   workingDir: '/x',
   toolWhitelist: ['Bash', 'Read'],
-  timeoutMs: 60_000,
+  timeoutMs: 300_000,
 };
 
 /**
@@ -228,7 +228,7 @@ describe('createClaudeCodeRuntime.sendInput', () => {
       sessionId: 'sess-per',
       workingDir: '/per-sess',
       toolWhitelist: ['Read', 'Grep'],
-      timeoutMs: 60_000,
+      timeoutMs: 300_000,
     });
 
     await runtime.sendInput(session, { type: 'user_message', text: 'hi', traceId: 't-x' });
@@ -279,6 +279,45 @@ describe('createClaudeCodeRuntime.sendInput', () => {
 
     const opts = mockedExeca.mock.calls[0]![2] as { timeout?: number };
     expect(opts.timeout).toBe(123_456);
+  });
+
+  it('SessionConfig.timeoutMs 缺失且 runtime 也无 perInputTimeoutMs 时，fallback 到 spec 默认 300_000', async () => {
+    const lines = [
+      JSON.stringify({ type: 'system', subtype: 'init', session_id: 'sid-fb', cwd: '/x' }),
+      JSON.stringify({
+        type: 'assistant',
+        message: { content: [{ type: 'text', text: 'ok' }] },
+      }),
+      JSON.stringify({
+        type: 'result',
+        stop_reason: 'end_turn',
+        usage: { input_tokens: 1, output_tokens: 1, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
+        total_cost_usd: 0.001,
+      }),
+    ];
+    mockedExeca.mockReturnValueOnce(
+      makeMockSubproc(lines) as unknown as ReturnType<typeof execa>,
+    );
+
+    const runtime = createClaudeCodeRuntime({
+      claudeBin: 'claude',
+      allowedTools: ['Bash'],
+      defaultWorkingDir: '/x',
+      logger: fakeLogger,
+      // 不传 perInputTimeoutMs，fallback 到 spec 默认 300_000
+    });
+    // SessionConfig.timeoutMs 在 spec 里标 required，但运行时 JS 可能传不进来；
+    // runtime 必须用 ?? 兜住，避免 undefined 进 execa timeout 触发立即超时。
+    const session = runtime.startSession(sessionKey, {
+      sessionId: 'sess-fb',
+      workingDir: '/x',
+      toolWhitelist: ['Bash'],
+    } as SessionConfig);
+
+    await runtime.sendInput(session, { type: 'user_message', text: 'hi', traceId: 't-fb' });
+
+    const opts = mockedExeca.mock.calls[0]![2] as { timeout?: number };
+    expect(opts.timeout).toBe(300_000);
   });
 
   it('execa throw → emit error + turn_finished{error}', async () => {

--- a/packages/agent/claudecode/src/index.ts
+++ b/packages/agent/claudecode/src/index.ts
@@ -23,7 +23,11 @@ export interface ClaudeCodeRuntimeOptions {
   allowedTools: string[];
   defaultWorkingDir: string;
   logger: Logger;
-  /** 单次 spawn 超时（ms），默认 60_000 */
+  /**
+   * runtime 级 spawn 超时（ms）兜底；当 SessionConfig.timeoutMs 缺失时才生效。
+   * 默认 300_000（5 分钟），与 spec/infra/cost-and-limits.md §perInputTimeoutMs 一致。
+   * 该 timer 仅作为 backend 进程寿命的 wallclock 兜底，与 daemon 视角的回合 UX 上限分开（ADR-0011）。
+   */
   perInputTimeoutMs?: number;
 }
 
@@ -51,7 +55,7 @@ export function createClaudeCodeRuntime(
   opts: ClaudeCodeRuntimeOptions,
 ): AgentRuntime {
   const { claudeBin, allowedTools, defaultWorkingDir, logger } = opts;
-  const perInputTimeoutMs = opts.perInputTimeoutMs ?? 60_000;
+  const defaultTimeoutMs = opts.perInputTimeoutMs ?? 300_000;
 
   const capabilities: AgentCapabilitySet = {
     supportsThinking: false,
@@ -136,6 +140,7 @@ export function createClaudeCodeRuntime(
       const sessionConfig = configMap.get(session);
       const cwd = sessionConfig?.workingDir ?? defaultWorkingDir;
       const tools = sessionConfig?.toolWhitelist ?? allowedTools;
+      const timeoutMs = sessionConfig?.timeoutMs ?? defaultTimeoutMs;
       // CC CLI 2.1.x 不接受 `--cwd` flag（出现 → exit 1 "unknown option"）；
       // 工作目录改由子进程 cwd option 传入。安全语义不变（子进程不继承 daemon cwd，
       // 必须显式锁定到 SessionConfig.workingDir）。
@@ -166,7 +171,7 @@ export function createClaudeCodeRuntime(
 
       try {
         const subproc = execa(claudeBin, args, {
-          timeout: perInputTimeoutMs,
+          timeout: timeoutMs,
           buffer: false,
           cwd,
         });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -69,7 +69,7 @@ async function main(): Promise<void> {
     defaultSessionConfig: {
       workingDir: config.claudeCode.workingDir,
       toolWhitelist: config.claudeCode.allowedTools,
-      timeoutMs: 60_000,
+      timeoutMs: 300_000,
     },
   });
 


### PR DESCRIPTION
## Summary

ADR-0011 §落地编排 里的"事故止血"子项。只动默认值 + 配置链路，不动状态机。

事故 trace：`1c68898f-eba5-447f-89f6-884102fb8dc9`（IM 7 字消息 → 60s wallclock timeout → `spawn_failed`）。

两处根因：

1. `packages/agent/claudecode/src/index.ts` — `sendInput` 没读 `sessionConfig.timeoutMs`，永远走构造期的 `perInputTimeoutMs`；而 `perInputTimeoutMs` 在 cli 里没传 → 永远是默认 60s
2. `packages/cli/src/index.ts:72` 的 `defaultSessionConfig.timeoutMs: 60_000` 既低于 spec 默认（5min），又是死字段——agent runtime 根本不读它

修法：

- `sendInput` 优先读 `sessionConfig.timeoutMs`，runtime 级 `perInputTimeoutMs` 退化为兜底
- 兜底默认 `60_000` → `300_000`，对齐 `docs/dev/spec/infra/cost-and-limits.md` §`perInputTimeoutMs`（5 分钟）
- cli `defaultSessionConfig.timeoutMs` 同步 `300_000`

## 必答三问

1. **对应哪条 ADR？** [ADR-0011](docs/dev/adr/0011-turn-layering.md)（PR #43）的"事故止血"子项；本 PR 不实现 ADR-0011 的 nexus turn 状态机 / watchdog 分层，那部分留给后续 spec + impl PR
2. **对应哪个 spec？** N/A——本 PR 把实现拉回 `agent-runtime.md` §SessionConfig 与 `cost-and-limits.md` §`perInputTimeoutMs` 已规定的契约，不新增能力
3. **对应哪些测试？**
   - 新增 [`packages/agent/claudecode/src/index.test.ts`](packages/agent/claudecode/src/index.test.ts) `per-session timeoutMs 进 execa timeout 选项（不被 runtime 默认覆盖）` —— 先 red（assert 123_456，得到 99_999）后 green
   - 既有 41 条测试全过

## 不在本 PR 范围（留给 ADR-0011 后续 PR）

- daemon engine 的回合状态机（"daemon 视角的回合"——独立 timer / UX 输出 / 用户中途取消）
- backend 进程寿命 watchdog 与 daemon UX 上限分层
- first-byte / inter-chunk idle timeout（替换当前单一 wallclock）

## Test plan

- [x] `pnpm test` 全绿（41 passed）
- [x] `pnpm -r typecheck` 通过
- [x] TDD：先写 failing test 看到 red，实现后看到 green
- [ ] codex review