### PR TITLE
docs(commit-style): §Subject 加可执行判据

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ related:
 | 写 / 维护 fixture | `docs/dev/testing/fixtures.md` |
 | 开 PR / codex review 触发 | `docs/dev/process/code-review.md` |
 | commit 流程编排（合并策略 / stacked PR） | `docs/dev/process/commit-and-branch.md` |
-| 写 commit message / 给分支命名 | `docs/dev/standards/commit-style.md` |
+| 写 commit message / PR title / 给分支命名 | `docs/dev/standards/commit-style.md` |
 | 判命名 / 函数 / 模块边界 / 注释 / 依赖引入是否合格 | `docs/dev/standards/coding.md` |
 | 引入 / 升级依赖 | `docs/dev/standards/dependencies.md` |
 | 写日志（写法约束） | `docs/dev/standards/logging.md` |

--- a/docs/dev/process/commit-and-branch.md
+++ b/docs/dev/process/commit-and-branch.md
@@ -12,7 +12,7 @@ related:
 
 # Commit 与分支编排
 
-本文件编排"何时开分支、何时打 commit、何时合并、失败如何处理"。**commit message 与分支名的产物形态合格条件**（Conventional Commits 格式、type 枚举、breaking change 写法、分支命名规则、commit 粒度合格条件、Co-Authored-By footer）住 [`../standards/commit-style.md`](../standards/commit-style.md)，本文件不复述。
+本文件编排"何时开分支、何时打 commit、何时合并、失败如何处理"。**commit message、PR title、分支名的产物形态合格条件**（Conventional Commits 格式、type 枚举、subject 语义合格条件、breaking change 写法、分支命名规则、commit 粒度合格条件、Co-Authored-By footer）住 [`../standards/commit-style.md`](../standards/commit-style.md)，本文件不复述。
 
 ## 分支先行（硬性要求）
 
@@ -57,4 +57,4 @@ main
 - 禁止跳过 hook：`--no-verify` 只有在 hook 本身出 bug 且得到维护者同意时才用
 - 禁止在 `main` 上直接 commit / push 未经 PR 的改动
 
-commit message 与分支名的合格条件违反（含 `wip` 信息、无 type 前缀、分支名超过 50 字符等）由 reviewer 拒绝——见 [`../standards/commit-style.md` §Reviewer 拒绝条件](../standards/commit-style.md#reviewer-拒绝条件)。
+commit message、PR title、分支名的合格条件违反（含 `wip` 信息、无 type 前缀、subject 未承载 thesis、分支名超过 50 字符等）由 reviewer 拒绝——见 [`../standards/commit-style.md` §Reviewer 拒绝条件](../standards/commit-style.md#reviewer-拒绝条件)。

--- a/docs/dev/standards/commit-style.md
+++ b/docs/dev/standards/commit-style.md
@@ -94,6 +94,32 @@ BREAKING CHANGE: session key 从 (platform, channelId, userId) 改为
 - 修 bug + 顺手改别的——顺手的部分不要做，或开独立 commit
 - 纯格式化（缩进、换行）单独一个 commit
 
+## Subject 语义合格条件
+
+`<subject>` 必须承载完整 thesis ——**只看 git log 这一行**、没读 issue body、没参与改动 session 的读者，要能用一句话复述出这条 commit 做了什么。
+
+squash merge 后 PR title 即落到 main 上的 commit subject，所以本节规则同时适用 PR title 与 commit subject。
+
+### 不合格模式
+
+| 不做 | 做 |
+|---|---|
+| `inline stopReasonToEnum + 加固 envelope→reason 测试覆盖` | 找统一动作覆盖；找不到 → 拆 commit / 拆 PR |
+| `emoji-safe slicing + PartialSendError 保留 sentIds` | 同上（这条 `+` 通常还是 PR scope 该拆的信号） |
+| `子进程句柄挂 session，interrupt / stopSession 真实生效` | 选 mechanism 或 outcome 之一作 subject |
+| `钉死 UsageRecord.completeness 语义（选 A）` | 写实际选了什么（如 `按 $ 视图可信度三态判定`） |
+| `partial textBuf 在异常退出时落日志（option C）` | 同上，把 option 字母换成实际方案描述 |
+| `补 X 视角 + 反例` | 用承载 thesis 的强动词（如 `加可执行判据`） |
+
+### 诊断信号
+
+写完 subject 跑这套自检：
+
+- **有 `+` / `、` / `,` / `；` 把两件事并列**：多半 thesis 没浓缩。问：两件事服务同一动作吗？是 → 用动作覆盖；不是 → **拆 commit / 拆 PR**（title 写不顺往往是 scope 该拆的信号，不只是写法问题）。
+- **括号里有 `(选 A)` / `(option C)` 这种内部 reference**：把选项名换成实际选的内容。"选 A" 不传递语义，"按 $ 视图可信度三态判定" 才传递。
+- **subject 里有刚发明的 framing 词或抽象名词**（"加固覆盖"、"冷上下文读者视角"等）：留给 body / doc，subject 用读者首读就能消化的具象内容。
+- **想用"补 / 加固 / 完善 / 整理"等弱动词**：通常是 thesis 没找到，换强动词（`钉死` / `inline` / `禁` / `让 X 生效`）逼自己说清楚到底改了什么。
+
 ## Co-Authored-By
 
 使用 AI 辅助生成的 commit，在 footer 加上对应的 Co-Authored-By 行，便于审计：
@@ -121,4 +147,7 @@ reviewer 在 PR 里看到下列模式应直接拒绝：
 - 未声明 breaking change 但实际改动破坏了对外契约
 - 分支名不符合 `<type>/<short-description>` 格式或超过 50 字符
 - 一个 commit 同时做了"新增功能 + 顺手重构"等多件逻辑事
+- subject 用 `+` / `、` / `,` 把两件 mechanic 并列（违反 [§Subject 语义合格条件](#subject-语义合格条件)，多半 thesis 没浓缩或 PR 该拆）
+- subject 含 `(选 A)` / `(option C)` 等只在 issue body 才有意义的内部 reference
+- subject 含改动期间发明的 framing 词或抽象名词，未替换为具象内容
 - AI 辅助生成的 commit 缺 `Co-Authored-By` footer

--- a/docs/dev/standards/commit-style.md
+++ b/docs/dev/standards/commit-style.md
@@ -115,9 +115,9 @@ BREAKING CHANGE: session key 从 (platform, channelId, userId) 改为
 
 写完 subject 跑这套自检：
 
-- **有 `+` / `、` / `,` / `；` 把两件事并列**：多半 thesis 没浓缩。问：两件事服务同一动作吗？是 → 用动作覆盖；不是 → **拆 commit / 拆 PR**（title 写不顺往往是 scope 该拆的信号，不只是写法问题）。
+- **有 `+` / `、` / `,` / `，` / `;` / `；` 把两件独立 mechanic / action 并列**：多半 thesis 没浓缩。问：两件事服务同一动作吗？是 → 用动作覆盖；不是 → **拆 commit / 拆 PR**（title 写不顺往往是 scope 该拆的信号，不只是写法问题）。注意符号本身不违规，**只在分隔独立改动时违规**——`feat(perf): N+1 query 修复` 的 `+` 是数学符号、`fix(daemon): SIGINT/SIGTERM 链路统一` 的 `/` 是同质 API 列举、`fix(claudecode): 子进程 SIGINT、SIGTERM、SIGKILL 三档处理` 的 `、` 是同质枚举，都合法。
 - **括号里有 `(选 A)` / `(option C)` 这种内部 reference**：把选项名换成实际选的内容。"选 A" 不传递语义，"按 $ 视图可信度三态判定" 才传递。
-- **subject 里有刚发明的 framing 词或抽象名词**（"加固覆盖"、"冷上下文读者视角"等）：留给 body / doc，subject 用读者首读就能消化的具象内容。
+- **subject 里有刚发明的 framing 词或抽象名词、且未在 subject 内被具体反例 / 协议名 / API 名展开**（如裸 "加固覆盖"、"冷上下文读者视角"）：留给 body / doc，subject 用读者首读就能消化的具象内容。判据是"framing 词**替代**了具体改动"，不是"含 framing 词"——"语义 / 策略 / 契约 / 规则" 本身合格，只要后面跟得上具象对象。
 - **想用"补 / 加固 / 完善 / 整理"等弱动词**：通常是 thesis 没找到，换强动词（`钉死` / `inline` / `禁` / `让 X 生效`）逼自己说清楚到底改了什么。
 
 ## Co-Authored-By
@@ -133,7 +133,7 @@ Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
 PR 合入 main 时的产物形态判据：
 
 - CI 全绿（unit + integration 必跑层全过；E2E / Eval 按 [`../process/tdd.md` §运行节奏与 CI 门槛](../process/tdd.md#运行节奏与-ci-门槛) 判定）
-- 所有 commit message 符合本文件 §Conventional Commits + §Commit 粒度
+- PR title 与所有 commit message 符合本文件 §Conventional Commits、§Commit 粒度、§Subject 语义合格条件
 - CHANGELOG 更新（若改动影响用户）
 - 走 squash merge（按 [`../process/commit-and-branch.md` §合并策略](../process/commit-and-branch.md#合并策略)）
 
@@ -147,7 +147,7 @@ reviewer 在 PR 里看到下列模式应直接拒绝：
 - 未声明 breaking change 但实际改动破坏了对外契约
 - 分支名不符合 `<type>/<short-description>` 格式或超过 50 字符
 - 一个 commit 同时做了"新增功能 + 顺手重构"等多件逻辑事
-- subject 用 `+` / `、` / `,` 把两件 mechanic 并列（违反 [§Subject 语义合格条件](#subject-语义合格条件)，多半 thesis 没浓缩或 PR 该拆）
+- subject 用 `+` / `、` / `,` / `，` / `;` / `；` 把两件独立 mechanic / action 并列（违反 [§Subject 语义合格条件](#subject-语义合格条件)，多半 thesis 没浓缩或 PR 该拆；符号本身不违规，分隔独立改动才违规——`N+1` / `SIGINT/SIGTERM` 等同质列举不算）
 - subject 含 `(选 A)` / `(option C)` 等只在 issue body 才有意义的内部 reference
-- subject 含改动期间发明的 framing 词或抽象名词，未替换为具象内容
+- subject 含改动期间发明的 framing 词或抽象名词、且未在 subject 内被具体反例 / 协议名 / API 名展开补足
 - AI 辅助生成的 commit 缺 `Co-Authored-By` footer

--- a/docs/dev/standards/commit-style.md
+++ b/docs/dev/standards/commit-style.md
@@ -1,17 +1,19 @@
 ---
-title: Commit 与分支命名规范
+title: Commit、PR title 与分支命名规范
 type: standards
 status: active
-summary: Conventional Commits 格式、type 枚举、breaking change 写法、分支命名格式、commit 粒度合格条件、Co-Authored-By 标签
-tags: [commit, standards, branch-naming, conventional-commits]
+summary: Conventional Commits 格式、type 枚举、subject 语义合格条件（同适用 PR title）、breaking change 写法、分支命名格式、commit 粒度、Co-Authored-By 标签
+tags: [commit, pr-title, standards, branch-naming, conventional-commits]
 related:
   - dev/process/commit-and-branch
   - dev/standards/docs-style
 ---
 
-# Commit 与分支命名规范
+# Commit、PR title 与分支命名规范
 
-本文件定义 commit message、分支名作为产物的形态合格条件。**何时打 commit / 何时合分支 / 失败如何处理**等流程编排见 [`../process/commit-and-branch.md`](../process/commit-and-branch.md)。
+本文件定义 commit message、PR title、分支名作为产物的形态合格条件。仓库走 squash merge（见 [`../process/commit-and-branch.md` §合并策略](../process/commit-and-branch.md#合并策略)），PR title 即落到 main 上的 commit subject，因此 PR title 与 commit subject 共享本文件所有规则。
+
+**何时打 commit / 何时合分支 / 失败如何处理**等流程编排见 [`../process/commit-and-branch.md`](../process/commit-and-branch.md)。
 
 ## Conventional Commits
 
@@ -96,9 +98,7 @@ BREAKING CHANGE: session key 从 (platform, channelId, userId) 改为
 
 ## Subject 语义合格条件
 
-`<subject>` 必须承载完整 thesis ——**只看 git log 这一行**、没读 issue body、没参与改动 session 的读者，要能用一句话复述出这条 commit 做了什么。
-
-squash merge 后 PR title 即落到 main 上的 commit subject，所以本节规则同时适用 PR title 与 commit subject。
+`<subject>` 必须承载完整 thesis ——**只看 git log 这一行**、没读 issue body、没参与改动 session 的读者，要能用一句话复述出这条 commit 做了什么。本节规则对 PR title 同样有效（squash merge 下两者等价，见本文件开头说明）。
 
 ### 不合格模式
 


### PR DESCRIPTION
## Summary

`docs/dev/standards/commit-style.md` 加 §Subject 语义合格条件 子节，把 commit subject / PR title 的"承载 thesis"判读规则化；§Reviewer 拒绝条件补 3 条对应拒稿行；doc 标题 / frontmatter / 仓库根入口索引 / `docs/dev/process/commit-and-branch.md` 入口索引把 PR title 显式纳入治理范围（squash merge 下与 commit subject 等价）。

具体反模式都来自本仓库 PR #78–#84 实战翻车：

| 不做 | 翻车 PR |
|---|---|
| `inline X + 加固测试覆盖`（`+` 并列两类型动作） | #78 第一版 title |
| `emoji-safe slicing + PartialSendError 保留 sentIds`（`+` 实际暴露 PR scope 该拆） | #80 |
| `子进程句柄挂 session，interrupt / stopSession 真实生效`（中文 `，` 并列 mechanic + outcome） | #81 |
| `钉死 X 语义（选 A）` / `落日志（option C）`（option 字母是内部 reference） | #82 / #83 |
| `补 X 视角 + 反例`（弱动词 + 自创术语 + `+`） | #84 |

诊断信号已收成可执行自检清单（4 条），并明示 `+` 既可能是 thesis 没浓缩、也可能是 **PR scope 该拆** 的信号。GAN R1 codex 又指出三处需要收紧（标点集合不全 / merge gate 漏同步 / framing 词判据过宽），R1 commit `addba5f` 已修；R2 codex 又指出邻接 `process/commit-and-branch.md` 入口索引漏同步，R2 commit `0c9d6e9` 已修。

## Why

一个 session 内连续翻车 5 次，本质是一个共性：**写完 title 自己满意了，没站到只看 git log 一行的读者那边再读一遍**。现有 §Conventional Commits 只规范"祈使句、小写、不加句号"等形式合规，没有语义判读规则；reviewer 拒稿条件只列"无信息量的 wip/temp/update"等极端案例，落不到 `+` 并列、option 字母 reference 这种**看似有内容实则没传递 thesis** 的中间档失败。本 PR 把判据补齐。

doc-ownership 矩阵下 `standards/commit-style.md` 是 commit subject 的唯一 owner；squash merge 下 PR title === main 上的 commit subject，本来就归此文件治理，只是之前 doc 标题 / frontmatter / 入口索引没显式说，reader 找"PR title 规则"时找不到入口。本 PR 把这层指向打通：

- doc 标题 `Commit 与分支命名规范` → `Commit、PR title 与分支命名规范`
- frontmatter `summary` / `tags` 加 PR title
- doc 开头一句话点明 squash merge 下两者等价
- 仓库根 `AGENTS.md` 文件定位速查表 `写 commit message / 给分支命名` → `写 commit message / PR title / 给分支命名`
- `docs/dev/process/commit-and-branch.md` 入口索引段 / 拒稿引用段把 PR title 纳入

## 三问

1. **对应哪条 ADR？** 无新 ADR。subject 语义规则属 `standards/commit-style.md` 的 owner 范围，且未改变 Conventional Commits 选型，不到 ADR 门槛（参考 `standards/when-to-add-doc.md` §不需要 ADR 的项："命名 / 注释 / 风格调整"）。
2. **对应哪个 spec？** 无 spec 改动。commit subject 不进 spec 层。
3. **对应哪些测试？** 无代码改动，无测试。reviewer 可手动核对：
   - 本 PR title `subject 禁三种偷懒写法（"+" 并列、内部 reference、自创术语）` 自身遵守新规则（单动作 `禁`、数字宾语 `三种`、括号内是反例的同质列举）
   - 仓库现有 PR #78–#84 title 按新表格能否被准确判违（PR #80 的 `+` 还应判为 PR scope 偷懒；PR #81 的中文 `，` 在 R1 修订后被纳入拒稿集合）

## Test plan

- [x] `grep "subject\\|PR title\\|commit subject" docs/dev/` 确认无其它文件复述本规则（SSOT 不冲突）
- [x] `AGENTS.md` 文件定位速查表更新指回 commit-style.md
- [x] frontmatter summary 涵盖新增内容
- [x] GAN R1 反馈 3 项全部 accept&apply（标点集合 / merge gate / framing 词收窄）
- [x] GAN R2 反馈 1 项 accept&apply（process/commit-and-branch.md 入口同步）

## 已知瑕疵（GAN R1 commit subject 自违规）

R1 修复 commit `addba5f docs(commit-style): subject 规则补中文标点 / 符号豁免 / framing 词收窄 / merge 门禁同步（GAN R1）` 自身用 `/` 串了 4 件独立 mechanic（标点扩集合 / 添豁免文 / framing 词收窄 / merge gate 同步），按本 PR 新增规则**不合格**。

保留不修的理由：
- 已 push，CLAUDE.md 全局规则禁 `git commit --amend` / `--force-push`
- PR 走 squash merge，该 commit subject 不会进入 main 历史；最终 squash title（= 本 PR title）必须合规——本 PR title 自评合规
- 把规则正反例都暴露在 PR review 历史里反而是有用的 review 训练材料

R2 修复 commit `0c9d6e9 docs(process): commit-and-branch 入口索引把 PR title 纳入合格产物` 单动作 + 单对象，作为合规示范。

## Out of scope

- 改 PR #80–#84 现有 title 让它们遵守新规则 —— 是 follow-up 工作，先把规则确立再回头清理（避免 stacked PR 来回 force-push）
- 让 CI / lint 自动检测 subject 不合格模式 —— 字符串级判读 `+` 容易误伤合法用法（如 `feat(perf): N+1 query 修复`），自动化方案需另行评估，本 PR 只做人工 reviewer 判据

🤖 Generated with [Claude Code](https://claude.com/claude-code)