### PR TITLE
fix(discord): send 失败时抛 PartialSendError 携带 sentIds

### DIFF
--- a/packages/platform/discord/src/index.test.ts
+++ b/packages/platform/discord/src/index.test.ts
@@ -122,6 +122,12 @@ describe('buildSlices', () => {
     }
     expect(slices.join('')).toBe(text);
   });
+
+  it('退化路径不产生 trailing 空切片：buildSlices("😀😀", 1) === ["😀","😀"]', () => {
+    // 预算比单个 code point 还小（cpLen=2 > maxUtf16=1）时走强行切分支；
+    // 旧实现末尾无条件 push 会留下 trailing 空串。直接钉住该回归。
+    expect(buildSlices('😀😀', 1)).toEqual(['😀', '😀']);
+  });
 });
 
 describe('PartialSendError', () => {
@@ -138,7 +144,9 @@ describe('PartialSendError', () => {
     expect(err.totalSlices).toBe(5);
     expect(err.cause).toBe(cause);
     expect(err.message).toContain('2/5');
-    // pino 默认 err serializer 会序列化 enumerable own props——sentIds / totalSlices / cause 必须 enumerable
+    // pino 默认 err serializer 会把 enumerable own props 平铺到日志（sentIds / totalSlices 直接落字段）；
+    // `cause` 走 pino 自己的 cause-chain 处理（折进 stack 末尾，不作为顶层 key），
+    // 但 own property 仍需保留 enumerable 以便 cause 内容随同序列化。
     const ownKeys = Object.keys(err);
     expect(ownKeys).toContain('sentIds');
     expect(ownKeys).toContain('totalSlices');

--- a/packages/platform/discord/src/index.test.ts
+++ b/packages/platform/discord/src/index.test.ts
@@ -4,6 +4,7 @@ import {
   buildBotMentionRegex,
   buildSlices,
   parseInbound,
+  PartialSendError,
   SLICE_SIZE,
   type ParsedInbound,
 } from './index.js';
@@ -83,9 +84,64 @@ describe('buildSlices', () => {
     expect(slices.join('')).toBe(text);
   });
 
-  it('custom sliceSize', () => {
+  it('custom maxUtf16 budget (ASCII)', () => {
     const slices = buildSlices('abcde', 2);
     expect(slices).toEqual(['ab', 'cd', 'e']);
+  });
+
+  it('emoji 在边界不被劈成 lone surrogate', () => {
+    // 边界附近放一个 surrogate pair emoji，确保切点不落在 high/low surrogate 之间。
+    // 预算 4 (UTF-16 单位) 下：'a' (1) + '😀' (2) = 3，再加 'b' (1) = 4，第一切片塞满；
+    // 'c' (1) 进第二片；'😀' (2) + 'd' (1) = 3 仍在第二片。
+    const text = 'a😀bc😀d';
+    const slices = buildSlices(text, 4);
+    expect(slices.join('')).toBe(text);
+    for (const slice of slices) {
+      // 没有 lone surrogate：每个切片自己重新迭代 code point 数 = 实际显示字符数
+      const codePoints = Array.from(slice);
+      // 重新连接代码点 = 切片本身（不含半 surrogate）
+      expect(codePoints.join('')).toBe(slice);
+    }
+  });
+
+  it('全 emoji 长文本：每片 UTF-16 长度不超 maxUtf16', () => {
+    // 1000 个 😀，每个占 2 UTF-16 单位 → 总 2000 UTF-16 单位
+    const text = '😀'.repeat(1000);
+    const slices = buildSlices(text, 100);
+    expect(slices.join('')).toBe(text);
+    for (const slice of slices) {
+      expect(slice.length).toBeLessThanOrEqual(100);
+    }
+  });
+
+  it('SLICE_SIZE 默认预算下，全 emoji 切片每片 UTF-16 长度 ≤ Discord 2000 上限', () => {
+    const text = '😀'.repeat(5000);
+    const slices = buildSlices(text);
+    for (const slice of slices) {
+      expect(slice.length).toBeLessThanOrEqual(2000);
+    }
+    expect(slices.join('')).toBe(text);
+  });
+});
+
+describe('PartialSendError', () => {
+  it('携带 sentIds / totalSlices / cause；通过 pino err 序列化器读得到', () => {
+    const cause = new Error('rate limit');
+    const err = new PartialSendError({
+      sentIds: ['m1', 'm2'],
+      totalSlices: 5,
+      cause,
+    });
+    expect(err).toBeInstanceOf(PartialSendError);
+    expect(err.name).toBe('PartialSendError');
+    expect(err.sentIds).toEqual(['m1', 'm2']);
+    expect(err.totalSlices).toBe(5);
+    expect(err.cause).toBe(cause);
+    expect(err.message).toContain('2/5');
+    // pino 默认 err serializer 会序列化 enumerable own props——sentIds 必须 enumerable
+    const ownKeys = Object.keys(err);
+    expect(ownKeys).toContain('sentIds');
+    expect(ownKeys).toContain('totalSlices');
   });
 });
 
@@ -365,5 +421,45 @@ describe('send: MessageRef shape (short vs long text)', () => {
     const ref = { messageId: sentIds[sentIds.length - 1], messageIds: sentIds };
     expect(ref.messageId).toBe('m-2');
     expect(ref.messageIds[0]).toBe('m-1');
+  });
+
+  /**
+   * 多片 send 中途失败：模拟 send() 内部的 try/catch 路径，验证 PartialSendError 携带
+   * 已发的 sentIds。end-to-end 集成（mock discord.js Client）走 #30 follow-up。
+   */
+  it('中途失败 → 抛 PartialSendError 携带前 N 片 sentIds', async () => {
+    const text = 'z'.repeat(SLICE_SIZE * 2 + 1); // 3 片
+    const slices = buildSlices(text);
+    expect(slices).toHaveLength(3);
+
+    let seq = 0;
+    const sendErr = new Error('rate limit');
+    const fakeSend = vi.fn(async (_content: string) => {
+      seq += 1;
+      if (seq === 2) throw sendErr;
+      return { id: `pf-${seq}` };
+    });
+
+    const sentIds: string[] = [];
+    let caught: unknown;
+    try {
+      for (const slice of slices) {
+        const msg = await fakeSend(slice);
+        sentIds.push(msg.id);
+      }
+    } catch (err) {
+      caught = new PartialSendError({
+        sentIds,
+        totalSlices: slices.length,
+        cause: err,
+      });
+    }
+
+    expect(caught).toBeInstanceOf(PartialSendError);
+    const partial = caught as PartialSendError;
+    expect(partial.sentIds).toEqual(['pf-1']);
+    expect(partial.totalSlices).toBe(3);
+    expect(partial.cause).toBe(sendErr);
+    expect(fakeSend).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/platform/discord/src/index.test.ts
+++ b/packages/platform/discord/src/index.test.ts
@@ -97,10 +97,10 @@ describe('buildSlices', () => {
     const slices = buildSlices(text, 4);
     expect(slices.join('')).toBe(text);
     for (const slice of slices) {
-      // 没有 lone surrogate：每个切片自己重新迭代 code point 数 = 实际显示字符数
-      const codePoints = Array.from(slice);
-      // 重新连接代码点 = 切片本身（不含半 surrogate）
-      expect(codePoints.join('')).toBe(slice);
+      // 真·检测 lone surrogate：用 /\p{Surrogate}/u 找 0xD800-0xDFFF 区间字符
+      // （配对正常的 emoji 内部 surrogate 在 code point 迭代后已被合成单字符，
+      // 不会被这个正则当 lone 命中——属性匹配看的是 code point，不是 code unit）
+      expect(slice).not.toMatch(/\p{Surrogate}/u);
     }
   });
 
@@ -138,10 +138,11 @@ describe('PartialSendError', () => {
     expect(err.totalSlices).toBe(5);
     expect(err.cause).toBe(cause);
     expect(err.message).toContain('2/5');
-    // pino 默认 err serializer 会序列化 enumerable own props——sentIds 必须 enumerable
+    // pino 默认 err serializer 会序列化 enumerable own props——sentIds / totalSlices / cause 必须 enumerable
     const ownKeys = Object.keys(err);
     expect(ownKeys).toContain('sentIds');
     expect(ownKeys).toContain('totalSlices');
+    expect(ownKeys).toContain('cause');
   });
 });
 

--- a/packages/platform/discord/src/index.test.ts
+++ b/packages/platform/discord/src/index.test.ts
@@ -128,10 +128,56 @@ describe('buildSlices', () => {
     // 旧实现末尾无条件 push 会留下 trailing 空串。直接钉住该回归。
     expect(buildSlices('😀😀', 1)).toEqual(['😀', '😀']);
   });
+
+  /**
+   * 已知限制（src/index.ts buildSlices doc 已注明）：当前按 code point 迭代，不识别
+   * grapheme cluster。下面这组用例把"当前接受的折中行为"显式钉死，避免：
+   *   1. 未来误以为已经做到 grapheme-safe；
+   *   2. 等 issue #56 stream-json epic 落地后切换到 `Intl.Segmenter` 时，这些用例
+   *      会以"应失败"形式提醒重写预期。
+   *
+   * 注：这些切法不是 lone surrogate（surrogate pair 在 `for…of` 迭代下已被正确合成单
+   * code point），只是 grapheme 被劈成两个独立 code point；Discord 渲染端看到的会是
+   * 两个独立字符而不是 �。
+   */
+  describe('known degenerate behavior（grapheme cluster 当前可被劈，钉死等 #56 收掉）', () => {
+    it('VS-16（❤️ = U+2764 + U+FE0F）：变体选择符可被切到下一片', () => {
+      // ❤(U+2764) 与 VS-16(U+FE0F) 都在 BMP，各 1 UTF-16 单位。
+      // 预算 1：第一片 ❤，第二片只剩孤立 VS-16。
+      const slices = buildSlices('❤️', 1);
+      expect(slices).toHaveLength(2);
+      expect(slices[0]).toBe('❤');
+      expect(slices[1]).toBe('️');
+      expect(slices.join('')).toBe('❤️');
+    });
+
+    it('国旗（🇨🇳 = 两个 regional indicator）：可在两个 indicator 间被切', () => {
+      // 每个 regional indicator 占 2 UTF-16。预算 2：第一片 🇨，第二片 🇳。
+      const slices = buildSlices('🇨🇳', 2);
+      expect(slices).toEqual(['\u{1F1E8}', '\u{1F1F3}']);
+      expect(slices.join('')).toBe('🇨🇳');
+    });
+
+    it('肤色修饰符（👋🏽 = 👋 + 🏽）：可在基础 emoji 与肤色修饰符间被切', () => {
+      // 各占 2 UTF-16。预算 2：第一片 👋（无肤色），第二片孤立肤色修饰符。
+      const slices = buildSlices('👋🏽', 2);
+      expect(slices).toEqual(['\u{1F44B}', '\u{1F3FD}']);
+      expect(slices.join('')).toBe('👋🏽');
+    });
+
+    it('ZWJ 序列（👨‍👩 = 👨 + ZWJ + 👩）：可在 ZWJ 前后被切', () => {
+      // 👨(2) + ZWJ(1) + 👩(2) = 5 UTF-16。预算 3：第一片 👨+ZWJ(3)，第二片 👩(2)。
+      const slices = buildSlices('👨‍👩', 3);
+      expect(slices).toHaveLength(2);
+      expect(slices[0]).toBe('\u{1F468}‍');
+      expect(slices[1]).toBe('\u{1F469}');
+      expect(slices.join('')).toBe('👨‍👩');
+    });
+  });
 });
 
 describe('PartialSendError', () => {
-  it('携带 sentIds / totalSlices / cause；通过 pino err 序列化器读得到', () => {
+  it('携带 sentIds / totalSlices / cause 作为 enumerable own props', () => {
     const cause = new Error('rate limit');
     const err = new PartialSendError({
       sentIds: ['m1', 'm2'],

--- a/packages/platform/discord/src/index.ts
+++ b/packages/platform/discord/src/index.ts
@@ -125,7 +125,7 @@ export function buildSlices(text: string, maxUtf16: number = SLICE_SIZE): string
       currentUtf16 += cpLen;
     }
   }
-  slices.push(current);
+  if (current.length > 0) slices.push(current);
   return slices;
 }
 

--- a/packages/platform/discord/src/index.ts
+++ b/packages/platform/discord/src/index.ts
@@ -59,20 +59,73 @@ export interface DiscordPlatformOptions {
   testGuildId?: string;
 }
 
+/**
+ * 单切片最多容纳的 UTF-16 code unit 数。Discord 上限是 2000 UTF-16 单位，
+ * 留 100 单位余量。该值是预算上限（不是固定切片长度）——单个代码点
+ * 最多占 2 个 UTF-16 单位（surrogate pair），所以 100 余量足够任何
+ * 代码点跨片场景。
+ */
 export const SLICE_SIZE = 1900;
 
 export type { ReplyMode } from './state.js';
 
 /**
- * Exported for tests. Splits arbitrary text into chunks of `sliceSize`.
- * Empty input returns `['']` so callers always have at least one sendable message.
+ * 多片 send 中途失败时抛出，sentIds 列出已落地的消息 id。
+ * 通过 pino 默认 err 序列化器自动序列化 enumerable 字段（含 sentIds）到日志。
  */
-export function buildSlices(text: string, sliceSize: number = SLICE_SIZE): string[] {
+export class PartialSendError extends Error {
+  public readonly sentIds: string[];
+  public readonly totalSlices: number;
+  public override readonly cause: unknown;
+  constructor(opts: { sentIds: string[]; totalSlices: number; cause: unknown }) {
+    super(
+      `platform-discord: partial send (${opts.sentIds.length}/${opts.totalSlices} slices sent)`,
+    );
+    this.name = 'PartialSendError';
+    this.sentIds = opts.sentIds;
+    this.totalSlices = opts.totalSlices;
+    this.cause = opts.cause;
+  }
+}
+
+/**
+ * 按 UTF-16 code unit 预算切片，迭代单位是 code point（`for…of` 行为）。
+ * 切点不会落在 surrogate pair 内部，因此基本 emoji 不会被劈成 `�`。
+ *
+ * 已知限制：grapheme cluster（含 ZWJ 序列 / VS-16 / 国旗 / 肤色修饰符）
+ * 仍可能在 code point 之间切——这是 BMP+emoji 约 95% 视觉场景的折中实现。
+ * 完全正确需要 `Intl.Segmenter`，留 TODO 等流式 edit 主路径替换掉切片机制
+ * （issue #56 stream-json epic 后切片会大幅缩减）。
+ *
+ * 空串返 `['']` 以保证 caller 总能拿到至少一条 sendable 消息。
+ */
+export function buildSlices(text: string, maxUtf16: number = SLICE_SIZE): string[] {
   if (text.length === 0) return [''];
   const slices: string[] = [];
-  for (let i = 0; i < text.length; i += sliceSize) {
-    slices.push(text.slice(i, i + sliceSize));
+  let current = '';
+  let currentUtf16 = 0;
+  for (const codePoint of text) {
+    const cpLen = codePoint.length;
+    if (cpLen > maxUtf16) {
+      // 预算比单个 code point 还小 → 退化成强行切（不可能在正常 ≥2 的预算下命中）
+      if (current.length > 0) {
+        slices.push(current);
+        current = '';
+        currentUtf16 = 0;
+      }
+      slices.push(codePoint);
+      continue;
+    }
+    if (currentUtf16 + cpLen > maxUtf16) {
+      slices.push(current);
+      current = codePoint;
+      currentUtf16 = cpLen;
+    } else {
+      current += codePoint;
+      currentUtf16 += cpLen;
+    }
   }
+  slices.push(current);
   return slices;
 }
 
@@ -312,13 +365,22 @@ export function createDiscordPlatform(opts: DiscordPlatformOptions): PlatformAda
       const slices = buildSlices(message.text);
 
       const sentIds: string[] = [];
-      let lastId: string | undefined;
-      for (const slice of slices) {
-        const msg = await channel.send(slice);
-        sentIds.push(msg.id);
-        lastId = msg.id;
+      try {
+        for (const slice of slices) {
+          const msg = await channel.send(slice);
+          sentIds.push(msg.id);
+        }
+      } catch (err) {
+        // 中途失败：上抛 PartialSendError 保留已发的 sentIds，让上层日志
+        // 可见"哪些已送出"，避免只剩"send_failed"什么都不知道的现场。
+        throw new PartialSendError({
+          sentIds,
+          totalSlices: slices.length,
+          cause: err,
+        });
       }
 
+      const lastId = sentIds[sentIds.length - 1];
       if (lastId === undefined) {
         // 理论上不会到这里——buildSlices 至少返 1 个切片
         throw new Error('platform-discord: send produced no message');

--- a/packages/platform/discord/src/index.ts
+++ b/packages/platform/discord/src/index.ts
@@ -60,28 +60,24 @@ export interface DiscordPlatformOptions {
 }
 
 /**
- * 单切片最多容纳的 UTF-16 code unit 数。Discord docs 声明 message content 上限
- * "2000 characters"（未指定字符口径——可能是 code point / grapheme / UTF-16）；
- * 本实现按 JS UTF-16 code unit 做保守预算，默认 1900 留 100 单位余量。
- * 该值是预算上限（不是固定切片长度）——单个 code point 最多占 2 个 UTF-16 单位
- * （surrogate pair），所以 100 余量足够任何 code point 跨片场景。
+ * 单切片字符预算（UTF-16 code unit）。Discord 文档说 message content 上限 "2000
+ * characters" 但没明指口径（code point / UTF-16 / grapheme 都可能），保守按最严的
+ * UTF-16 取 1900。
  */
 export const SLICE_SIZE = 1900;
 
 export type { ReplyMode } from './state.js';
 
 /**
- * 多片 send 中途失败时抛出，sentIds 列出已落地的消息 id。
+ * 多片 send 中途失败时抛出。`sentIds` 列出已落地的消息 id，顺序对应 `buildSlices`
+ * 的输出 —— 依赖 `send()` 串行 await；如果未来改成并发，需要重新定义"前 N 片"语义。
  *
- * 序列化语义：`sentIds` / `totalSlices` 作为 enumerable own props，会被 pino 默认 err
- * serializer 平铺到日志的 `err` 子对象。`cause` 走 pino 自己的 cause-chain 处理
- * （折进 stack 末尾），**cause 上的附加字段（如 `DiscordAPIError.code` / `status`）
- * 不会作为顶层字段输出**——需要看 Discord 错误码时仍要展开 cause；该缺口由 daemon
- * engine 错误日志契约整体落地时解决（见 spec/infra/observability.md §错误日志必含 +
- * spec/infra/errors.md）。
- *
- * 顺序契约：`sentIds` 按 `buildSlices` 输出顺序排列，依赖 send() 串行 await 的实现。
- * 改并发（如 `Promise.allSettled`）需重新定义"前 N 片"语义。
+ * 日志序列化：`sentIds` / `totalSlices` 是 enumerable own props，pino 默认 err
+ * serializer 会平铺到 `err.sentIds` / `err.totalSlices`。`cause` 走 pino 自身的
+ * cause-chain（折进 stack 末尾），cause 上的字段（如 `DiscordAPIError.code` /
+ * `status`）不会作为顶层字段输出 —— 想查 Discord 错误码要自行展开 cause 链。
+ * 这个缺口由 daemon 错误日志契约整体落地时收口，见
+ * spec/infra/observability.md §错误日志必含 + spec/infra/errors.md。
  */
 export class PartialSendError extends Error {
   public readonly sentIds: string[];
@@ -99,15 +95,14 @@ export class PartialSendError extends Error {
 }
 
 /**
- * 按 UTF-16 code unit 预算切片，迭代单位是 code point（`for…of` 行为）。
- * 切点不会落在 surrogate pair 内部，因此基本 emoji 不会被劈成 `�`。
+ * 按 UTF-16 code unit 预算切片，迭代单位是 code point（`for…of`），切点不落在
+ * surrogate pair 内部 —— 基本 emoji 不会变成 `�`。
  *
- * 已知限制：grapheme cluster（含 ZWJ 序列 / VS-16 / 国旗 / 肤色修饰符）
- * 仍可能在 code point 之间切——这是 BMP+emoji 约 95% 视觉场景的折中实现。
- * 完全正确需要 `Intl.Segmenter`，留 TODO 等流式 edit 主路径替换掉切片机制
- * （issue #56 stream-json epic 后切片会大幅缩减）。
+ * 已知缺口：grapheme cluster（ZWJ 序列 / VS-16 / 国旗 / 肤色修饰）仍可能在 code point
+ * 之间被切；测试里有 known-degenerate 用例钉死当前行为。彻底正确要 `Intl.Segmenter`，
+ * 留到 stream-json epic（#56）替换整套切片机制时一并处理。
  *
- * 空串返 `['']` 以保证 caller 总能拿到至少一条 sendable 消息。
+ * 空串返 `['']` 以保 caller 总能拿到至少一条 sendable 消息。
  */
 export function buildSlices(text: string, maxUtf16: number = SLICE_SIZE): string[] {
   if (text.length === 0) return [''];
@@ -117,7 +112,7 @@ export function buildSlices(text: string, maxUtf16: number = SLICE_SIZE): string
   for (const codePoint of text) {
     const cpLen = codePoint.length;
     if (cpLen > maxUtf16) {
-      // 预算比单个 code point 还小 → 退化成强行切（不可能在正常 ≥2 的预算下命中）
+      // 防御性兜底：预算比单个 code point 还小时强行切；正常预算（≥2）下不会命中
       if (current.length > 0) {
         slices.push(current);
         current = '';
@@ -381,8 +376,9 @@ export function createDiscordPlatform(opts: DiscordPlatformOptions): PlatformAda
           sentIds.push(msg.id);
         }
       } catch (err) {
-        // 中途失败：上抛 PartialSendError 保留已发的 sentIds，让上层日志
-        // 可见"哪些已送出"，避免只剩"send_failed"什么都不知道的现场。
+        // 包成 PartialSendError 而不是直接 rethrow：保留已发出的 sentIds，让上层日志
+        // 能看到"中断在第几片"。直接 rethrow 时栈帧销毁，daemon 那边只剩孤零零的
+        // platform_send_failed，无法重建已落地的消息序列。
         throw new PartialSendError({
           sentIds,
           totalSlices: slices.length,
@@ -396,7 +392,7 @@ export function createDiscordPlatform(opts: DiscordPlatformOptions): PlatformAda
         throw new Error('platform-discord: send produced no message');
       }
 
-      // Collect every slice's ID into messageIds; messageId points at the last one (single-slice compat)
+      // messageIds 列全部切片 id；messageId 指向最后一片（单片场景兼容）
       // → docs/dev/spec/platform-adapter.md §MessageRef
       return {
         platform: 'discord',

--- a/packages/platform/discord/src/index.ts
+++ b/packages/platform/discord/src/index.ts
@@ -60,10 +60,11 @@ export interface DiscordPlatformOptions {
 }
 
 /**
- * 单切片最多容纳的 UTF-16 code unit 数。Discord 上限是 2000 UTF-16 单位，
- * 留 100 单位余量。该值是预算上限（不是固定切片长度）——单个代码点
- * 最多占 2 个 UTF-16 单位（surrogate pair），所以 100 余量足够任何
- * 代码点跨片场景。
+ * 单切片最多容纳的 UTF-16 code unit 数。Discord docs 声明 message content 上限
+ * "2000 characters"（未指定字符口径——可能是 code point / grapheme / UTF-16）；
+ * 本实现按 JS UTF-16 code unit 做保守预算，默认 1900 留 100 单位余量。
+ * 该值是预算上限（不是固定切片长度）——单个 code point 最多占 2 个 UTF-16 单位
+ * （surrogate pair），所以 100 余量足够任何 code point 跨片场景。
  */
 export const SLICE_SIZE = 1900;
 
@@ -71,7 +72,16 @@ export type { ReplyMode } from './state.js';
 
 /**
  * 多片 send 中途失败时抛出，sentIds 列出已落地的消息 id。
- * 通过 pino 默认 err 序列化器自动序列化 enumerable 字段（含 sentIds）到日志。
+ *
+ * 序列化语义：`sentIds` / `totalSlices` 作为 enumerable own props，会被 pino 默认 err
+ * serializer 平铺到日志的 `err` 子对象。`cause` 走 pino 自己的 cause-chain 处理
+ * （折进 stack 末尾），**cause 上的附加字段（如 `DiscordAPIError.code` / `status`）
+ * 不会作为顶层字段输出**——需要看 Discord 错误码时仍要展开 cause；该缺口由 daemon
+ * engine 错误日志契约整体落地时解决（见 spec/infra/observability.md §错误日志必含 +
+ * spec/infra/errors.md）。
+ *
+ * 顺序契约：`sentIds` 按 `buildSlices` 输出顺序排列，依赖 send() 串行 await 的实现。
+ * 改并发（如 `Promise.allSettled`）需重新定义"前 N 片"语义。
  */
 export class PartialSendError extends Error {
   public readonly sentIds: string[];


### PR DESCRIPTION
Closes #55.

## Summary

合并 issue #55 的两个子问题：

### A. buildSlices 按 code point 切，预算按 UTF-16 单位

- 旧实现 `text.slice()` 按 UTF-16 单位切，落在 surrogate pair 中间会渲染成 `�`
- 改为 `for…of` 迭代 code point（不在 surrogate pair 内劈），按 UTF-16 单位累加预算（贴 Discord 2000 字符上限的真实约束）
- ASCII 兼容：1 char = 1 UTF-16 单位，行为不变；现有 `SLICE_SIZE=1900` ASCII 测试照过
- 已知限制：ZWJ 序列 / VS-16 / 国旗 / 肤色修饰符仍可能在 code point 之间切（issue 注明 95% 视觉场景的折中），TODO 等 #56 stream-json epic 落地后切片机制大幅缩减时再用 `Intl.Segmenter`

### B. PartialSendError 携带 sentIds

- 旧实现 send 多片中途失败时 sentIds 局部变量随栈帧销毁，daemon 日志只剩 `platform_send_failed` 没法重建 "哪些已发"
- 新 `PartialSendError` 包装 `sentIds` / `totalSlices` / `cause`
- enumerable own properties → pino 默认 err 序列化器自动落到日志
- **不动 daemon engine**：所有现有的 `logger.error({ err }, 'platform_send_failed')` 调用都会自动获得 sentIds 字段

## Test plan

- [x] `corepack pnpm test` — 138 → 143 passed（新增 5 个 buildSlices/PartialSendError 用例）
- [x] `corepack pnpm typecheck` — clean
- [x] emoji 边界场景：`'a😀bc😀d'` 切 4-budget → 每片可 `Array.from` round-trip（无 lone surrogate）
- [x] 全 emoji `'😀'.repeat(5000)`：默认预算下每片 UTF-16 长度 ≤ Discord 2000 上限
- [x] 模拟 send 多片中途失败：抛 PartialSendError 携带前 1 片 sentIds

## Out of scope

- end-to-end send() 集成测（mock discord.js Client）走 #30 follow-up
- 切片机制根本性替换 → #56 stream-json epic

🤖 Generated with [Claude Code](https://claude.com/claude-code)