### PR TITLE
docs(coding): §注释 加可执行判据

### DIFF
--- a/docs/dev/standards/coding.md
+++ b/docs/dev/standards/coding.md
@@ -62,6 +62,18 @@ related:
 - 外部约束（协议要求、三方 bug workaround）
 - TODO / FIXME 必须带 issue 编号：`// TODO(#42): ...`
 
+### 视角：写给冷上下文读者
+
+写每条注释时，心里设一个**没参与本次 session、不知道改动历史**的 reader（未来的 agent，或新加入的人）。他们读到代码时只会问几类问题——注释只回答这些：
+
+- 为什么是这个数 / 阈值？（`SLICE_SIZE = 1900` 会被问"为啥不是 2000"）
+- 这个分支什么时候触发？（看起来"不可能"的 fallback / catch / guard）
+- 这里有哪些已知坑？（哪些字段 logger 不会平铺、哪些 emoji 边界会切坏）
+- 谁来把这个坑收口？（指向 spec / ADR / issue）
+- 为什么不是更显然的别的写法？（为什么包成 typed error 而不是直接 rethrow）
+
+不要复述代码本身已经说清的事（函数名、类型签名、变量名）；不要做教科书延伸（"surrogate pair 占 2 个 UTF-16 单位"、"WeakMap GC 时机"），除非阈值或分支直接由它推出。
+
 ### 做 / 不做
 
 | 不做 | 做 |
@@ -69,6 +81,9 @@ related:
 | `// 发送消息` 之前是 `send(msg)` | 不加（代码自己说清楚了） |
 | `// hack: 因为 XX API 返回不一致这里绕一下` | 好的——解释了 why |
 | `// 用于后续可能的 Y 功能` | 不加（YAGNI） |
+| `// 覆盖 BMP+emoji 约 95% 视觉场景的折中实现` | 换成可验证表述（"测试里有 known-degenerate 用例钉死当前行为"） |
+| `// defense-in-depth: 防 spec 漂移` | 写清楚防什么（"防非法 stop_reason 落到合法 reason"） |
+| 行内 `// Collect every slice's ID into messageIds` | 中文写，且不复述代码本身（说"为什么有两个字段"） |
 
 ## 依赖
 


### PR DESCRIPTION
## Summary

在 `docs/dev/standards/coding.md` §注释 加一个新子节 `### 视角：写给冷上下文读者`，把这次 PR #78 / #80 review 沉淀出的注释判读测试规则化：

- 给注释设一个"没参与 session、不知改动历史"的 reader（未来 agent / 新人），注释只回答他们会问的 5 类问题（阈值/分支触发/已知坑/收口位置/非显然写法）
- 明令不要复述代码本身已经说清的事，不要做教科书延伸（"surrogate pair 占 2 字节"之类）
- 「做 / 不做」表加 3 行反例，对应本次 review 真踩到的注释失误（无法验证的"95%"模糊数字、"defense-in-depth"中英混塞、行内英文注释复述代码）

## Why

PR #78 / #80 走 adversarial-review 后我手动 review subagent 留下的注释，发现共性失误：

1. 「自吹模糊数字」—— `// 约 95% 视觉场景的折中实现`，cold reader 无法验证 95% 从哪来；换成 "测试里有 known-degenerate 用例钉死当前行为" 可验证
2. 「教科书延伸」—— `// surrogate pair 占 2 个 UTF-16 单位` 这种 JS 基础知识写在阈值附近，与"为啥不是 2000"的真实疑问无关
3. 「中英混塞」—— `// defense-in-depth: 防 spec 漂移` 不如直接说防什么
4. 「行内英文」—— `// Collect every slice's ID into messageIds` 既不中文也复述代码

现有 §注释 节只列了"什么时候写注释"，没指导"写注释时该想着谁"。冷上下文读者视角是测试题：写完一条注释问自己"一个不知道我刚做了什么的人，看代码后会被这条注释回答到吗？" — 这是个机械可执行的判据。

doc-ownership 矩阵下 `standards/coding.md` 是 §注释 的唯一 owner，本 PR 单文件加 15 行。

## 三问

1. **对应哪条 ADR？** 无新 ADR。注释规则属于 `standards/coding.md` 的 owner 范围，不到 ADR 门槛（参考 `standards/when-to-add-doc.md` §不需要 ADR 的项："命名 / 注释 / 风格调整"）。
2. **对应哪个 spec？** 无 spec 改动。注释是代码内文本，不进 spec 层。
3. **对应哪些测试？** 无代码改动，无测试。doc-only。reviewer 可手动核对：本 PR 自身的 commit message + diff 是否遵守新加入的规则（自托管验证）。

## Test plan

- [x] `grep "注释" docs/dev/standards/` 已确认 coding.md 是唯一 §注释 owner，其它文件只引用不重定义
- [x] frontmatter `summary` 仍准确（"命名、函数长度、模块边界、**注释**、依赖与泛化时机的语言无关原则"，无需改）
- [x] 现有规则（默认不写注释 / "做 / 不做"表）保持不动，新增是**补充而非替换**

## Out of scope

- 把同类视角推广到 `standards/docs-style.md` 的文档写作规则 — 不同读者群体（doc reader vs code reader），独立工作
- 把"defense-in-depth" / "95% 视觉场景" 反例反向应用回已合并 PR — 那些注释已生效，按本规则下次接触相关代码时清理即可，不单独起 cleanup PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)