### PR TITLE
refactor(config): platform/agent config 解析下沉到 owner 包，CLI 退化为路由

### DIFF
--- a/docs/dev/standards/config-ownership.md
+++ b/docs/dev/standards/config-ownership.md
@@ -1,0 +1,68 @@
+---
+status: active
+---
+
+# Config Ownership Standard
+
+每个可插拔的 platform / agent 包**必须自包含其 config 解析逻辑**——包括字段定义、类型、默认值（运行时无关部分）、校验。CLI 退化为路由层，只负责文件读取、路径计算和错误包装。
+
+> 精神来源：ADR-0008 §"代码与设计维度"；同一 SSOT 原则在代码层的落地。  
+> 首次显式陈述于 Issue #49。
+
+## 规则
+
+### 1. owner 包导出 config parser
+
+每个可插拔包（`packages/platform/<name>/`、`packages/agent/<name>/`）必须在 `src/config.ts` 中定义并导出：
+
+```ts
+// 必选导出
+export interface XxxConfig { ... }
+export class XxxConfigError extends Error { ... }
+export function parseXxxConfig(raw: unknown, ctx: { ... }): XxxConfig { ... }
+```
+
+并在 `src/index.ts` 中重新导出：
+
+```ts
+export { parseXxxConfig, type XxxConfig, XxxConfigError } from './config.js';
+```
+
+### 2. CLI 只做路由
+
+`packages/cli/src/config.ts` 的职责：
+
+- 读取 `~/.agent-nexus/config.json`（文件 I/O、JSON 解析、顶层结构校验）
+- 计算环境相关路径（如 `defaultStatePath`）并作为参数传入 owner parser
+- 调用各 owner 包的 parser，统一 catch owner 错误后包成 `ConfigError`（保持 CLI 是 `ConfigError` 的唯一 owner）
+- 不直接持有任何 owner 包的字段名
+
+**合规**检测：`packages/cli/src/config.ts` 全文不应出现 owner 包的具体字段名（如 `botUserId`、`workingDir`、`allowedTools` 等）。
+
+### 3. 默认值归属
+
+- **运行时无关默认值**（如 `DEFAULT_BIN = 'claude'`、`DEFAULT_ALLOWED_TOOLS`）：属于 owner 包，定义并导出在 `src/config.ts`
+- **环境相关路径默认值**（如 `~/.agent-nexus/state/discord.json`）：属于 CLI，由 CLI 计算后作为 `ctx` 参数传入 owner parser
+
+### 4. 错误归属
+
+owner 包只 throw 自己的错误子类（如 `DiscordConfigError`）；CLI 统一 catch 并包成 `ConfigError`。禁止 owner 包 import CLI 的 `ConfigError`（会形成反向依赖）。
+
+### 5. 测试归属
+
+字段级校验测试（字段缺失、类型错误、默认值）放在 owner 包的 `src/config.test.ts`；CLI 的 `config.test.ts` 只测文件级场景（缺文件、非法 JSON）和集成路由（验证错误经过包装后含正确字段名）。
+
+## 接入新 platform / agent 的清单
+
+1. 新建 `packages/platform/<name>/src/config.ts`，导出 `XxxConfig`、`XxxConfigError`、`parseXxxConfig`
+2. 在 `packages/platform/<name>/src/index.ts` 重新导出
+3. 在 `packages/cli/src/config.ts` 的 `AgentNexusConfig` 中加入新字段，`loadConfig()` 调用 `parseXxxConfig`，catch `XxxConfigError` 包成 `ConfigError`
+4. 新建 `packages/platform/<name>/src/config.test.ts` 覆盖字段校验
+5. 更新 `packages/cli/src/config.test.ts` 仅加集成 smoke test（非字段级）
+
+## 反模式（禁止）
+
+- CLI 直接校验 owner 包字段（字段名硬编码在 CLI）
+- owner 包 import CLI 的 `ConfigError`
+- 字段校验测试只有 `cli/config.test.ts`，owner 包无测试
+- owner 包依赖 `~/.agent-nexus/` 目录布局（这是 CLI 层知识）

--- a/docs/dev/standards/config-ownership.md
+++ b/docs/dev/standards/config-ownership.md
@@ -37,7 +37,7 @@ export { parseXxxConfig, type XxxConfig, XxxConfigError } from './config.js';
 - 调用各 owner 包的 parser，统一 catch owner 错误后包成 `ConfigError`（保持 CLI 是 `ConfigError` 的唯一 owner）
 - 不直接持有任何 owner 包的字段名
 
-**合规**检测：`packages/cli/src/config.ts` 全文不应出现 owner 包的具体字段名（如 `botUserId`、`workingDir`、`allowedTools` 等）。
+**人工 review 检查点**（reviewer 应验证）：`packages/cli/src/config.ts` 全文不应出现 owner 包的具体字段名（如 `botUserId`、`workingDir`、`allowedTools` 等）。
 
 ### 3. 默认值归属
 

--- a/packages/agent/claudecode/src/config.test.ts
+++ b/packages/agent/claudecode/src/config.test.ts
@@ -30,7 +30,16 @@ describe('parseClaudeCodeConfig', () => {
     expect(result.bin).toBe('/usr/local/bin/claude');
   });
 
-  it('显式 allowedTools 含 Bash → 保留（Bash 启用走 cli warn 路径）', () => {
+  it('bin 为空字符串 → ClaudeCodeConfigError', () => {
+    expect(() => parseClaudeCodeConfig({ workingDir: '/x', bin: '' })).toThrow(ClaudeCodeConfigError);
+    expect(() => parseClaudeCodeConfig({ workingDir: '/x', bin: '' })).toThrow(/bin/);
+  });
+
+  it('bin 为非字符串 → ClaudeCodeConfigError', () => {
+    expect(() => parseClaudeCodeConfig({ workingDir: '/x', bin: 42 })).toThrow(ClaudeCodeConfigError);
+  });
+
+  it('显式 allowedTools 含 Bash → 保留', () => {
     const result = parseClaudeCodeConfig({
       workingDir: '/x',
       allowedTools: ['Read', 'Bash'],
@@ -51,12 +60,19 @@ describe('parseClaudeCodeConfig', () => {
     expect(result.allowedTools).toEqual(['Read']);
   });
 
-  it('allowedTools 含非字符串元素 → 过滤掉非字符串', () => {
-    const result = parseClaudeCodeConfig({
-      workingDir: '/x',
-      allowedTools: ['Read', 42, 'Grep'],
-    });
-    expect(result.allowedTools).toEqual(['Read', 'Grep']);
+  it('allowedTools 含非字符串元素 → ClaudeCodeConfigError', () => {
+    expect(() =>
+      parseClaudeCodeConfig({ workingDir: '/x', allowedTools: ['Read', 42, 'Grep'] }),
+    ).toThrow(ClaudeCodeConfigError);
+    expect(() =>
+      parseClaudeCodeConfig({ workingDir: '/x', allowedTools: ['Read', 42, 'Grep'] }),
+    ).toThrow(/allowedTools/);
+  });
+
+  it('allowedTools 为非数组 → ClaudeCodeConfigError', () => {
+    expect(() =>
+      parseClaudeCodeConfig({ workingDir: '/x', allowedTools: 'Read' }),
+    ).toThrow(ClaudeCodeConfigError);
   });
 
   it('raw 为 undefined → ClaudeCodeConfigError（缺 workingDir）', () => {

--- a/packages/agent/claudecode/src/config.test.ts
+++ b/packages/agent/claudecode/src/config.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { parseClaudeCodeConfig, ClaudeCodeConfigError, DEFAULT_ALLOWED_TOOLS, DEFAULT_BIN } from './config.js';
+
+describe('parseClaudeCodeConfig', () => {
+  it('缺 workingDir → ClaudeCodeConfigError', () => {
+    expect(() => parseClaudeCodeConfig({})).toThrow(ClaudeCodeConfigError);
+    expect(() => parseClaudeCodeConfig({})).toThrow(/workingDir/);
+  });
+
+  it('workingDir 空字符串 → ClaudeCodeConfigError', () => {
+    expect(() => parseClaudeCodeConfig({ workingDir: '' })).toThrow(ClaudeCodeConfigError);
+  });
+
+  it('workingDir 非字符串 → ClaudeCodeConfigError', () => {
+    expect(() => parseClaudeCodeConfig({ workingDir: 42 })).toThrow(ClaudeCodeConfigError);
+  });
+
+  it('默认值兜底：bin = "claude", allowedTools 含默认集, Bash 默认禁用', () => {
+    // spec/security/tool-boundary.md：Bash 必须默认禁用，启用须显式列入 allowedTools。
+    const result = parseClaudeCodeConfig({ workingDir: '/x' });
+    expect(result.bin).toBe(DEFAULT_BIN);
+    expect(result.allowedTools).not.toContain('Bash');
+    expect(result.allowedTools).toEqual(
+      expect.arrayContaining(['Read', 'Grep', 'Glob', 'Edit', 'Write']),
+    );
+  });
+
+  it('显式 bin → 原样保留', () => {
+    const result = parseClaudeCodeConfig({ workingDir: '/x', bin: '/usr/local/bin/claude' });
+    expect(result.bin).toBe('/usr/local/bin/claude');
+  });
+
+  it('显式 allowedTools 含 Bash → 保留（Bash 启用走 cli warn 路径）', () => {
+    const result = parseClaudeCodeConfig({
+      workingDir: '/x',
+      allowedTools: ['Read', 'Bash'],
+    });
+    expect(result.allowedTools).toEqual(['Read', 'Bash']);
+  });
+
+  it('ctx.defaultBin 覆盖内置默认值', () => {
+    const result = parseClaudeCodeConfig({ workingDir: '/x' }, { defaultBin: 'claude-custom' });
+    expect(result.bin).toBe('claude-custom');
+  });
+
+  it('ctx.defaultAllowedTools 覆盖内置默认值', () => {
+    const result = parseClaudeCodeConfig(
+      { workingDir: '/x' },
+      { defaultAllowedTools: ['Read'] },
+    );
+    expect(result.allowedTools).toEqual(['Read']);
+  });
+
+  it('allowedTools 含非字符串元素 → 过滤掉非字符串', () => {
+    const result = parseClaudeCodeConfig({
+      workingDir: '/x',
+      allowedTools: ['Read', 42, 'Grep'],
+    });
+    expect(result.allowedTools).toEqual(['Read', 'Grep']);
+  });
+
+  it('raw 为 undefined → ClaudeCodeConfigError（缺 workingDir）', () => {
+    expect(() => parseClaudeCodeConfig(undefined)).toThrow(ClaudeCodeConfigError);
+  });
+
+  it('DEFAULT_ALLOWED_TOOLS 不含 Bash', () => {
+    expect(DEFAULT_ALLOWED_TOOLS).not.toContain('Bash');
+    expect(DEFAULT_ALLOWED_TOOLS).toEqual(
+      expect.arrayContaining(['Read', 'Grep', 'Glob', 'Edit', 'Write']),
+    );
+  });
+});

--- a/packages/agent/claudecode/src/config.ts
+++ b/packages/agent/claudecode/src/config.ts
@@ -26,12 +26,27 @@ export function parseClaudeCodeConfig(
     throw new ClaudeCodeConfigError('缺字段 claudeCode.workingDir（非空字符串）');
   }
 
-  const bin = typeof cc['bin'] === 'string' ? (cc['bin'] as string) : (ctx.defaultBin ?? DEFAULT_BIN);
+  const binRaw = cc['bin'];
+  if (binRaw !== undefined && (typeof binRaw !== 'string' || binRaw.length === 0)) {
+    throw new ClaudeCodeConfigError('字段 claudeCode.bin 必须是非空字符串');
+  }
+  const bin = (typeof binRaw === 'string' ? binRaw : undefined) ?? ctx.defaultBin ?? DEFAULT_BIN;
 
   const allowedToolsRaw = cc['allowedTools'];
-  const allowedTools = Array.isArray(allowedToolsRaw)
-    ? allowedToolsRaw.filter((s): s is string => typeof s === 'string')
-    : (ctx.defaultAllowedTools ?? DEFAULT_ALLOWED_TOOLS);
+  let allowedTools: string[];
+  if (allowedToolsRaw !== undefined) {
+    if (!Array.isArray(allowedToolsRaw)) {
+      throw new ClaudeCodeConfigError('字段 claudeCode.allowedTools 必须是字符串数组');
+    }
+    for (const v of allowedToolsRaw) {
+      if (typeof v !== 'string') {
+        throw new ClaudeCodeConfigError('字段 claudeCode.allowedTools 必须是字符串数组');
+      }
+    }
+    allowedTools = [...allowedToolsRaw];
+  } else {
+    allowedTools = ctx.defaultAllowedTools ?? DEFAULT_ALLOWED_TOOLS;
+  }
 
   return { bin, workingDir, allowedTools };
 }

--- a/packages/agent/claudecode/src/config.ts
+++ b/packages/agent/claudecode/src/config.ts
@@ -1,0 +1,37 @@
+// spec/security/tool-boundary.md：默认集 Read/Grep/Glob/Edit/Write；Bash 必须显式启用
+export const DEFAULT_ALLOWED_TOOLS = ['Read', 'Grep', 'Glob', 'Edit', 'Write'];
+export const DEFAULT_BIN = 'claude';
+
+export interface ClaudeCodeConfig {
+  bin: string;
+  workingDir: string;
+  allowedTools: string[];
+}
+
+export class ClaudeCodeConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ClaudeCodeConfigError';
+  }
+}
+
+export function parseClaudeCodeConfig(
+  raw: unknown,
+  ctx: { defaultBin?: string; defaultAllowedTools?: string[] } = {},
+): ClaudeCodeConfig {
+  const cc = (raw as Record<string, unknown> | undefined) ?? {};
+
+  const workingDir = cc['workingDir'];
+  if (typeof workingDir !== 'string' || workingDir.length === 0) {
+    throw new ClaudeCodeConfigError('缺字段 claudeCode.workingDir（非空字符串）');
+  }
+
+  const bin = typeof cc['bin'] === 'string' ? (cc['bin'] as string) : (ctx.defaultBin ?? DEFAULT_BIN);
+
+  const allowedToolsRaw = cc['allowedTools'];
+  const allowedTools = Array.isArray(allowedToolsRaw)
+    ? allowedToolsRaw.filter((s): s is string => typeof s === 'string')
+    : (ctx.defaultAllowedTools ?? DEFAULT_ALLOWED_TOOLS);
+
+  return { bin, workingDir, allowedTools };
+}

--- a/packages/agent/claudecode/src/index.ts
+++ b/packages/agent/claudecode/src/index.ts
@@ -1,3 +1,11 @@
+export {
+  parseClaudeCodeConfig,
+  type ClaudeCodeConfig,
+  ClaudeCodeConfigError,
+  DEFAULT_ALLOWED_TOOLS,
+  DEFAULT_BIN,
+} from './config.js';
+
 import { EventEmitter } from 'node:events';
 import { createInterface } from 'node:readline';
 import { execa } from 'execa';

--- a/packages/cli/src/config.test.ts
+++ b/packages/cli/src/config.test.ts
@@ -71,7 +71,7 @@ describe('config loader', () => {
     expect(cfg.log.level).toBe('info');
   });
 
-  it('loadConfig 用户显式列出 Bash → 保留（启用走 cli warn 路径）', async () => {
+  it('loadConfig 用户显式列出 Bash → 保留', async () => {
     await writeFile(
       join(tmp, '.agent-nexus', 'config.json'),
       JSON.stringify({

--- a/packages/cli/src/config.test.ts
+++ b/packages/cli/src/config.test.ts
@@ -34,19 +34,21 @@ describe('config loader', () => {
     await expect(loadConfig()).rejects.toThrow(/config\.json/);
   });
 
-  it('loadConfig 缺 discord.botUserId → ConfigError', async () => {
+  it('loadConfig 缺 discord.botUserId → ConfigError（含字段名）', async () => {
     await writeFile(
       join(tmp, '.agent-nexus', 'config.json'),
       JSON.stringify({ claudeCode: { workingDir: '/x' } }),
     );
+    await expect(loadConfig()).rejects.toBeInstanceOf(ConfigError);
     await expect(loadConfig()).rejects.toThrow(/botUserId/);
   });
 
-  it('loadConfig 缺 claudeCode.workingDir → ConfigError', async () => {
+  it('loadConfig 缺 claudeCode.workingDir → ConfigError（含字段名）', async () => {
     await writeFile(
       join(tmp, '.agent-nexus', 'config.json'),
       JSON.stringify({ discord: { botUserId: '12345' } }),
     );
+    await expect(loadConfig()).rejects.toBeInstanceOf(ConfigError);
     await expect(loadConfig()).rejects.toThrow(/workingDir/);
   });
 
@@ -81,6 +83,21 @@ describe('config loader', () => {
     expect(cfg.claudeCode.allowedTools).toEqual(['Read', 'Bash']);
   });
 
+  it('loadConfig discord.ownerUserIds / statePath 缺省 → 路由正确传递默认值', async () => {
+    await writeFile(
+      join(tmp, '.agent-nexus', 'config.json'),
+      JSON.stringify({
+        discord: { botUserId: '12345' },
+        claudeCode: { workingDir: '/x' },
+      }),
+    );
+    const cfg = await loadConfig();
+    expect(cfg.discord.ownerUserIds).toEqual([]);
+    expect(cfg.discord.statePath).toBe(
+      join(tmp, '.agent-nexus', 'state', 'discord.json'),
+    );
+  });
+
   it('loadDiscordToken 缺 token 文件 → SecretsPermissionError', async () => {
     await expect(loadDiscordToken()).rejects.toBeInstanceOf(
       SecretsPermissionError,
@@ -100,77 +117,5 @@ describe('config loader', () => {
     await chmod(path, 0o600);
     const t = await loadDiscordToken();
     expect(t).toBe('token-abc');
-  });
-
-  it('discord.ownerUserIds / statePath 缺省 → 默认空数组 + ~/.agent-nexus/state/discord.json', async () => {
-    await writeFile(
-      join(tmp, '.agent-nexus', 'config.json'),
-      JSON.stringify({
-        discord: { botUserId: '12345' },
-        claudeCode: { workingDir: '/x' },
-      }),
-    );
-    const cfg = await loadConfig();
-    expect(cfg.discord.ownerUserIds).toEqual([]);
-    expect(cfg.discord.statePath).toBe(
-      join(tmp, '.agent-nexus', 'state', 'discord.json'),
-    );
-  });
-
-  it('discord.ownerUserIds 显式提供 → 原样保留', async () => {
-    await writeFile(
-      join(tmp, '.agent-nexus', 'config.json'),
-      JSON.stringify({
-        discord: { botUserId: '12345', ownerUserIds: ['U1', 'U2'] },
-        claudeCode: { workingDir: '/x' },
-      }),
-    );
-    const cfg = await loadConfig();
-    expect(cfg.discord.ownerUserIds).toEqual(['U1', 'U2']);
-  });
-
-  it('discord.ownerUserIds 非数组 → ConfigError', async () => {
-    await writeFile(
-      join(tmp, '.agent-nexus', 'config.json'),
-      JSON.stringify({
-        discord: { botUserId: '12345', ownerUserIds: 'not-array' },
-        claudeCode: { workingDir: '/x' },
-      }),
-    );
-    await expect(loadConfig()).rejects.toThrow(/ownerUserIds/);
-  });
-
-  it('discord.ownerUserIds 含非字符串元素 → ConfigError', async () => {
-    await writeFile(
-      join(tmp, '.agent-nexus', 'config.json'),
-      JSON.stringify({
-        discord: { botUserId: '12345', ownerUserIds: ['U1', 42] },
-        claudeCode: { workingDir: '/x' },
-      }),
-    );
-    await expect(loadConfig()).rejects.toThrow(/ownerUserIds/);
-  });
-
-  it('discord.statePath 显式提供 → 原样保留', async () => {
-    await writeFile(
-      join(tmp, '.agent-nexus', 'config.json'),
-      JSON.stringify({
-        discord: { botUserId: '12345', statePath: '/var/lib/foo.json' },
-        claudeCode: { workingDir: '/x' },
-      }),
-    );
-    const cfg = await loadConfig();
-    expect(cfg.discord.statePath).toBe('/var/lib/foo.json');
-  });
-
-  it('discord.statePath 非字符串 → ConfigError', async () => {
-    await writeFile(
-      join(tmp, '.agent-nexus', 'config.json'),
-      JSON.stringify({
-        discord: { botUserId: '12345', statePath: 123 },
-        claudeCode: { workingDir: '/x' },
-      }),
-    );
-    await expect(loadConfig()).rejects.toThrow(/statePath/);
   });
 });

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,20 +1,22 @@
 import { readFile, stat } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
+import {
+  parseDiscordConfig,
+  type DiscordConfig,
+  DiscordConfigError,
+} from '@agent-nexus/platform-discord';
+import {
+  parseClaudeCodeConfig,
+  type ClaudeCodeConfig,
+  ClaudeCodeConfigError,
+} from '@agent-nexus/agent-claudecode';
+
+export type { DiscordConfig, ClaudeCodeConfig };
 
 export interface AgentNexusConfig {
-  discord: {
-    botUserId: string;
-    /** 允许执行 /reply-mode slash command 的 user id 列表；空 = 没人能切。 */
-    ownerUserIds: string[];
-    /** reply-mode 持久化文件路径；默认 ~/.agent-nexus/state/discord.json。 */
-    statePath: string;
-  };
-  claudeCode: {
-    bin: string;
-    workingDir: string;
-    allowedTools: string[];
-  };
+  discord: DiscordConfig;
+  claudeCode: ClaudeCodeConfig;
   log: {
     level: 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'fatal';
   };
@@ -34,9 +36,6 @@ export class SecretsPermissionError extends Error {
   }
 }
 
-// spec/security/tool-boundary.md：默认集 Read/Grep/Glob/Edit/Write；Bash 必须显式启用
-const DEFAULT_ALLOWED_TOOLS = ['Read', 'Grep', 'Glob', 'Edit', 'Write'];
-const DEFAULT_BIN = 'claude';
 const DEFAULT_LOG_LEVEL = 'info' as const;
 
 export function configRoot(): string {
@@ -100,43 +99,27 @@ export async function loadConfig(): Promise<AgentNexusConfig> {
   }
   const obj = parsed as Record<string, unknown>;
 
-  const discord = obj['discord'] as Record<string, unknown> | undefined;
-  const botUserId = discord?.['botUserId'];
-  if (typeof botUserId !== 'string' || botUserId.length === 0) {
-    throw new ConfigError(`${path} 缺字段 discord.botUserId（非空字符串）`);
-  }
-
-  const ownerUserIdsRaw = discord?.['ownerUserIds'];
-  let ownerUserIds: string[] = [];
-  if (ownerUserIdsRaw !== undefined) {
-    if (!Array.isArray(ownerUserIdsRaw)) {
-      throw new ConfigError(`${path} 字段 discord.ownerUserIds 必须是字符串数组`);
+  let discord: DiscordConfig;
+  try {
+    discord = parseDiscordConfig(obj['discord'], {
+      defaultStatePath: defaultDiscordStatePath(),
+    });
+  } catch (err) {
+    if (err instanceof DiscordConfigError) {
+      throw new ConfigError(`${path} ${err.message}`);
     }
-    for (const v of ownerUserIdsRaw) {
-      if (typeof v !== 'string' || v.length === 0) {
-        throw new ConfigError(`${path} 字段 discord.ownerUserIds 必须是非空字符串数组`);
-      }
+    throw err;
+  }
+
+  let claudeCode: ClaudeCodeConfig;
+  try {
+    claudeCode = parseClaudeCodeConfig(obj['claudeCode']);
+  } catch (err) {
+    if (err instanceof ClaudeCodeConfigError) {
+      throw new ConfigError(`${path} ${err.message}`);
     }
-    ownerUserIds = [...ownerUserIdsRaw];
+    throw err;
   }
-
-  const statePathRaw = discord?.['statePath'];
-  if (statePathRaw !== undefined && (typeof statePathRaw !== 'string' || statePathRaw.length === 0)) {
-    throw new ConfigError(`${path} 字段 discord.statePath 必须是非空字符串`);
-  }
-  const statePath = (statePathRaw as string | undefined) ?? defaultDiscordStatePath();
-
-  const cc = (obj['claudeCode'] as Record<string, unknown> | undefined) ?? {};
-  const workingDir = cc['workingDir'];
-  if (typeof workingDir !== 'string' || workingDir.length === 0) {
-    throw new ConfigError(`${path} 缺字段 claudeCode.workingDir（非空字符串）`);
-  }
-
-  const bin = typeof cc['bin'] === 'string' ? (cc['bin'] as string) : DEFAULT_BIN;
-  const allowedToolsRaw = cc['allowedTools'];
-  const allowedTools = Array.isArray(allowedToolsRaw)
-    ? allowedToolsRaw.filter((s): s is string => typeof s === 'string')
-    : DEFAULT_ALLOWED_TOOLS;
 
   const log = (obj['log'] as Record<string, unknown> | undefined) ?? {};
   const levelRaw = log['level'];
@@ -147,8 +130,8 @@ export async function loadConfig(): Promise<AgentNexusConfig> {
       : DEFAULT_LOG_LEVEL;
 
   return {
-    discord: { botUserId, ownerUserIds, statePath },
-    claudeCode: { bin, workingDir, allowedTools },
+    discord,
+    claudeCode,
     log: { level },
   };
 }

--- a/packages/platform/discord/src/config.test.ts
+++ b/packages/platform/discord/src/config.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import { parseDiscordConfig, DiscordConfigError } from './config.js';
+
+const DEFAULT_STATE_PATH = '/default/state/discord.json';
+const ctx = { defaultStatePath: DEFAULT_STATE_PATH };
+
+describe('parseDiscordConfig', () => {
+  it('缺 botUserId → DiscordConfigError', () => {
+    expect(() => parseDiscordConfig({}, ctx)).toThrow(DiscordConfigError);
+    expect(() => parseDiscordConfig({}, ctx)).toThrow(/botUserId/);
+  });
+
+  it('botUserId 空字符串 → DiscordConfigError', () => {
+    expect(() => parseDiscordConfig({ botUserId: '' }, ctx)).toThrow(DiscordConfigError);
+  });
+
+  it('botUserId 非字符串 → DiscordConfigError', () => {
+    expect(() => parseDiscordConfig({ botUserId: 42 }, ctx)).toThrow(DiscordConfigError);
+  });
+
+  it('最小合法配置 → 返回默认值', () => {
+    const result = parseDiscordConfig({ botUserId: '12345' }, ctx);
+    expect(result.botUserId).toBe('12345');
+    expect(result.ownerUserIds).toEqual([]);
+    expect(result.statePath).toBe(DEFAULT_STATE_PATH);
+  });
+
+  it('ownerUserIds 缺省 → 默认空数组', () => {
+    const result = parseDiscordConfig({ botUserId: '12345' }, ctx);
+    expect(result.ownerUserIds).toEqual([]);
+  });
+
+  it('ownerUserIds 显式提供 → 原样保留', () => {
+    const result = parseDiscordConfig({ botUserId: '12345', ownerUserIds: ['U1', 'U2'] }, ctx);
+    expect(result.ownerUserIds).toEqual(['U1', 'U2']);
+  });
+
+  it('ownerUserIds 非数组 → DiscordConfigError', () => {
+    expect(() =>
+      parseDiscordConfig({ botUserId: '12345', ownerUserIds: 'not-array' }, ctx),
+    ).toThrow(/ownerUserIds/);
+  });
+
+  it('ownerUserIds 含非字符串元素 → DiscordConfigError', () => {
+    expect(() =>
+      parseDiscordConfig({ botUserId: '12345', ownerUserIds: ['U1', 42] }, ctx),
+    ).toThrow(/ownerUserIds/);
+  });
+
+  it('statePath 缺省 → 使用 ctx.defaultStatePath', () => {
+    const result = parseDiscordConfig({ botUserId: '12345' }, ctx);
+    expect(result.statePath).toBe(DEFAULT_STATE_PATH);
+  });
+
+  it('statePath 显式提供 → 原样保留', () => {
+    const result = parseDiscordConfig(
+      { botUserId: '12345', statePath: '/var/lib/foo.json' },
+      ctx,
+    );
+    expect(result.statePath).toBe('/var/lib/foo.json');
+  });
+
+  it('statePath 非字符串 → DiscordConfigError', () => {
+    expect(() =>
+      parseDiscordConfig({ botUserId: '12345', statePath: 123 }, ctx),
+    ).toThrow(/statePath/);
+  });
+
+  it('statePath 空字符串 → DiscordConfigError', () => {
+    expect(() =>
+      parseDiscordConfig({ botUserId: '12345', statePath: '' }, ctx),
+    ).toThrow(/statePath/);
+  });
+
+  it('raw 为 undefined → DiscordConfigError（缺 botUserId）', () => {
+    expect(() => parseDiscordConfig(undefined, ctx)).toThrow(DiscordConfigError);
+  });
+});

--- a/packages/platform/discord/src/config.ts
+++ b/packages/platform/discord/src/config.ts
@@ -1,0 +1,48 @@
+export interface DiscordConfig {
+  botUserId: string;
+  /** 允许执行 /reply-mode slash command 的 user id 列表；空 = 没人能切。 */
+  ownerUserIds: string[];
+  /** reply-mode 持久化文件路径。 */
+  statePath: string;
+}
+
+export class DiscordConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'DiscordConfigError';
+  }
+}
+
+export function parseDiscordConfig(
+  raw: unknown,
+  ctx: { defaultStatePath: string },
+): DiscordConfig {
+  const discord = (raw as Record<string, unknown> | undefined) ?? {};
+
+  const botUserId = discord['botUserId'];
+  if (typeof botUserId !== 'string' || botUserId.length === 0) {
+    throw new DiscordConfigError('缺字段 discord.botUserId（非空字符串）');
+  }
+
+  const ownerUserIdsRaw = discord['ownerUserIds'];
+  let ownerUserIds: string[] = [];
+  if (ownerUserIdsRaw !== undefined) {
+    if (!Array.isArray(ownerUserIdsRaw)) {
+      throw new DiscordConfigError('字段 discord.ownerUserIds 必须是字符串数组');
+    }
+    for (const v of ownerUserIdsRaw) {
+      if (typeof v !== 'string' || v.length === 0) {
+        throw new DiscordConfigError('字段 discord.ownerUserIds 必须是非空字符串数组');
+      }
+    }
+    ownerUserIds = [...ownerUserIdsRaw];
+  }
+
+  const statePathRaw = discord['statePath'];
+  if (statePathRaw !== undefined && (typeof statePathRaw !== 'string' || statePathRaw.length === 0)) {
+    throw new DiscordConfigError('字段 discord.statePath 必须是非空字符串');
+  }
+  const statePath = (statePathRaw as string | undefined) ?? ctx.defaultStatePath;
+
+  return { botUserId, ownerUserIds, statePath };
+}

--- a/packages/platform/discord/src/config.ts
+++ b/packages/platform/discord/src/config.ts
@@ -42,7 +42,7 @@ export function parseDiscordConfig(
   if (statePathRaw !== undefined && (typeof statePathRaw !== 'string' || statePathRaw.length === 0)) {
     throw new DiscordConfigError('字段 discord.statePath 必须是非空字符串');
   }
-  const statePath = (statePathRaw as string | undefined) ?? ctx.defaultStatePath;
+  const statePath = typeof statePathRaw === 'string' ? statePathRaw : ctx.defaultStatePath;
 
   return { botUserId, ownerUserIds, statePath };
 }

--- a/packages/platform/discord/src/index.ts
+++ b/packages/platform/discord/src/index.ts
@@ -1,3 +1,5 @@
+export { parseDiscordConfig, type DiscordConfig, DiscordConfigError } from './config.js';
+
 // TODO MVP 跳过：
 // - DM 消息（intents 没开 DirectMessages）
 // - 长文本切片保留代码块边界 → docs/dev/spec/message-protocol.md §文本切片


### PR DESCRIPTION
Implements #49

**PR 三问：**
1. 对应哪条 ADR：ADR-0008 §"代码与设计维度"；本 PR 把同一 SSOT 原则贯彻到代码层
2. 对应哪个 spec：N/A（纯实现细节，新增 docs/dev/standards/config-ownership.md 记录接入契约）
3. 对应哪些测试：platform-discord/src/config.test.ts，agent-claudecode/src/config.test.ts，cli/src/config.test.ts

Generated with [Claude Code](https://claude.ai/code)