### PR TITLE
docs(spec): 落地 tool_result 独立事件协议契约

### DIFF
--- a/docs/dev/spec/agent-backends/claude-code-cli.md
+++ b/docs/dev/spec/agent-backends/claude-code-cli.md
@@ -156,7 +156,7 @@ MVP 只依赖两类输入：
 | `stream_event`（`event.type:content_block_delta`，`delta.type:text_delta`；**仅 `--include-partial-messages` 下出现**，Anthropic SSE 包裹，不在 assistant content） | `text_delta`（默认模板无此事件，攒整段走 `text`→`text_final`） |
 | `assistant / tool_use` | `tool_call_started`（`callId` ← `tool_use.id`） |
 | `user / tool_result` | `tool_result`（独立事件；`content` 按 [`agent-runtime.md`](../agent-runtime.md) ToolResultContent 判别优先级映射，`isError` ← `is_error`，`callId` ← `tool_use_id`，同 `tool_use_id` 多条按到达序 `resultSequence` 0+ 递增）¹ |
-| （工具块终结，无独立 CC 事件，runtime 合成） | `tool_call_finished`：runtime 在该 `tool_use_id` 结果流终结时合成；`callId` ← 对应 `tool_call_started.callId`、`toolName` ← 缓存的 `tool_use.name`；`status` 由工具块**终结态**决定（**不得仅凭某条中间 result 的 `is_error` 推导**）——0-result 异常终止、或终结该 `tool_use_id` 的 result 为 error 且无后续恢复 → `error`，中断 / 取消 → `cancelled`，否则 `ok`；`status != "ok"` 时 `errorSummary` 尽力填² |
+| （工具块终结，无独立 CC 事件，runtime 合成） | `tool_call_finished`：runtime 在该 `tool_use_id` 结果流终结时合成；`callId` ← 对应 `tool_call_started.callId`、`toolName` ← 缓存的 `tool_use.name`；`status` 由工具块**终结态**决定（**不得仅凭某条中间 result 的 `is_error` 推导**）——0-result 异常终止、或该 `tool_use_id` 的终结性 result 为 error（执行失败 / backend error / timeout）→ `error`，中断 / 取消 → `cancelled`，否则 `ok`；`status != "ok"` 时 `errorSummary` 尽力填² |
 | `result / success` | `turn_finished { reason: stop_reason_to_enum(...) }` + `usage` 事件 |
 | `result / error_during_execution` + `terminal_reason:"aborted_streaming"`（SIGINT 中断） | `turn_finished { reason: "user_interrupt" }`（见 §中断；runtime 识别 terminal_reason 或合成，**不**走 error 路径） |
 | `result / error_*`（其余错误态） | `turn_finished { reason: "error" }` + `error` 事件 |

--- a/docs/dev/spec/agent-backends/claude-code-cli.md
+++ b/docs/dev/spec/agent-backends/claude-code-cli.md
@@ -140,7 +140,7 @@ MVP 只依赖两类输入：
 // 加 --include-partial-messages 时，token 增量以 stream_event（Anthropic SSE 包裹）出现，不在 assistant content 里：
 // {"type":"stream_event","event":{"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"hel"}}}
 {"type":"assistant","message":{"content":[{"type":"tool_use","id":"toolu_123","name":"Bash","input":{"command":"..."}}]}}
-// tool_result.content 在本次实测样例中为 string；AgentEvent 层如何承载 tool_result 变体，待 ADR-0012 / agent-runtime.md 落地后同步
+// tool_result.content 在本次实测样例中为 string；多形态（string/块数组/object/空/其他）由独立 tool_result 事件承载，见 agent-runtime.md §ToolResultContent
 {"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_123","content":"...","is_error":false}]}}
 {"type":"rate_limit_event","rate_limit_info":{"status":"allowed","resetsAt":1779441000,"rateLimitType":"five_hour","overageStatus":"..."}}
 {"type":"result","subtype":"success","stop_reason":"end_turn","usage":{"input_tokens":100,"output_tokens":50}}
@@ -154,8 +154,9 @@ MVP 只依赖两类输入：
 | `system / init`（**每 turn 重发，session_id 不变**） | 仅首个 init / session_id 变化时发 `session_started`；后续同 session_id 的 init 当 turn 边界，**不重复**发 |
 | `assistant / text`（完整块，**MVP 默认形态**） | `text_final` |
 | `stream_event`（`event.type:content_block_delta`，`delta.type:text_delta`；**仅 `--include-partial-messages` 下出现**，Anthropic SSE 包裹，不在 assistant content） | `text_delta`（默认模板无此事件，攒整段走 `text`→`text_final`） |
-| `assistant / tool_use` | `tool_call_started` |
-| `user / tool_result` | `tool_call_finished`（status 由 `is_error` 决定）¹ |
+| `assistant / tool_use` | `tool_call_started`（`callId` ← `tool_use.id`） |
+| `user / tool_result` | `tool_result`（独立事件；`content` 按 [`agent-runtime.md`](../agent-runtime.md) ToolResultContent 判别优先级映射，`isError` ← `is_error`，`callId` ← `tool_use_id`，同 `tool_use_id` 多条按到达序 `resultSequence` 0+ 递增）¹ |
+| （工具块终结，无独立 CC 事件，runtime 合成） | `tool_call_finished`：runtime 在该 `tool_use_id` 结果流终结时合成；`callId` ← 对应 `tool_call_started.callId`、`toolName` ← 缓存的 `tool_use.name`；`status` 由工具块**终结态**决定（**不得仅凭某条中间 result 的 `is_error` 推导**）——0-result 异常终止、或终结该 `tool_use_id` 的 result 为 error 且无后续恢复 → `error`，中断 / 取消 → `cancelled`，否则 `ok`；`status != "ok"` 时 `errorSummary` 尽力填² |
 | `result / success` | `turn_finished { reason: stop_reason_to_enum(...) }` + `usage` 事件 |
 | `result / error_during_execution` + `terminal_reason:"aborted_streaming"`（SIGINT 中断） | `turn_finished { reason: "user_interrupt" }`（见 §中断；runtime 识别 terminal_reason 或合成，**不**走 error 路径） |
 | `result / error_*`（其余错误态） | `turn_finished { reason: "error" }` + `error` 事件 |
@@ -164,7 +165,9 @@ MVP 只依赖两类输入：
 | `rate_limit_event` | 暂不映射 AgentEvent；限额信号是否接入 limits 由 [`cost-and-limits.md`](../infra/cost-and-limits.md) 决定（TODO） |
 | **未列出的 type / subtype** | **debug log + 忽略，不报错**（兜底，见下） |
 
-¹ `tool_result` → AgentEvent 的具体形态（独立 `tool_result` 事件 vs 并入 `tool_call_finished`）以 ADR-0012 决策点 1 / `agent-runtime.md` 修订为准；本表保持现状映射，ADR-0012 实施时同步更新。
+¹ `tool_result` 形态已按 ADR-0012 决策点 1 子问题（1-tr-B 独立事件）落地：CC `user/tool_result` 映射为独立 `tool_result` AgentEvent，content 五类承载见 [`agent-runtime.md`](../agent-runtime.md) §ToolResultContent。
+
+² `tool_call_finished` 无 CC 原生事件，由 runtime 据结果流终结合成——终结判定：该 `tool_use_id` 不再有后续 result + turn 推进 / stop。`status` / `errorSummary` 字段语义 SSOT 在 [`agent-runtime.md`](../agent-runtime.md)。
 
 ## hook 事件与未知 type 兜底
 

--- a/docs/dev/spec/agent-runtime.md
+++ b/docs/dev/spec/agent-runtime.md
@@ -164,7 +164,7 @@ enum EventType {
 4. plain object → `{ kind: "object", object: <JSON object> }`
 5. 其他 JSON scalar（number / bool）→ `{ kind: "unknown", raw: string }`
 
-`ContentBlock = { type: string, ...保留原始字段 }`。**未识别的块原样保留在 `blocks` 数组内**（不上升为顶层 `unknown`）；仅当整个 content 落不进 1-4 时才用顶层 `unknown`。`unknown.raw` 为原始 JSON 截断字符串，写入前**必须经 redactor 脱敏**（见 [`security/redaction.md`](security/redaction.md)）；其截断上限同属 redaction 策略，由该 spec 统一约束，实现不得落地无界 raw。
+`ContentBlock = { type: string, ...保留原始字段 }`。**未识别的块原样保留在 `blocks` 数组内**（不上升为顶层 `unknown`）；仅当整个 content 落不进 1-4 时才用顶层 `unknown`。`unknown.raw` 为原始 JSON 截断字符串：截断上限默认 **4 KB**（够保留诊断信息又不爆日志；最终值可随 observability 日志策略校准），写入前**必须经 redactor 脱敏**（脱敏规则见 [`security/redaction.md`](security/redaction.md)）。截断上限是 ToolResultContent 的协议约束（本 spec owner），脱敏才属 redaction——实现不得落地无界 raw。
 
 字段语义：
 

--- a/docs/dev/spec/agent-runtime.md
+++ b/docs/dev/spec/agent-runtime.md
@@ -152,7 +152,9 @@ enum EventType {
 | `error` | `{ errorKind, code, message, cause? }` |
 | `session_stopped` | `{ reason: "idle_timeout" | "user_stop" | "error" | "budget_exceeded" | "turn_limit" | "wallclock_timeout" }` |
 
-**ToolResultContent**（`tool_result.content` 字段类型）—— 按 `kind` 区分的判别联合，结构化承载 CC `tool_result.content` 多形态（不压扁为单字符串）。runtime 按以下**判别优先级**（自上而下首个匹配）归类，保证边界唯一：
+### ToolResultContent
+
+`tool_result.content` 字段类型 —— 按 `kind` 区分的判别联合，结构化承载 CC `tool_result.content` 多形态（不压扁为单字符串）。runtime 按以下**判别优先级**（自上而下首个匹配）归类，保证边界唯一：
 
 1. content 字段缺失 / null → `{ kind: "empty" }`
 2. string（含空串 `""`）→ `{ kind: "text", text: string }`
@@ -162,7 +164,7 @@ enum EventType {
 4. plain object → `{ kind: "object", object: <JSON object> }`
 5. 其他 JSON scalar（number / bool）→ `{ kind: "unknown", raw: string }`
 
-`ContentBlock = { type: string, ...保留原始字段 }`。**未识别的块原样保留在 `blocks` 数组内**（不上升为顶层 `unknown`）；仅当整个 content 落不进 1-4 时才用顶层 `unknown`。`unknown.raw` 为原始 JSON 截断字符串，**必须经 redactor**；截断长度与脱敏规则见 [`security/redaction.md`](security/redaction.md)。
+`ContentBlock = { type: string, ...保留原始字段 }`。**未识别的块原样保留在 `blocks` 数组内**（不上升为顶层 `unknown`）；仅当整个 content 落不进 1-4 时才用顶层 `unknown`。`unknown.raw` 为原始 JSON 截断字符串，写入前**必须经 redactor 脱敏**（见 [`security/redaction.md`](security/redaction.md)）；其截断上限同属 redaction 策略，由该 spec 统一约束，实现不得落地无界 raw。
 
 字段语义：
 

--- a/docs/dev/spec/agent-runtime.md
+++ b/docs/dev/spec/agent-runtime.md
@@ -6,6 +6,7 @@ summary: Agent 后端适配层接口契约；SessionConfig、AgentEvent 流、CC
 tags: [spec, agent-runtime, cc-cli, subprocess]
 related:
   - dev/adr/0002-agent-backend-claude-code-cli
+  - dev/adr/0012-claudecode-stream-json-mainline
   - dev/spec/agent-backends/claude-code-cli
   - dev/spec/message-protocol
   - dev/spec/security/README
@@ -125,7 +126,8 @@ enum EventType {
     text_final             // 一轮文本输出完成
     tool_call_started      // 工具调用开始
     tool_call_progress     // 工具调用中（可选）
-    tool_call_finished     // 工具调用完成（含结果摘要）
+    tool_result            // 工具结果（独立事件；CC 多形态 content 结构化承载，见 ADR-0012 决策点 1 子问题 1-tr-B）
+    tool_call_finished     // 工具调用终态（不承载完整结果；结果走 tool_result）
     turn_finished          // 一个完整回合结束（等待下一条输入）
     usage                  // token/成本事件
     error                  // 错误事件
@@ -143,11 +145,31 @@ enum EventType {
 | `text_final` | `{ text: string }` |
 | `tool_call_started` | `{ callId, toolName, inputSummary }` |
 | `tool_call_progress` | `{ callId, note }` |
-| `tool_call_finished` | `{ callId, toolName, status: "ok" | "error", resultSummary }` |
+| `tool_result` | `{ callId, resultSequence: int, content: ToolResultContent, isError: bool }` |
+| `tool_call_finished` | `{ callId, toolName, status: "ok" | "error" | "cancelled", errorSummary? }` |
 | `turn_finished` | `{ reason: TurnEndReason, turnSequence: int }` |
 | `usage` | `UsageRecord` — 见下方 |
 | `error` | `{ errorKind, code, message, cause? }` |
 | `session_stopped` | `{ reason: "idle_timeout" | "user_stop" | "error" | "budget_exceeded" | "turn_limit" | "wallclock_timeout" }` |
+
+**ToolResultContent**（`tool_result.content` 字段类型）—— 按 `kind` 区分的判别联合，结构化承载 CC `tool_result.content` 多形态（不压扁为单字符串）。runtime 按以下**判别优先级**（自上而下首个匹配）归类，保证边界唯一：
+
+1. content 字段缺失 / null → `{ kind: "empty" }`
+2. string（含空串 `""`）→ `{ kind: "text", text: string }`
+3. array：
+   - 元素均 block-like（`type` 为 string 的 object）或空数组 `[]` → `{ kind: "blocks", blocks: ContentBlock[] }`
+   - 否则（标量数组 / 混杂非 block）→ `{ kind: "unknown", raw: string }`
+4. plain object → `{ kind: "object", object: <JSON object> }`
+5. 其他 JSON scalar（number / bool）→ `{ kind: "unknown", raw: string }`
+
+`ContentBlock = { type: string, ...保留原始字段 }`。**未识别的块原样保留在 `blocks` 数组内**（不上升为顶层 `unknown`）；仅当整个 content 落不进 1-4 时才用顶层 `unknown`。`unknown.raw` 为原始 JSON 截断字符串，**必须经 redactor**；截断长度与脱敏规则见 [`security/redaction.md`](security/redaction.md)。
+
+字段语义：
+
+- `status`（`tool_call_finished`）是**工具调用块的终态**，由工具块终态决定、**不可由单条 `tool_result.isError` 推导**：`ok`=正常结束；`error`=执行失败 / 超时 / 后端错误，含 0 条 result 直接异常终止；`cancelled`=用户中断 / runtime 主动取消。`status != "ok"` 时 `errorSummary` 尽力填——这是 **0-result error case 唯一的错误信息来源**（完整结果一律走独立 `tool_result` 事件，不再压进 `tool_call_finished`）。
+- `callId` = CC 后端的 `tool_use.id` / `tool_result.tool_use_id` 归一化 ID（对应 `tool_call_started.callId`）。
+- `resultSequence` 同一 `callId` 内从 0 连续递增、不重复；不同 callId 间无可比性；最终投递顺序仍以 AgentEvent `sequence`（session 全局单调）为准。
+- `isError` ← CC `tool_result.is_error`，单条 result 级。
 
 ### TurnEndReason 枚举
 
@@ -189,7 +211,10 @@ UsageRecord {
 - 同 session 的事件严格按 `sequence` 升序投递
 - `text_delta` 的文本拼起来等于随后的 `text_final.text`
 - 每个 `tool_call_started` 必有且仅有一个对应的 `tool_call_finished`
-- `turn_finished` 在一轮的最后一个 `text_final` / `tool_call_finished` 之后
+- 每个 callId 有 **0 条或多条** `tool_result`，且**全部在对应 `tool_call_finished` 之前**（模型 A：`tool_call_finished` 即该工具结果流终态——见 ADR-0012 决策点 1 子问题）
+- 同一 callId 的多条 `tool_result` 按 `resultSequence` 升序投递
+- `tool_call_finished` 之后到达的同 callId `tool_result` 是 late event，runtime **必须丢弃 + debug log，不得重排到 finished 前**（与 ADR-0012 §interrupt 投递契约 late event 规则一致）
+- `turn_finished` 在一轮的最后一个 `text_final` / `tool_call_finished` 之后（`tool_result` 因 happens-before `tool_call_finished`，无需单独锚定）
 
 ## CC CLI 专属说明（Claude Code 实现）
 
@@ -226,6 +251,8 @@ Agent runtime 实现必须有：
 4. 超时 → 产出 `turn_finished { reason: "error" }` + `error` 事件
 5. 子进程崩溃 fixture → 产出 `error` + `session_stopped`
 6. `usage` 事件的 token 数可被 daemon 成功记账
+7. tool_result 多变体 + 边界 fixture：content 为 string / 空串 / null / 缺字段 / 块数组 / 空数组 / 非 block 数组 / 未识别块 / plain object 各形态 → 产出 kind 正确的 ToolResultContent（按判别优先级），未识别块原样留在 `blocks` 内
+8. 排序与终态 fixture：同 callId 多条 result 按 `resultSequence` 升序且全在 `tool_call_finished` 前；0-result 异常终止 → `tool_call_finished.status` 为 error/cancelled 且 `errorSummary` 非空；finished 后 late result 被丢弃；`isError` 真假 × `status` ok/error 各组合不互相推导
 
 transcript fixture 放在 `testdata/cc-cli/` 下（见 [`../testing/fixtures.md`](../testing/fixtures.md)）。
 

--- a/docs/dev/spec/message-flow.md
+++ b/docs/dev/spec/message-flow.md
@@ -87,8 +87,8 @@ contracts:
   - 解析后端 stdout 为 AgentEvent
     （EventType 完整枚举权威源：agent-runtime.md §AgentEvent §EventType；含
      session_started / thinking / text_delta / text_final / tool_call_started /
-     tool_call_progress / tool_call_finished / turn_finished / usage / error /
-     session_stopped）
+     tool_call_progress / tool_result / tool_call_finished / turn_finished / usage /
+     error / session_stopped）
   - tool 调用前 daemon.toolguard 校验（见下文 §工具边界校验）
         │
         │  (2) AgentEvent 流（push 给 daemon）

--- a/docs/dev/spec/message-protocol.md
+++ b/docs/dev/spec/message-protocol.md
@@ -183,7 +183,7 @@ Agent 输出是流式的（`text_delta`）。适配到 IM 的策略：
 - 优点：实时反馈
 - 缺点：消息数不变但编辑次数多；Discord 对 edit 也有 rate limit
 
-MVP 优先实现模式 A；模式 B 已由 [ADR-0012](../adr/0012-claudecode-stream-json-mainline.md)（stream-json 主路径切换）评审通过，作为 stream-json 切换后的增强落地——节流窗口 / edit 周期等数值见 [`infra/cost-and-limits.md`](infra/cost-and-limits.md)，平台 `edit()` / capability 见 [`platform-adapter.md`](platform-adapter.md)。
+MVP 优先实现模式 A；模式 B 的协议契约已由 [ADR-0012](../adr/0012-claudecode-stream-json-mainline.md)（stream-json 主路径切换）评审通过（取代原"独立 ADR 中评审"占位）。MVP 仍默认模式 A；模式 B 的具体落地（节流数值、平台 `edit()` capability）随 ADR-0012 PR-C 及配套 spec 更新。
 
 ## 控制语义
 

--- a/docs/dev/spec/message-protocol.md
+++ b/docs/dev/spec/message-protocol.md
@@ -183,7 +183,7 @@ Agent 输出是流式的（`text_delta`）。适配到 IM 的策略：
 - 优点：实时反馈
 - 缺点：消息数不变但编辑次数多；Discord 对 edit 也有 rate limit
 
-MVP 优先实现模式 A，模式 B 作为后续增强（在独立 ADR 中评审）。
+MVP 优先实现模式 A；模式 B 已由 [ADR-0012](../adr/0012-claudecode-stream-json-mainline.md)（stream-json 主路径切换）评审通过，作为 stream-json 切换后的增强落地——节流窗口 / edit 周期等数值见 [`infra/cost-and-limits.md`](infra/cost-and-limits.md)，平台 `edit()` / capability 见 [`platform-adapter.md`](platform-adapter.md)。
 
 ## 控制语义
 

--- a/docs/dev/spec/message-protocol.md
+++ b/docs/dev/spec/message-protocol.md
@@ -183,7 +183,7 @@ Agent 输出是流式的（`text_delta`）。适配到 IM 的策略：
 - 优点：实时反馈
 - 缺点：消息数不变但编辑次数多；Discord 对 edit 也有 rate limit
 
-MVP 优先实现模式 A；模式 B 的协议契约已由 [ADR-0012](../adr/0012-claudecode-stream-json-mainline.md)（stream-json 主路径切换）评审通过（取代原"独立 ADR 中评审"占位）。MVP 仍默认模式 A；模式 B 的具体落地（节流数值、平台 `edit()` capability）随 ADR-0012 PR-C 及配套 spec 更新。
+MVP 优先实现模式 A；模式 B 的协议契约已由 [ADR-0012](../adr/0012-claudecode-stream-json-mainline.md)（stream-json 主路径切换）评审通过（取代原"独立 ADR 中评审"占位）。MVP 仍默认模式 A；模式 B 的平台 `edit()` capability 与最终节流数值随 ADR-0012 PR-C 及配套 spec 落地（上方 1s / 200 字符为示例量级、非最终契约）。
 
 ## 控制语义
 


### PR DESCRIPTION
## 这个 PR 做什么

把 ADR-0012 决策点 1（1A union 一次性对齐 + 子问题 1-tr-B 独立 `tool_result` 事件）落地到 spec，作为 **P3 PR-A（protocol union 代码补齐）的 spec 前置**。这是 P2 spec 修订压缩后的第 1 个 PR（PR-spec-1：协议事件契约）。

横跨 3 个 spec 文件，因为它们是同一个 AgentEvent 协议变更的多 owner 切面（协议定义 + CC 映射 + 流式语义标记）。

## 改动

**`agent-runtime.md`（协议定义 SSOT）**
- EventType enum 加 `tool_result` 独立事件；`tool_call_finished` 注释改"终态、不承载完整结果"
- payload 表加 `tool_result` 行 + `ToolResultContent` 五类判别联合（text / blocks / object / empty / unknown），带**边界唯一的判别优先级**；未识别块原样保留在 `blocks` 内、不上升为顶层 unknown
- `tool_call_finished` 改 `status: ok|error|cancelled` + `errorSummary?`——覆盖 0-result error 终态，**独立于单条 `tool_result.isError`**（不可由 isError 推导）
- §顺序保证补模型 A（每 callId 的 tool_result 全在 tool_call_finished 之前）+ resultSequence 多条升序 + late event 丢弃
- §合约测试加 2 条（多变体+边界 / 排序+终态+late+isError×status 组合）

**`claude-code-cli.md`（CC→AgentEvent 映射 SSOT）**
- `user/tool_result` → 独立 `tool_result` 事件（content 按 ToolResultContent 判别优先级，callId ← tool_use_id，多条按 resultSequence）
- `tool_call_finished` 由 runtime 在结果流终结时合成（无 CC 原生事件）；status 由工具块终结态决定，不得仅凭中间 result 的 is_error 推导
- 脚注¹²更新为已落地，去掉"待 ADR-0012 落地后同步"

**`message-protocol.md`**
- §流式语义 模式 B 标记 ADR-0012 评审通过（指向 cost-and-limits 数值 / platform-adapter capability）

## SSOT 边界

ADR-0012 锁架构不变量（独立事件 / 5 类承载 / terminal status 覆盖 0-result / 顺序模型 A）；payload 字段表 SSOT 在 agent-runtime.md；CC 映射 SSOT 在 claude-code-cli.md。

## 不在本 PR（companion，列为 P2 PR-spec-2）

- `security/redaction.md`：`ToolResultContent.unknown.raw` 截断长度 + 脱敏规则（本 PR 已埋"必须经 redactor"不悬空）
- `infra/observability.md`：`tool_call_finished` 日志 `status` 值域加 `cancelled`（字段名不变）
- `claude-code-cli.md` 的 §中断/§超时投递契约两层 + 子进程树终止平台细节 + control/hook 强制契约（与 tool_result 映射无耦合）

Refs: #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)