### PR TITLE
refactor(protocol,daemon): vocab-neutral 清存量 cc/CC 词汇 leak

### DIFF
--- a/docs/dev/spec/agent-backends/claude-code-cli.md
+++ b/docs/dev/spec/agent-backends/claude-code-cli.md
@@ -80,7 +80,7 @@ claude --print "<single prompt>" --output-format json
 | `--allowed-tools` / `--allowedTools` | 工具白名单（逗号或空格分隔，支持 `Bash(git *)` 子模式） | **必传** | §权限边界、`security/tool-boundary.md` |
 | `--disallowed-tools` / `--disallowedTools` | 工具黑名单 | **不用**（当前只用白名单） | §交互式 session（保留为可选） |
 | `--model <id>` | 模型别名（`sonnet` / `opus`）或全名（`claude-sonnet-4-6`） | **用**（按 SessionConfig 注入） | §交互式 session |
-| `--resume [value]` / `-r` | 按 session id（UUID）续话；裸用打开 picker | **用**（持有 `ccSessionID` 时传） | §交互式 session、`agent-runtime.md` |
+| `--resume [value]` / `-r` | 按 session id（UUID）续话；裸用打开 picker | **用**（持有 `agentSessionId` 时传） | §交互式 session、`agent-runtime.md` |
 | `--permission-mode <…>` | 取值：`acceptEdits` / `auto` / `bypassPermissions` / `default` / `dontAsk` / `plan` | **用** `default` / `plan`；**禁用** `bypassPermissions` / `acceptEdits` | §权限边界、`security/tool-boundary.md` |
 | `--dangerously-skip-permissions` | 等价于 `--permission-mode bypassPermissions` | **禁用** | `security/README.md` |
 | `--allow-dangerously-skip-permissions` | 让用户可以**选择**开启 bypass，但不默认开启 | **禁用** | `security/README.md` |

--- a/packages/agent/claudecode/src/index.test.ts
+++ b/packages/agent/claudecode/src/index.test.ts
@@ -127,7 +127,7 @@ describe('createClaudeCodeRuntime.sendInput', () => {
 
     const started = events[0];
     if (started?.type !== 'session_started') throw new Error('expected session_started');
-    expect(started.payload.ccSessionID).toBe('sid-1');
+    expect(started.payload.agentSessionId).toBe('sid-1');
 
     const textFinal = events[1];
     if (textFinal?.type !== 'text_final') throw new Error('expected text_final');
@@ -144,8 +144,8 @@ describe('createClaudeCodeRuntime.sendInput', () => {
     if (turnFinished?.type !== 'turn_finished') throw new Error('expected turn_finished');
     expect(turnFinished.payload.reason).toBe('stop');
 
-    // ccSessionID 应该写回 session
-    expect(session.ccSessionID).toBe('sid-1');
+    // agentSessionId 应该写回 session
+    expect(session.agentSessionId).toBe('sid-1');
   });
 
   it('非 JSON 行被跳过', async () => {

--- a/packages/agent/claudecode/src/index.ts
+++ b/packages/agent/claudecode/src/index.ts
@@ -87,7 +87,7 @@ export function createClaudeCodeRuntime(
         backend: 'claudecode',
         state: 'Idle',
         startedAt: new Date(),
-        ccSessionID: config.resumeFromCcSessionID,
+        agentSessionId: config.resumeFromAgentSessionId,
       };
       // 预创建 emitter，确保 onEvent 在 sendInput 之前就能挂上
       getEmitter(session);
@@ -161,8 +161,8 @@ export function createClaudeCodeRuntime(
         '--allowed-tools',
         tools.join(','),
       ];
-      if (session.ccSessionID) {
-        args.push('--resume', session.ccSessionID);
+      if (session.agentSessionId) {
+        args.push('--resume', session.agentSessionId);
       }
 
       interface CcUsage {
@@ -210,8 +210,8 @@ export function createClaudeCodeRuntime(
             const sid = e['session_id'];
             const cwd = e['cwd'];
             if (typeof sid === 'string') {
-              // ccSessionID 写回 session：protocol 把它标了可选 string，直接赋值即可
-              session.ccSessionID = sid;
+              // agentSessionId 写回 session：protocol 把它标了可选 string，直接赋值即可
+              session.agentSessionId = sid;
             }
             emitEvent({
               type: 'session_started',
@@ -219,7 +219,7 @@ export function createClaudeCodeRuntime(
               timestamp: new Date(),
               sequence: sequence++,
               payload: {
-                ccSessionID: typeof sid === 'string' ? sid : undefined,
+                agentSessionId: typeof sid === 'string' ? sid : undefined,
                 workingDir: typeof cwd === 'string' ? cwd : undefined,
               },
             });

--- a/packages/daemon/src/engine.test.ts
+++ b/packages/daemon/src/engine.test.ts
@@ -207,8 +207,8 @@ describe('Engine', () => {
     });
 
     agent.queueEvents([
-      ev('session_started', { agentSessionId: 'cc-123' }),
-      ev('text_final', { text: 'hi from cc' }),
+      ev('session_started', { agentSessionId: 'sid-123' }),
+      ev('text_final', { text: 'hi from agent' }),
       ev('turn_finished', { reason: 'stop', turnSequence: 1 }),
     ]);
 
@@ -223,12 +223,12 @@ describe('Engine', () => {
     expect(cfg.resumeFromAgentSessionId).toBeUndefined();
     expect(cfg.sessionId).toBeTruthy();
 
-    expect(store.get(SESSION_KEY)?.agentSessionId).toBe('cc-123');
+    expect(store.get(SESSION_KEY)?.agentSessionId).toBe('sid-123');
 
     expect(platform.send).toHaveBeenCalledTimes(1);
     const sendArgs = platform.send.mock.calls[0]!;
     const out = sendArgs[1] as OutboundMessage;
-    expect(out.text).toBe('hi from cc');
+    expect(out.text).toBe('hi from agent');
 
     expect(agent.stopSession).toHaveBeenCalledTimes(1);
   });
@@ -248,18 +248,18 @@ describe('Engine', () => {
     await engine.start();
     const dispatchHandler = (platform.start as ReturnType<typeof vi.fn>).mock.calls[0]![0] as EventHandler;
 
-    // 首轮：写入 cc-123
+    // 首轮：写入 sid-123
     agent.queueEvents([
-      ev('session_started', { agentSessionId: 'cc-123' }),
+      ev('session_started', { agentSessionId: 'sid-123' }),
       ev('text_final', { text: 'first' }),
       ev('turn_finished', { reason: 'stop', turnSequence: 1 }),
     ]);
     await dispatchHandler(makeEvent('first prompt'));
-    expect(store.get(SESSION_KEY)?.agentSessionId).toBe('cc-123');
+    expect(store.get(SESSION_KEY)?.agentSessionId).toBe('sid-123');
 
-    // 第二轮：startSession 必须收到 cc-123 作 resume
+    // 第二轮：startSession 必须收到 sid-123 作 resume
     agent.queueEvents([
-      ev('session_started', { agentSessionId: 'cc-456' }),
+      ev('session_started', { agentSessionId: 'sid-456' }),
       ev('text_final', { text: 'second' }),
       ev('turn_finished', { reason: 'stop', turnSequence: 2 }),
     ]);
@@ -267,9 +267,9 @@ describe('Engine', () => {
 
     expect(agent.startSession).toHaveBeenCalledTimes(2);
     const cfg2 = agent.startSession.mock.calls[1]![1] as SessionConfig;
-    expect(cfg2.resumeFromAgentSessionId).toBe('cc-123');
+    expect(cfg2.resumeFromAgentSessionId).toBe('sid-123');
 
-    expect(store.get(SESSION_KEY)?.agentSessionId).toBe('cc-456');
+    expect(store.get(SESSION_KEY)?.agentSessionId).toBe('sid-456');
   });
 
   it('/new 带后续文本：清 store + 用 trim 后的剩余作 prompt', async () => {
@@ -277,7 +277,7 @@ describe('Engine', () => {
     const agent = makeAgent();
     const store = new SessionStore();
     // 预置一条旧的
-    store.set(SESSION_KEY, { agentSessionId: 'cc-123', lastTurnAt: new Date(0) });
+    store.set(SESSION_KEY, { agentSessionId: 'sid-123', lastTurnAt: new Date(0) });
 
     const engine = new Engine({
       platform,
@@ -291,7 +291,7 @@ describe('Engine', () => {
     const dispatchHandler = (platform.start as ReturnType<typeof vi.fn>).mock.calls[0]![0] as EventHandler;
 
     agent.queueEvents([
-      ev('session_started', { agentSessionId: 'cc-new' }),
+      ev('session_started', { agentSessionId: 'sid-new' }),
       ev('text_final', { text: 'answer' }),
       ev('turn_finished', { reason: 'stop', turnSequence: 1 }),
     ]);
@@ -306,8 +306,8 @@ describe('Engine', () => {
     const input = agent.sendInput.mock.calls[0]![1] as AgentInput;
     expect(input.text).toBe('what is X?');
 
-    // 新一轮 session_started 写回 cc-new；旧的 cc-123 已被清掉
-    expect(store.get(SESSION_KEY)?.agentSessionId).toBe('cc-new');
+    // 新一轮 session_started 写回 sid-new；旧的 sid-123 已被清掉
+    expect(store.get(SESSION_KEY)?.agentSessionId).toBe('sid-new');
   });
 
   it('/new 单独：发 [new session ready] 不调 agent', async () => {
@@ -356,7 +356,7 @@ describe('Engine', () => {
     // 第一条 dispatch 故意慢——session_started 在 8ms 后才进 store
     agent.queueEventsAfter(
       [
-        ev('session_started', { agentSessionId: 'cc-first' }),
+        ev('session_started', { agentSessionId: 'sid-first' }),
         ev('text_final', { text: 'first reply' }),
         ev('turn_finished', { reason: 'stop', turnSequence: 1 }),
       ],
@@ -364,7 +364,7 @@ describe('Engine', () => {
     );
     // 第二条 dispatch 紧随其后
     agent.queueEvents([
-      ev('session_started', { agentSessionId: 'cc-second' }),
+      ev('session_started', { agentSessionId: 'sid-second' }),
       ev('text_final', { text: 'second reply' }),
       ev('turn_finished', { reason: 'stop', turnSequence: 2 }),
     ]);
@@ -375,10 +375,10 @@ describe('Engine', () => {
 
     expect(agent.startSession).toHaveBeenCalledTimes(2);
     const cfg2 = agent.startSession.mock.calls[1]![1] as SessionConfig;
-    expect(cfg2.resumeFromAgentSessionId).toBe('cc-first');
+    expect(cfg2.resumeFromAgentSessionId).toBe('sid-first');
 
-    // store 终态是第二轮写入的 cc-second（顺序写）
-    expect(store.get(SESSION_KEY)?.agentSessionId).toBe('cc-second');
+    // store 终态是第二轮写入的 sid-second（顺序写）
+    expect(store.get(SESSION_KEY)?.agentSessionId).toBe('sid-second');
   });
 
   it('不同 SessionKey 并发不串行：互不阻塞', async () => {
@@ -402,14 +402,14 @@ describe('Engine', () => {
     // A 慢；B 应该不被 A 拖累，可以早于 A 完成
     agent.queueEventsAfter(
       [
-        ev('session_started', { agentSessionId: 'cc-a' }),
+        ev('session_started', { agentSessionId: 'sid-a' }),
         ev('text_final', { text: 'a' }),
         ev('turn_finished', { reason: 'stop', turnSequence: 1 }),
       ],
       30,
     );
     agent.queueEvents([
-      ev('session_started', { agentSessionId: 'cc-b' }),
+      ev('session_started', { agentSessionId: 'sid-b' }),
       ev('text_final', { text: 'b' }),
       ev('turn_finished', { reason: 'stop', turnSequence: 1 }),
     ]);
@@ -424,8 +424,8 @@ describe('Engine', () => {
     // B 不应等满 A 的 30ms 延迟；给 25ms 余量足够区分串行/并行
     expect(tBDone).toBeLessThan(25);
 
-    expect(store.get(KEY_A)?.agentSessionId).toBe('cc-a');
-    expect(store.get(KEY_B)?.agentSessionId).toBe('cc-b');
+    expect(store.get(KEY_A)?.agentSessionId).toBe('sid-a');
+    expect(store.get(KEY_B)?.agentSessionId).toBe('sid-b');
   });
 
   it('turn_finished 后写 outbound info 日志（含 length、无 text），debug 日志含 text', async () => {
@@ -451,7 +451,7 @@ describe('Engine', () => {
     });
 
     agent.queueEvents([
-      ev('session_started', { agentSessionId: 'cc-1' }),
+      ev('session_started', { agentSessionId: 'sid-1' }),
       ev('text_final', { text: 'hello reply' }),
       ev('turn_finished', { reason: 'stop', turnSequence: 1 }),
     ]);
@@ -498,7 +498,7 @@ describe('Engine', () => {
     const dispatchHandler = (platform.start as ReturnType<typeof vi.fn>).mock.calls[0]![0] as EventHandler;
 
     agent.queueEvents([
-      ev('session_started', { agentSessionId: 'cc-1' }),
+      ev('session_started', { agentSessionId: 'sid-1' }),
       ev('text_final', { text: 'first reply' }),
       ev('turn_finished', { reason: 'stop', turnSequence: 1 }),
     ]);
@@ -542,7 +542,7 @@ describe('Engine', () => {
 
     // 用 fill-0 重投触发完整 agent 路径——若被淘汰，agent.startSession 会调一次
     agent.queueEvents([
-      ev('session_started', { agentSessionId: 'cc-evicted' }),
+      ev('session_started', { agentSessionId: 'sid-evicted' }),
       ev('text_final', { text: 're' }),
       ev('turn_finished', { reason: 'stop', turnSequence: 1 }),
     ]);

--- a/packages/daemon/src/engine.test.ts
+++ b/packages/daemon/src/engine.test.ts
@@ -207,7 +207,7 @@ describe('Engine', () => {
     });
 
     agent.queueEvents([
-      ev('session_started', { ccSessionID: 'cc-123' }),
+      ev('session_started', { agentSessionId: 'cc-123' }),
       ev('text_final', { text: 'hi from cc' }),
       ev('turn_finished', { reason: 'stop', turnSequence: 1 }),
     ]);
@@ -220,7 +220,7 @@ describe('Engine', () => {
     expect(agent.startSession).toHaveBeenCalledTimes(1);
     const startArgs = agent.startSession.mock.calls[0]!;
     const cfg = startArgs[1] as SessionConfig;
-    expect(cfg.resumeFromCcSessionID).toBeUndefined();
+    expect(cfg.resumeFromAgentSessionId).toBeUndefined();
     expect(cfg.sessionId).toBeTruthy();
 
     expect(store.get(SESSION_KEY)?.agentSessionId).toBe('cc-123');
@@ -233,7 +233,7 @@ describe('Engine', () => {
     expect(agent.stopSession).toHaveBeenCalledTimes(1);
   });
 
-  it('第二轮：复用同 sessionKey，agent.startSession 收到 prev agentSessionId 作 resumeFromCcSessionID', async () => {
+  it('第二轮：复用同 sessionKey，agent.startSession 收到 prev agentSessionId 作 resumeFromAgentSessionId', async () => {
     const platform = makePlatform();
     const agent = makeAgent();
     const store = new SessionStore();
@@ -250,7 +250,7 @@ describe('Engine', () => {
 
     // 首轮：写入 cc-123
     agent.queueEvents([
-      ev('session_started', { ccSessionID: 'cc-123' }),
+      ev('session_started', { agentSessionId: 'cc-123' }),
       ev('text_final', { text: 'first' }),
       ev('turn_finished', { reason: 'stop', turnSequence: 1 }),
     ]);
@@ -259,7 +259,7 @@ describe('Engine', () => {
 
     // 第二轮：startSession 必须收到 cc-123 作 resume
     agent.queueEvents([
-      ev('session_started', { ccSessionID: 'cc-456' }),
+      ev('session_started', { agentSessionId: 'cc-456' }),
       ev('text_final', { text: 'second' }),
       ev('turn_finished', { reason: 'stop', turnSequence: 2 }),
     ]);
@@ -267,7 +267,7 @@ describe('Engine', () => {
 
     expect(agent.startSession).toHaveBeenCalledTimes(2);
     const cfg2 = agent.startSession.mock.calls[1]![1] as SessionConfig;
-    expect(cfg2.resumeFromCcSessionID).toBe('cc-123');
+    expect(cfg2.resumeFromAgentSessionId).toBe('cc-123');
 
     expect(store.get(SESSION_KEY)?.agentSessionId).toBe('cc-456');
   });
@@ -291,7 +291,7 @@ describe('Engine', () => {
     const dispatchHandler = (platform.start as ReturnType<typeof vi.fn>).mock.calls[0]![0] as EventHandler;
 
     agent.queueEvents([
-      ev('session_started', { ccSessionID: 'cc-new' }),
+      ev('session_started', { agentSessionId: 'cc-new' }),
       ev('text_final', { text: 'answer' }),
       ev('turn_finished', { reason: 'stop', turnSequence: 1 }),
     ]);
@@ -300,7 +300,7 @@ describe('Engine', () => {
 
     expect(agent.startSession).toHaveBeenCalledTimes(1);
     const cfg = agent.startSession.mock.calls[0]![1] as SessionConfig;
-    expect(cfg.resumeFromCcSessionID).toBeUndefined();
+    expect(cfg.resumeFromAgentSessionId).toBeUndefined();
 
     expect(agent.sendInput).toHaveBeenCalledTimes(1);
     const input = agent.sendInput.mock.calls[0]![1] as AgentInput;
@@ -337,7 +337,7 @@ describe('Engine', () => {
 
   it('同 SessionKey 并发：第二条 dispatch 必须串行在第一条之后，看到首轮 agentSessionId 作 resume', async () => {
     // race regression：两条来自同一频道+同一用户的 @mention 几乎同时到达。
-    // 期望：第二条 startSession 的 config.resumeFromCcSessionID === 首轮的 agentSessionId。
+    // 期望：第二条 startSession 的 config.resumeFromAgentSessionId === 首轮的 agentSessionId。
     // 旧实现里两次 dispatch 都同步读 sessionStore（仍为 undefined），都启新 session 并互相覆盖。
     const platform = makePlatform();
     const agent = makeAgent();
@@ -356,7 +356,7 @@ describe('Engine', () => {
     // 第一条 dispatch 故意慢——session_started 在 8ms 后才进 store
     agent.queueEventsAfter(
       [
-        ev('session_started', { ccSessionID: 'cc-first' }),
+        ev('session_started', { agentSessionId: 'cc-first' }),
         ev('text_final', { text: 'first reply' }),
         ev('turn_finished', { reason: 'stop', turnSequence: 1 }),
       ],
@@ -364,7 +364,7 @@ describe('Engine', () => {
     );
     // 第二条 dispatch 紧随其后
     agent.queueEvents([
-      ev('session_started', { ccSessionID: 'cc-second' }),
+      ev('session_started', { agentSessionId: 'cc-second' }),
       ev('text_final', { text: 'second reply' }),
       ev('turn_finished', { reason: 'stop', turnSequence: 2 }),
     ]);
@@ -375,7 +375,7 @@ describe('Engine', () => {
 
     expect(agent.startSession).toHaveBeenCalledTimes(2);
     const cfg2 = agent.startSession.mock.calls[1]![1] as SessionConfig;
-    expect(cfg2.resumeFromCcSessionID).toBe('cc-first');
+    expect(cfg2.resumeFromAgentSessionId).toBe('cc-first');
 
     // store 终态是第二轮写入的 cc-second（顺序写）
     expect(store.get(SESSION_KEY)?.agentSessionId).toBe('cc-second');
@@ -402,14 +402,14 @@ describe('Engine', () => {
     // A 慢；B 应该不被 A 拖累，可以早于 A 完成
     agent.queueEventsAfter(
       [
-        ev('session_started', { ccSessionID: 'cc-a' }),
+        ev('session_started', { agentSessionId: 'cc-a' }),
         ev('text_final', { text: 'a' }),
         ev('turn_finished', { reason: 'stop', turnSequence: 1 }),
       ],
       30,
     );
     agent.queueEvents([
-      ev('session_started', { ccSessionID: 'cc-b' }),
+      ev('session_started', { agentSessionId: 'cc-b' }),
       ev('text_final', { text: 'b' }),
       ev('turn_finished', { reason: 'stop', turnSequence: 1 }),
     ]);
@@ -451,7 +451,7 @@ describe('Engine', () => {
     });
 
     agent.queueEvents([
-      ev('session_started', { ccSessionID: 'cc-1' }),
+      ev('session_started', { agentSessionId: 'cc-1' }),
       ev('text_final', { text: 'hello reply' }),
       ev('turn_finished', { reason: 'stop', turnSequence: 1 }),
     ]);
@@ -498,7 +498,7 @@ describe('Engine', () => {
     const dispatchHandler = (platform.start as ReturnType<typeof vi.fn>).mock.calls[0]![0] as EventHandler;
 
     agent.queueEvents([
-      ev('session_started', { ccSessionID: 'cc-1' }),
+      ev('session_started', { agentSessionId: 'cc-1' }),
       ev('text_final', { text: 'first reply' }),
       ev('turn_finished', { reason: 'stop', turnSequence: 1 }),
     ]);
@@ -542,7 +542,7 @@ describe('Engine', () => {
 
     // 用 fill-0 重投触发完整 agent 路径——若被淘汰，agent.startSession 会调一次
     agent.queueEvents([
-      ev('session_started', { ccSessionID: 'cc-evicted' }),
+      ev('session_started', { agentSessionId: 'cc-evicted' }),
       ev('text_final', { text: 're' }),
       ev('turn_finished', { reason: 'stop', turnSequence: 1 }),
     ]);

--- a/packages/daemon/src/engine.test.ts
+++ b/packages/daemon/src/engine.test.ts
@@ -223,7 +223,7 @@ describe('Engine', () => {
     expect(cfg.resumeFromCcSessionID).toBeUndefined();
     expect(cfg.sessionId).toBeTruthy();
 
-    expect(store.get(SESSION_KEY)?.ccSessionID).toBe('cc-123');
+    expect(store.get(SESSION_KEY)?.agentSessionId).toBe('cc-123');
 
     expect(platform.send).toHaveBeenCalledTimes(1);
     const sendArgs = platform.send.mock.calls[0]!;
@@ -233,7 +233,7 @@ describe('Engine', () => {
     expect(agent.stopSession).toHaveBeenCalledTimes(1);
   });
 
-  it('第二轮：复用同 sessionKey，agent.startSession 收到 prev ccSessionID 作 resumeFromCcSessionID', async () => {
+  it('第二轮：复用同 sessionKey，agent.startSession 收到 prev agentSessionId 作 resumeFromCcSessionID', async () => {
     const platform = makePlatform();
     const agent = makeAgent();
     const store = new SessionStore();
@@ -255,7 +255,7 @@ describe('Engine', () => {
       ev('turn_finished', { reason: 'stop', turnSequence: 1 }),
     ]);
     await dispatchHandler(makeEvent('first prompt'));
-    expect(store.get(SESSION_KEY)?.ccSessionID).toBe('cc-123');
+    expect(store.get(SESSION_KEY)?.agentSessionId).toBe('cc-123');
 
     // 第二轮：startSession 必须收到 cc-123 作 resume
     agent.queueEvents([
@@ -269,7 +269,7 @@ describe('Engine', () => {
     const cfg2 = agent.startSession.mock.calls[1]![1] as SessionConfig;
     expect(cfg2.resumeFromCcSessionID).toBe('cc-123');
 
-    expect(store.get(SESSION_KEY)?.ccSessionID).toBe('cc-456');
+    expect(store.get(SESSION_KEY)?.agentSessionId).toBe('cc-456');
   });
 
   it('/new 带后续文本：清 store + 用 trim 后的剩余作 prompt', async () => {
@@ -277,7 +277,7 @@ describe('Engine', () => {
     const agent = makeAgent();
     const store = new SessionStore();
     // 预置一条旧的
-    store.set(SESSION_KEY, { ccSessionID: 'cc-123', lastTurnAt: new Date(0) });
+    store.set(SESSION_KEY, { agentSessionId: 'cc-123', lastTurnAt: new Date(0) });
 
     const engine = new Engine({
       platform,
@@ -307,7 +307,7 @@ describe('Engine', () => {
     expect(input.text).toBe('what is X?');
 
     // 新一轮 session_started 写回 cc-new；旧的 cc-123 已被清掉
-    expect(store.get(SESSION_KEY)?.ccSessionID).toBe('cc-new');
+    expect(store.get(SESSION_KEY)?.agentSessionId).toBe('cc-new');
   });
 
   it('/new 单独：发 [new session ready] 不调 agent', async () => {
@@ -335,9 +335,9 @@ describe('Engine', () => {
     expect(out.text).toBe('[new session ready]');
   });
 
-  it('同 SessionKey 并发：第二条 dispatch 必须串行在第一条之后，看到首轮 ccSessionID 作 resume', async () => {
+  it('同 SessionKey 并发：第二条 dispatch 必须串行在第一条之后，看到首轮 agentSessionId 作 resume', async () => {
     // race regression：两条来自同一频道+同一用户的 @mention 几乎同时到达。
-    // 期望：第二条 startSession 的 config.resumeFromCcSessionID === 首轮的 ccSessionID。
+    // 期望：第二条 startSession 的 config.resumeFromCcSessionID === 首轮的 agentSessionId。
     // 旧实现里两次 dispatch 都同步读 sessionStore（仍为 undefined），都启新 session 并互相覆盖。
     const platform = makePlatform();
     const agent = makeAgent();
@@ -378,7 +378,7 @@ describe('Engine', () => {
     expect(cfg2.resumeFromCcSessionID).toBe('cc-first');
 
     // store 终态是第二轮写入的 cc-second（顺序写）
-    expect(store.get(SESSION_KEY)?.ccSessionID).toBe('cc-second');
+    expect(store.get(SESSION_KEY)?.agentSessionId).toBe('cc-second');
   });
 
   it('不同 SessionKey 并发不串行：互不阻塞', async () => {
@@ -424,8 +424,8 @@ describe('Engine', () => {
     // B 不应等满 A 的 30ms 延迟；给 25ms 余量足够区分串行/并行
     expect(tBDone).toBeLessThan(25);
 
-    expect(store.get(KEY_A)?.ccSessionID).toBe('cc-a');
-    expect(store.get(KEY_B)?.ccSessionID).toBe('cc-b');
+    expect(store.get(KEY_A)?.agentSessionId).toBe('cc-a');
+    expect(store.get(KEY_B)?.agentSessionId).toBe('cc-b');
   });
 
   it('turn_finished 后写 outbound info 日志（含 length、无 text），debug 日志含 text', async () => {
@@ -554,7 +554,7 @@ describe('Engine', () => {
     expect(agent.startSession).toHaveBeenCalledTimes(1);
   });
 
-  it('error 路径：agent emit error → platform.send 收到 [CC error: ...]', async () => {
+  it('error 路径：agent emit error → platform.send 收到 [agent error: ...]', async () => {
     const platform = makePlatform();
     const agent = makeAgent();
     const store = new SessionStore();
@@ -578,7 +578,7 @@ describe('Engine', () => {
 
     expect(platform.send).toHaveBeenCalledTimes(1);
     const out = platform.send.mock.calls[0]![1] as OutboundMessage;
-    expect(out.text).toContain('CC error');
+    expect(out.text).toContain('agent error');
     expect(out.text).toContain('spawn_failed');
     expect(out.text).toContain('boom');
   });

--- a/packages/daemon/src/engine.ts
+++ b/packages/daemon/src/engine.ts
@@ -16,10 +16,10 @@ export interface EngineDeps {
   agent: AgentRuntime;
   logger: Logger;
   sessionStore: SessionStore;
-  /** 每轮 sessionId 由 Engine 生成；resumeFromCcSessionID 由 store 决定 */
+  /** 每轮 sessionId 由 Engine 生成；resumeFromAgentSessionId 由 store 决定 */
   defaultSessionConfig: Omit<
     SessionConfig,
-    'resumeFromCcSessionID' | 'sessionId'
+    'resumeFromAgentSessionId' | 'sessionId'
   >;
 }
 
@@ -41,7 +41,7 @@ export class Engine {
   private readonly sessionStore: SessionStore;
   private readonly defaultSessionConfig: Omit<
     SessionConfig,
-    'resumeFromCcSessionID' | 'sessionId'
+    'resumeFromAgentSessionId' | 'sessionId'
   >;
   /**
    * Per-SessionKey 串行队列：同 key 的 dispatch 必须按到达序排队执行，
@@ -156,7 +156,7 @@ export class Engine {
       const config: SessionConfig = {
         ...this.defaultSessionConfig,
         sessionId: randomUUID(),
-        resumeFromCcSessionID: prevAgentSessionId,
+        resumeFromAgentSessionId: prevAgentSessionId,
       };
 
       const session = this.agent.startSession(event.sessionKey, config);
@@ -167,7 +167,7 @@ export class Engine {
       const handler = async (e: AgentEvent): Promise<void> => {
         try {
           if (e.type === 'session_started') {
-            const agentSessionId = e.payload.ccSessionID;
+            const agentSessionId = e.payload.agentSessionId;
             if (agentSessionId) {
               this.sessionStore.set(event.sessionKey, {
                 agentSessionId,

--- a/packages/daemon/src/engine.ts
+++ b/packages/daemon/src/engine.ts
@@ -45,8 +45,8 @@ export class Engine {
   >;
   /**
    * Per-SessionKey 串行队列：同 key 的 dispatch 必须按到达序排队执行，
-   * 否则两条并发 inbound 会同时读到陈旧 prevCc 各自启新 session、
-   * 互相覆盖 sessionStore 里的 ccSessionID（ordering corruption）。
+   * 否则两条并发 inbound 会同时读到陈旧 prevAgentSessionId 各自启新 session、
+   * 互相覆盖 sessionStore 里的 agentSessionId（ordering corruption）。
    * 不同 key 之间互不阻塞。
    */
   private readonly inflight = new Map<string, Promise<void>>();
@@ -150,11 +150,13 @@ export class Engine {
         prompt = rawText;
       }
 
-      const prevCc = this.sessionStore.get(event.sessionKey)?.ccSessionID;
+      const prevAgentSessionId = this.sessionStore.get(
+        event.sessionKey,
+      )?.agentSessionId;
       const config: SessionConfig = {
         ...this.defaultSessionConfig,
         sessionId: randomUUID(),
-        resumeFromCcSessionID: prevCc,
+        resumeFromCcSessionID: prevAgentSessionId,
       };
 
       const session = this.agent.startSession(event.sessionKey, config);
@@ -165,10 +167,10 @@ export class Engine {
       const handler = async (e: AgentEvent): Promise<void> => {
         try {
           if (e.type === 'session_started') {
-            const ccSessionID = e.payload.ccSessionID;
-            if (ccSessionID) {
+            const agentSessionId = e.payload.ccSessionID;
+            if (agentSessionId) {
               this.sessionStore.set(event.sessionKey, {
-                ccSessionID,
+                agentSessionId,
                 lastTurnAt: new Date(),
               });
             }
@@ -193,7 +195,7 @@ export class Engine {
             );
             await this.safeSend(
               event,
-              `[CC error: ${e.payload.errorKind}] ${e.payload.message}`,
+              `[agent error: ${e.payload.errorKind}] ${e.payload.message}`,
             );
             this.logger.info(
               {

--- a/packages/daemon/src/session-store.test.ts
+++ b/packages/daemon/src/session-store.test.ts
@@ -19,7 +19,7 @@ describe('SessionStore', () => {
   it('set then get returns the same entry', () => {
     const store = new SessionStore();
     const key = makeKey();
-    const entry = { agentSessionId: 'cc-1', lastTurnAt: new Date(0) };
+    const entry = { agentSessionId: 'sid-1', lastTurnAt: new Date(0) };
     store.set(key, entry);
     expect(store.get(key)).toEqual(entry);
     expect(store.size).toBe(1);
@@ -32,16 +32,16 @@ describe('SessionStore', () => {
     const k3 = makeKey({ channelId: 'C2' });
     const k4 = makeKey({ initiatorUserId: 'U2' });
 
-    store.set(k1, { agentSessionId: 'cc-1', lastTurnAt: new Date(1) });
-    store.set(k2, { agentSessionId: 'cc-2', lastTurnAt: new Date(2) });
-    store.set(k3, { agentSessionId: 'cc-3', lastTurnAt: new Date(3) });
-    store.set(k4, { agentSessionId: 'cc-4', lastTurnAt: new Date(4) });
+    store.set(k1, { agentSessionId: 'sid-1', lastTurnAt: new Date(1) });
+    store.set(k2, { agentSessionId: 'sid-2', lastTurnAt: new Date(2) });
+    store.set(k3, { agentSessionId: 'sid-3', lastTurnAt: new Date(3) });
+    store.set(k4, { agentSessionId: 'sid-4', lastTurnAt: new Date(4) });
 
     expect(store.size).toBe(4);
-    expect(store.get(k1)?.agentSessionId).toBe('cc-1');
-    expect(store.get(k2)?.agentSessionId).toBe('cc-2');
-    expect(store.get(k3)?.agentSessionId).toBe('cc-3');
-    expect(store.get(k4)?.agentSessionId).toBe('cc-4');
+    expect(store.get(k1)?.agentSessionId).toBe('sid-1');
+    expect(store.get(k2)?.agentSessionId).toBe('sid-2');
+    expect(store.get(k3)?.agentSessionId).toBe('sid-3');
+    expect(store.get(k4)?.agentSessionId).toBe('sid-4');
 
     // 序列化形式确认互不相同
     const ids = new Set([k1, k2, k3, k4].map(serializeSessionKey));
@@ -51,7 +51,7 @@ describe('SessionStore', () => {
   it('delete returns true when present, false when missing', () => {
     const store = new SessionStore();
     const key = makeKey();
-    store.set(key, { agentSessionId: 'cc-x', lastTurnAt: new Date() });
+    store.set(key, { agentSessionId: 'sid-x', lastTurnAt: new Date() });
     expect(store.delete(key)).toBe(true);
     expect(store.delete(key)).toBe(false);
     expect(store.get(key)).toBeUndefined();
@@ -60,11 +60,11 @@ describe('SessionStore', () => {
   it('clearAll empties the store', () => {
     const store = new SessionStore();
     store.set(makeKey({ channelId: 'A' }), {
-      agentSessionId: 'cc-a',
+      agentSessionId: 'sid-a',
       lastTurnAt: new Date(),
     });
     store.set(makeKey({ channelId: 'B' }), {
-      agentSessionId: 'cc-b',
+      agentSessionId: 'sid-b',
       lastTurnAt: new Date(),
     });
     expect(store.size).toBe(2);

--- a/packages/daemon/src/session-store.test.ts
+++ b/packages/daemon/src/session-store.test.ts
@@ -19,7 +19,7 @@ describe('SessionStore', () => {
   it('set then get returns the same entry', () => {
     const store = new SessionStore();
     const key = makeKey();
-    const entry = { ccSessionID: 'cc-1', lastTurnAt: new Date(0) };
+    const entry = { agentSessionId: 'cc-1', lastTurnAt: new Date(0) };
     store.set(key, entry);
     expect(store.get(key)).toEqual(entry);
     expect(store.size).toBe(1);
@@ -32,16 +32,16 @@ describe('SessionStore', () => {
     const k3 = makeKey({ channelId: 'C2' });
     const k4 = makeKey({ initiatorUserId: 'U2' });
 
-    store.set(k1, { ccSessionID: 'cc-1', lastTurnAt: new Date(1) });
-    store.set(k2, { ccSessionID: 'cc-2', lastTurnAt: new Date(2) });
-    store.set(k3, { ccSessionID: 'cc-3', lastTurnAt: new Date(3) });
-    store.set(k4, { ccSessionID: 'cc-4', lastTurnAt: new Date(4) });
+    store.set(k1, { agentSessionId: 'cc-1', lastTurnAt: new Date(1) });
+    store.set(k2, { agentSessionId: 'cc-2', lastTurnAt: new Date(2) });
+    store.set(k3, { agentSessionId: 'cc-3', lastTurnAt: new Date(3) });
+    store.set(k4, { agentSessionId: 'cc-4', lastTurnAt: new Date(4) });
 
     expect(store.size).toBe(4);
-    expect(store.get(k1)?.ccSessionID).toBe('cc-1');
-    expect(store.get(k2)?.ccSessionID).toBe('cc-2');
-    expect(store.get(k3)?.ccSessionID).toBe('cc-3');
-    expect(store.get(k4)?.ccSessionID).toBe('cc-4');
+    expect(store.get(k1)?.agentSessionId).toBe('cc-1');
+    expect(store.get(k2)?.agentSessionId).toBe('cc-2');
+    expect(store.get(k3)?.agentSessionId).toBe('cc-3');
+    expect(store.get(k4)?.agentSessionId).toBe('cc-4');
 
     // 序列化形式确认互不相同
     const ids = new Set([k1, k2, k3, k4].map(serializeSessionKey));
@@ -51,7 +51,7 @@ describe('SessionStore', () => {
   it('delete returns true when present, false when missing', () => {
     const store = new SessionStore();
     const key = makeKey();
-    store.set(key, { ccSessionID: 'cc-x', lastTurnAt: new Date() });
+    store.set(key, { agentSessionId: 'cc-x', lastTurnAt: new Date() });
     expect(store.delete(key)).toBe(true);
     expect(store.delete(key)).toBe(false);
     expect(store.get(key)).toBeUndefined();
@@ -60,11 +60,11 @@ describe('SessionStore', () => {
   it('clearAll empties the store', () => {
     const store = new SessionStore();
     store.set(makeKey({ channelId: 'A' }), {
-      ccSessionID: 'cc-a',
+      agentSessionId: 'cc-a',
       lastTurnAt: new Date(),
     });
     store.set(makeKey({ channelId: 'B' }), {
-      ccSessionID: 'cc-b',
+      agentSessionId: 'cc-b',
       lastTurnAt: new Date(),
     });
     expect(store.size).toBe(2);

--- a/packages/daemon/src/session-store.ts
+++ b/packages/daemon/src/session-store.ts
@@ -2,13 +2,13 @@ import type { SessionKey } from '@agent-nexus/protocol';
 import { serializeSessionKey } from '@agent-nexus/protocol';
 
 /**
- * 跨 turn 维护 SessionKey → ccSessionID 的最小内存映射。
+ * 跨 turn 维护 SessionKey → agentSessionId 的最小内存映射。
  *
  * MVP 仅在进程内存活；进程重启即清空。持久化、状态机、TTL、并发竞态
  * 处理留给后续 PR——TODO docs/dev/architecture/session-model.md。
  */
 export interface SessionEntry {
-  ccSessionID: string;
+  agentSessionId: string;
   lastTurnAt: Date;
 }
 

--- a/packages/protocol/src/agent.ts
+++ b/packages/protocol/src/agent.ts
@@ -44,7 +44,7 @@ export type AgentEvent =
       timestamp: Date;
       sequence: number;
       payload: {
-        ccSessionID?: string;
+        agentSessionId?: string;
         workingDir?: string;
       };
     }
@@ -104,7 +104,7 @@ export interface SessionConfig {
   toolWhitelist: string[];
   timeoutMs: number;
   /** 若非空 → agent 启动时透传给后端做 multi-turn 续话（CC 的 --resume） */
-  resumeFromCcSessionID?: string;
+  resumeFromAgentSessionId?: string;
 }
 
 export type AgentSessionState =
@@ -123,5 +123,5 @@ export interface AgentSession {
   startedAt: Date;
   pid?: number;
   /** 后端会话 ID（如 CC CLI 的 session_id），用于 multi-turn 续话 */
-  ccSessionID?: string;
+  agentSessionId?: string;
 }

--- a/packages/protocol/src/agent.ts
+++ b/packages/protocol/src/agent.ts
@@ -103,7 +103,7 @@ export interface SessionConfig {
   workingDir: string;
   toolWhitelist: string[];
   timeoutMs: number;
-  /** 若非空 → agent 启动时透传给后端做 multi-turn 续话（CC 的 --resume） */
+  /** 若非空 → agent 启动时透传给后端做 multi-turn 续话（如恢复某条已知 agent 会话） */
   resumeFromAgentSessionId?: string;
 }
 
@@ -122,6 +122,6 @@ export interface AgentSession {
   state: AgentSessionState;
   startedAt: Date;
   pid?: number;
-  /** 后端会话 ID（如 CC CLI 的 session_id），用于 multi-turn 续话 */
+  /** 后端会话 ID（由 agent runtime 在 session_started 时回传），用于 multi-turn 续话 */
   agentSessionId?: string;
 }


### PR DESCRIPTION
关闭 #76。把 daemon-internal 命名 + 用户可见错误串 + protocol 字段名 + protocol 注释 + daemon 测试 fixture 一次性切换到后端中立命名。

## 改动

### protocol（A 路线 — 字段 + 注释）

`packages/protocol/src/agent.ts`：

| 旧 | 新 |
|---|---|
| `AgentEvent<session_started>.payload.ccSessionID` | `agentSessionId` |
| `SessionConfig.resumeFromCcSessionID` | `resumeFromAgentSessionId` |
| `AgentSession.ccSessionID` | `agentSessionId` |

注释里 `CC 的 --resume` / `CC CLI 的 session_id` → 后端中立表述（standards/coding.md §抽象中枢的词汇中立 严格禁止 protocol 内注释提具体后端）。

无外部消费者，单 PR 一次性切换；不引入 alias 中间态。

### daemon（C + A + 测试 fixture）

`packages/daemon/src/engine.ts`：

- 局部变量 `prevCc` → `prevAgentSessionId`
- 注释里的 `ccSessionID` → `agentSessionId`
- `Omit<SessionConfig, 'resumeFromCcSessionID' | ...>` 跟随 protocol rename
- **用户可见出口**：`[CC error: ${kind}] ${msg}` → `[agent error: ...]`（最显眼的 leak — IM 端真的会被用户看到）

`packages/daemon/src/session-store.ts`：

- `SessionEntry.ccSessionID` → `agentSessionId`
- 注释 `SessionKey → ccSessionID 的最小内存映射` → `agentSessionId`

`packages/daemon/src/{engine,session-store}.test.ts`：

- 跟随 rename + 测试名 / assertion 同步（`'CC error'` → `'agent error'`、`prev ccSessionID` → `prev agentSessionId`）
- Fixture 值 `'cc-1'` / `'cc-123'` / `'hi from cc'` → `'sid-1'` / `'sid-123'` / `'hi from agent'`，相关注释同步

### agent/claudecode（A 跟随）

`packages/agent/claudecode/src/index.ts`：6 处 `session.ccSessionID` / `payload.ccSessionID` / `config.resumeFromCcSessionID` 全部跟随 protocol rename。`backend: 'claudecode'` 标识保留——这是后端身份字段，规则允许。

### docs

`docs/dev/spec/agent-backends/claude-code-cli.md`：`--resume` 行内引用从 `ccSessionID` 改为 `agentSessionId`。

## 不在范围（issue 已声明）

- 引入 lint 规则 / grep pattern 自动拦截新违反——独立工作
- 在 `spec/agent-runtime.md` 加字段命名约束——独立工作

## 验证

- `pnpm vitest run`：138 tests / 11 files 全绿
- `pnpm -r typecheck`：5 packages 全绿
- 全仓 audit：

```
$ grep -rniE 'claudecode|claude-code|\bCC\b|\bcc[A-Z_]|gpt|openai' packages/protocol/src/
（无命中）

$ grep -rniE '\bCC\b|\bcc[A-Z_]|cc-[a-z0-9]|claudecode|hi from cc|gpt|openai' packages/daemon/src/
（无命中）
```

Closes #76
