### PR TITLE
fix(daemon): 进程内 eventId LRU 去重防 WS resume 重复扣费

### DIFF
--- a/packages/daemon/src/engine.test.ts
+++ b/packages/daemon/src/engine.test.ts
@@ -48,9 +48,11 @@ const SESSION_KEY: SessionKey = {
   initiatorUserId: 'U1',
 };
 
+let eventCounter = 0;
 function makeEvent(text: string, overrides: Partial<NormalizedEvent> = {}): NormalizedEvent {
+  eventCounter += 1;
   return {
-    eventId: 'e-1',
+    eventId: `e-${eventCounter}`,
     platform: 'discord',
     sessionKey: SESSION_KEY,
     messageId: 'm-1',
@@ -468,6 +470,88 @@ describe('Engine', () => {
     const outboundDebug = debugCalls.find(([, msg]) => msg === 'outbound');
     expect(outboundDebug).toBeDefined();
     expect(outboundDebug![0]).toMatchObject({ text: 'hello reply', traceId: 't-1' });
+  });
+
+  it('eventId 去重：同 eventId 二次投递被丢弃，agent.startSession 只调一次，info 日志 dispatch_dedup', async () => {
+    const platform = makePlatform();
+    const agent = makeAgent();
+    const store = new SessionStore();
+    const mockLogger = {
+      info: vi.fn(),
+      debug: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      trace: vi.fn(),
+      fatal: vi.fn(),
+      child: vi.fn(),
+    } as unknown as Logger;
+
+    const engine = new Engine({
+      platform,
+      agent: agent.runtime,
+      logger: mockLogger,
+      sessionStore: store,
+      defaultSessionConfig: DEFAULT_CFG,
+    });
+
+    await engine.start();
+    const dispatchHandler = (platform.start as ReturnType<typeof vi.fn>).mock.calls[0]![0] as EventHandler;
+
+    agent.queueEvents([
+      ev('session_started', { ccSessionID: 'cc-1' }),
+      ev('text_final', { text: 'first reply' }),
+      ev('turn_finished', { reason: 'stop', turnSequence: 1 }),
+    ]);
+    // 第二次 dispatch 不入 agent 队列；若代码漏 dedup，agent.sendInput 会等待空队列
+    // 然后立即返回，但 startSession 已被多调一次——这是 fixture 设计的关键。
+
+    const dup = makeEvent('hello');
+    await dispatchHandler(dup);
+    await dispatchHandler(dup);
+
+    expect(agent.startSession).toHaveBeenCalledTimes(1);
+    expect(platform.send).toHaveBeenCalledTimes(1);
+
+    const infoCalls = (mockLogger.info as ReturnType<typeof vi.fn>).mock.calls;
+    const dedupLog = infoCalls.find(([, msg]) => msg === 'dispatch_dedup');
+    expect(dedupLog).toBeDefined();
+    expect(dedupLog![0]).toMatchObject({ eventId: dup.eventId, traceId: 't-1' });
+  });
+
+  it('eventId 去重 cap 淘汰：最早 entry 被淘汰，最新 entry 仍被 dedup（非整表 clear）', async () => {
+    const platform = makePlatform();
+    const agent = makeAgent();
+    const store = new SessionStore();
+    const engine = new Engine({
+      platform,
+      agent: agent.runtime,
+      logger: SILENT_LOGGER,
+      sessionStore: store,
+      defaultSessionConfig: DEFAULT_CFG,
+    });
+
+    await engine.start();
+    const dispatchHandler = (platform.start as ReturnType<typeof vi.fn>).mock.calls[0]![0] as EventHandler;
+
+    // 用 /new 快路径填表（不动 agent），共 1024 + 1 条独立 eventId
+    // /new 不调 agent.startSession，但仍走 dispatchImpl 入口的 dedup 检查
+    for (let i = 0; i <= 1024; i++) {
+      await dispatchHandler(makeEvent('/new', { eventId: `fill-${i}` }));
+    }
+    // 此时 fill-0 应已被淘汰；fill-1024 仍在表内
+
+    // 用 fill-0 重投触发完整 agent 路径——若被淘汰，agent.startSession 会调一次
+    agent.queueEvents([
+      ev('session_started', { ccSessionID: 'cc-evicted' }),
+      ev('text_final', { text: 're' }),
+      ev('turn_finished', { reason: 'stop', turnSequence: 1 }),
+    ]);
+    await dispatchHandler(makeEvent('hello', { eventId: 'fill-0' }));
+    expect(agent.startSession).toHaveBeenCalledTimes(1);
+
+    // 用 fill-1024 重投——还在表内，应被 dedup，agent.startSession 不再增加
+    await dispatchHandler(makeEvent('hello', { eventId: 'fill-1024' }));
+    expect(agent.startSession).toHaveBeenCalledTimes(1);
   });
 
   it('error 路径：agent emit error → platform.send 收到 [CC error: ...]', async () => {

--- a/packages/daemon/src/engine.ts
+++ b/packages/daemon/src/engine.ts
@@ -27,7 +27,8 @@ export interface EngineDeps {
  * Engine：把 platform 入站事件路由到 agent，并把 agent 输出回送 platform。
  *
  * MVP 跳过的横切能力——下一批 PR 逐个补：
- * - 幂等去重（messageId）→ docs/dev/spec/infra/idempotency.md
+ * - 持久化幂等 / auth ordering → docs/dev/spec/infra/idempotency.md
+ *   （进程内 eventId LRU 已落，详见 seenEventIds 字段）
  * - 限流 / 预算 → docs/dev/spec/infra/cost-and-limits.md
  * - allowlist 鉴权 → docs/dev/spec/security/auth.md
  * - 出口脱敏 → docs/dev/spec/security/redaction.md
@@ -49,6 +50,14 @@ export class Engine {
    * 不同 key 之间互不阻塞。
    */
   private readonly inflight = new Map<string, Promise<void>>();
+
+  /**
+   * eventId 内存去重：防 WS resume 重投同一事件触发 CC 重复扣费。
+   * Map insertion order = LRU；满 cap 后删最旧。
+   * 持久化幂等见 docs/dev/spec/infra/idempotency.md（重启窗口 ≪ Discord resume 窗口，跨进程暂不做）。
+   */
+  private static readonly DEDUP_CAP = 1024;
+  private readonly seenEventIds = new Map<string, true>();
 
   constructor(deps: EngineDeps) {
     this.platform = deps.platform;
@@ -89,8 +98,25 @@ export class Engine {
   }
 
   private async dispatchImpl(event: NormalizedEvent): Promise<void> {
+    const sessionKeyStr = serializeSessionKey(event.sessionKey);
+    if (this.seenEventIds.has(event.eventId)) {
+      this.logger.info(
+        {
+          eventId: event.eventId,
+          sessionKey: sessionKeyStr,
+          traceId: event.traceId,
+        },
+        'dispatch_dedup',
+      );
+      return;
+    }
+    this.seenEventIds.set(event.eventId, true);
+    if (this.seenEventIds.size > Engine.DEDUP_CAP) {
+      const oldest = this.seenEventIds.keys().next().value;
+      if (oldest !== undefined) this.seenEventIds.delete(oldest);
+    }
+
     try {
-      const sessionKeyStr = serializeSessionKey(event.sessionKey);
       this.logger.info(
         {
           traceId: event.traceId,

--- a/packages/daemon/src/engine.ts
+++ b/packages/daemon/src/engine.ts
@@ -52,9 +52,9 @@ export class Engine {
   private readonly inflight = new Map<string, Promise<void>>();
 
   /**
-   * eventId 内存去重：防 WS resume 重投同一事件触发 CC 重复扣费。
+   * eventId 内存去重：防 adapter 重投同一事件导致 agent 被重复触发（重复消耗 turn 预算）。
    * Map insertion order = LRU；满 cap 后删最旧。
-   * 持久化幂等见 docs/dev/spec/infra/idempotency.md（重启窗口 ≪ Discord resume 窗口，跨进程暂不做）。
+   * 持久化幂等见 docs/dev/spec/infra/idempotency.md（重启窗口足够小时 in-memory 即可，跨进程暂不做）。
    */
   private static readonly DEDUP_CAP = 1024;
   private readonly seenEventIds = new Map<string, true>();


### PR DESCRIPTION
closes #53

## 背景

`Engine.dispatch` 的 per-SessionKey 串行队列（`inflight` map）只防同 key 并发，不防"同 eventId 二次到达"。Discord gateway resume 在断网边缘会把已 ack 附近的 `messageCreate` 重发——旧实现下第二次到达会重新 spawn CC 子进程，**重复扣费**。无上层防御能拦。

## 改动

`packages/daemon/src/engine.ts` `dispatchImpl` 入口加去重：

- `seenEventIds: Map<string, true>`，cap `Engine.DEDUP_CAP = 1024`
- 命中 → 直接 return + `info` 日志 `dispatch_dedup`（带 `eventId / sessionKey / traceId`）
- 未命中 → set + 满 cap 删 Map insertion-order 最旧（不是整表 clear）

未做完整 spec（`docs/dev/spec/infra/idempotency.md` 的 persistence / auth ordering / TTL / "failed 重试"）——重启窗口 ≪ Discord resume 窗口，跨进程暂可接受；class 注释已注明这一点。

cap 值 1024 取自 issue：Discord rate limit 5 msg/5s 下约 17 分钟窗口，个人使用够用。

## 测试

`packages/daemon/src/engine.test.ts` 加 2 个 case：

1. **dedup hit**：同 `NormalizedEvent` 投递两次 → `agent.startSession` 只被调一次 + `platform.send` 只被调一次 + `info` 日志 `dispatch_dedup` 有命中
2. **cap 淘汰**：`/new` 快路径填 1025 条独立 eventId 后，最早 entry (`fill-0`) 被淘汰（重投触发完整 agent 路径）；最新 entry (`fill-1024`) 仍在表内（重投仍被 dedup）—— 验证不是整表 clear

附带把 `makeEvent` 默认 `eventId` 改成全局自增计数（旧 fixture 全是 `'e-1'` 撞到新 dedup 上挂掉了 3 个老测试；改完后老测试与新约束兼容）。

## 验证

- `pnpm vitest run packages/daemon/src/engine.test.ts`：10/10 通过（原 8 + 新 2）
- `pnpm -r typecheck`：clean
- `pnpm vitest run`：138/138 通过（全仓无回归）

## 不在范围

- 持久化幂等表（重启后 dedup 表丢失）
- auth → idempotency → 限流 顺序（auth 模块本身还没接入）
- TTL 过期 / GC（in-memory cap 替代）
- "failed 重试窗口"

以上属 spec 的下一批工作，与本 PR 解决的"重启间隔内的真金白银重复扣费"是不同优先级。
