### PR TITLE
feat(protocol)!: define stream-json agent event contract

### DIFF
--- a/packages/agent/claudecode/src/index.ts
+++ b/packages/agent/claudecode/src/index.ts
@@ -137,6 +137,7 @@ export function createClaudeCodeRuntime(
     supportsStreaming: false,
     supportsToolCallEvents: false,
     supportsInterrupt: true,
+    supportsStdinInterrupt: false,
   };
 
   const runtime: AgentRuntime = {
@@ -376,7 +377,8 @@ export function createClaudeCodeRuntime(
                 sequence: sequence++,
                 payload: {
                   agentSessionId: typeof sid === 'string' ? sid : undefined,
-                  workingDir: typeof reportedCwd === 'string' ? reportedCwd : undefined,
+                  workingDir: typeof reportedCwd === 'string' ? reportedCwd : cwd,
+                  capabilities,
                 },
               });
               continue;

--- a/packages/daemon/src/engine.test.ts
+++ b/packages/daemon/src/engine.test.ts
@@ -178,7 +178,7 @@ type SessionStartedPayload = Extract<
 function ev<T extends AgentEvent['type']>(
   type: T,
   payload: T extends 'session_started'
-    ? Partial<SessionStartedPayload> & Pick<SessionStartedPayload, 'agentSessionId'>
+    ? Partial<SessionStartedPayload>
     : Extract<AgentEvent, { type: T }>['payload'],
   sequence = 0,
 ): AgentEvent {

--- a/packages/daemon/src/engine.test.ts
+++ b/packages/daemon/src/engine.test.ts
@@ -40,6 +40,7 @@ const agentCaps: AgentCapabilitySet = {
   supportsStreaming: false,
   supportsToolCallEvents: false,
   supportsInterrupt: false,
+  supportsStdinInterrupt: false,
 };
 
 const SESSION_KEY: SessionKey = {
@@ -169,17 +170,32 @@ function makeAgent() {
   };
 }
 
+type SessionStartedPayload = Extract<
+  AgentEvent,
+  { type: 'session_started' }
+>['payload'];
+
 function ev<T extends AgentEvent['type']>(
   type: T,
-  payload: Extract<AgentEvent, { type: T }>['payload'],
+  payload: T extends 'session_started'
+    ? Partial<SessionStartedPayload> & Pick<SessionStartedPayload, 'agentSessionId'>
+    : Extract<AgentEvent, { type: T }>['payload'],
   sequence = 0,
 ): AgentEvent {
+  const fullPayload =
+    type === 'session_started'
+      ? {
+          workingDir: DEFAULT_CFG.workingDir,
+          capabilities: agentCaps,
+          ...payload,
+        }
+      : payload;
   return {
     type,
     traceId: 't-1',
     timestamp: new Date(0),
     sequence,
-    payload,
+    payload: fullPayload,
   } as AgentEvent;
 }
 

--- a/packages/protocol/src/agent.test.ts
+++ b/packages/protocol/src/agent.test.ts
@@ -104,7 +104,6 @@ const events = [
       callId: 'toolu-1',
       toolName: 'Read',
       status: toolStatus[0]!,
-      errorSummary: undefined,
     },
   },
   {

--- a/packages/protocol/src/agent.test.ts
+++ b/packages/protocol/src/agent.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  AgentCapabilitySet,
+  AgentEvent,
+  ContentBlock,
+  ToolCallStatus,
+  ToolResultContent,
+} from './agent.js';
+
+const capabilities = {
+  supportsThinking: true,
+  supportsStreaming: true,
+  supportsToolCallEvents: true,
+  supportsInterrupt: true,
+  supportsStdinInterrupt: true,
+} satisfies AgentCapabilitySet;
+
+const toolResultContents = [
+  { kind: 'empty' },
+  { kind: 'text', text: 'hello' },
+  {
+    kind: 'blocks',
+    blocks: [{ type: 'custom_block', value: 1 } satisfies ContentBlock],
+  },
+  { kind: 'object', object: { ok: true } },
+  { kind: 'unknown', raw: '{"unexpected":true}' },
+] satisfies ToolResultContent[];
+
+const toolStatus = ['ok', 'error', 'cancelled'] satisfies ToolCallStatus[];
+
+const events = [
+  {
+    type: 'session_started',
+    traceId: 'trace-1',
+    timestamp: new Date(0),
+    sequence: 0,
+    payload: {
+      agentSessionId: 'agent-session-1',
+      pid: 123,
+      workingDir: '/workspace/agent-nexus',
+      capabilities,
+    },
+  },
+  {
+    type: 'thinking',
+    traceId: 'trace-1',
+    timestamp: new Date(0),
+    sequence: 1,
+    payload: { text: 'thinking' },
+  },
+  {
+    type: 'text_delta',
+    traceId: 'trace-1',
+    timestamp: new Date(0),
+    sequence: 2,
+    payload: { text: 'partial' },
+  },
+  {
+    type: 'text_final',
+    traceId: 'trace-1',
+    timestamp: new Date(0),
+    sequence: 3,
+    payload: { text: 'final' },
+  },
+  {
+    type: 'tool_call_started',
+    traceId: 'trace-1',
+    timestamp: new Date(0),
+    sequence: 4,
+    payload: {
+      callId: 'toolu-1',
+      toolName: 'Read',
+      inputSummary: 'Read package.json',
+    },
+  },
+  {
+    type: 'tool_call_progress',
+    traceId: 'trace-1',
+    timestamp: new Date(0),
+    sequence: 5,
+    payload: {
+      callId: 'toolu-1',
+      note: 'running',
+    },
+  },
+  {
+    type: 'tool_result',
+    traceId: 'trace-1',
+    timestamp: new Date(0),
+    sequence: 6,
+    payload: {
+      callId: 'toolu-1',
+      resultSequence: 0,
+      content: toolResultContents[1]!,
+      isError: false,
+    },
+  },
+  {
+    type: 'tool_call_finished',
+    traceId: 'trace-1',
+    timestamp: new Date(0),
+    sequence: 7,
+    payload: {
+      callId: 'toolu-1',
+      toolName: 'Read',
+      status: toolStatus[0]!,
+      errorSummary: undefined,
+    },
+  },
+  {
+    type: 'usage',
+    traceId: 'trace-1',
+    timestamp: new Date(0),
+    sequence: 8,
+    payload: {
+      model: 'claude-sonnet',
+      inputTokens: 1,
+      outputTokens: 2,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+      costUsd: null,
+      turnSequence: 1,
+      toolCallsThisTurn: 1,
+      wallClockMs: 100,
+      completeness: 'partial',
+    },
+  },
+  {
+    type: 'turn_finished',
+    traceId: 'trace-1',
+    timestamp: new Date(0),
+    sequence: 9,
+    payload: { reason: 'wallclock_timeout', turnSequence: 1 },
+  },
+  {
+    type: 'error',
+    traceId: 'trace-1',
+    timestamp: new Date(0),
+    sequence: 10,
+    payload: {
+      errorKind: 'runtime',
+      code: 'E_RUNTIME',
+      message: 'failed',
+      cause: { code: 1 },
+    },
+  },
+  {
+    type: 'session_stopped',
+    traceId: 'trace-1',
+    timestamp: new Date(0),
+    sequence: 11,
+    payload: { reason: 'wallclock_timeout' },
+  },
+] satisfies AgentEvent[];
+
+function eventTypeName(event: AgentEvent): AgentEvent['type'] {
+  switch (event.type) {
+    case 'session_started':
+    case 'thinking':
+    case 'text_delta':
+    case 'text_final':
+    case 'tool_call_started':
+    case 'tool_call_progress':
+    case 'tool_result':
+    case 'tool_call_finished':
+    case 'usage':
+    case 'turn_finished':
+    case 'error':
+    case 'session_stopped':
+      return event.type;
+    default: {
+      const unreachable: never = event;
+      return unreachable;
+    }
+  }
+}
+
+describe('AgentEvent protocol contract', () => {
+  it('should_construct_stream_json_event_union_when_protocol_schema_is_complete', () => {
+    expect(events.map(eventTypeName)).toEqual([
+      'session_started',
+      'thinking',
+      'text_delta',
+      'text_final',
+      'tool_call_started',
+      'tool_call_progress',
+      'tool_result',
+      'tool_call_finished',
+      'usage',
+      'turn_finished',
+      'error',
+      'session_stopped',
+    ]);
+    expect(toolResultContents.map((content) => content.kind)).toEqual([
+      'empty',
+      'text',
+      'blocks',
+      'object',
+      'unknown',
+    ]);
+    expect(toolStatus).toEqual(['ok', 'error', 'cancelled']);
+  });
+});

--- a/packages/protocol/src/agent.ts
+++ b/packages/protocol/src/agent.ts
@@ -1,5 +1,14 @@
 import type { SessionKey } from './session-key.js';
 
+/** docs/dev/spec/agent-runtime.md §AgentCapabilitySet */
+export interface AgentCapabilitySet {
+  supportsThinking: boolean;
+  supportsStreaming: boolean;
+  supportsToolCallEvents: boolean;
+  supportsInterrupt: boolean;
+  supportsStdinInterrupt: boolean;
+}
+
 /** docs/dev/spec/agent-runtime.md §AgentInput */
 export interface AgentInput {
   type: 'user_message' | 'tool_result' | 'interrupt_ack';
@@ -43,11 +52,20 @@ export interface UsageRecord {
   completeness: 'complete' | 'partial' | 'missing';
 }
 
+/** docs/dev/spec/agent-runtime.md §ToolResultContent */
+export type ContentBlock = { type: string; [key: string]: unknown };
+
+export type ToolResultContent =
+  | { kind: 'empty' }
+  | { kind: 'text'; text: string }
+  | { kind: 'blocks'; blocks: ContentBlock[] }
+  | { kind: 'object'; object: Record<string, unknown> }
+  | { kind: 'unknown'; raw: string };
+
+export type ToolCallStatus = 'ok' | 'error' | 'cancelled';
+
 /**
  * docs/dev/spec/agent-runtime.md §AgentEvent
- *
- * MVP 子集：仅 session_started / text_final / turn_finished / usage / error / session_stopped。
- * thinking / text_delta / tool_call_* 留给 stream-json 升级 PR。
  */
 export type AgentEvent =
   | {
@@ -57,8 +75,24 @@ export type AgentEvent =
       sequence: number;
       payload: {
         agentSessionId?: string;
-        workingDir?: string;
+        pid?: number;
+        workingDir: string;
+        capabilities: AgentCapabilitySet;
       };
+    }
+  | {
+      type: 'thinking';
+      traceId: string;
+      timestamp: Date;
+      sequence: number;
+      payload: { text: string };
+    }
+  | {
+      type: 'text_delta';
+      traceId: string;
+      timestamp: Date;
+      sequence: number;
+      payload: { text: string };
     }
   | {
       type: 'text_final';
@@ -66,6 +100,44 @@ export type AgentEvent =
       timestamp: Date;
       sequence: number;
       payload: { text: string };
+    }
+  | {
+      type: 'tool_call_started';
+      traceId: string;
+      timestamp: Date;
+      sequence: number;
+      payload: { callId: string; toolName: string; inputSummary: string };
+    }
+  | {
+      type: 'tool_call_progress';
+      traceId: string;
+      timestamp: Date;
+      sequence: number;
+      payload: { callId: string; note: string };
+    }
+  | {
+      type: 'tool_result';
+      traceId: string;
+      timestamp: Date;
+      sequence: number;
+      payload: {
+        callId: string;
+        resultSequence: number;
+        content: ToolResultContent;
+        isError: boolean;
+      };
+    }
+  | {
+      type: 'tool_call_finished';
+      traceId: string;
+      timestamp: Date;
+      sequence: number;
+      payload: {
+        callId: string;
+        toolName: string;
+        status: ToolCallStatus;
+        errorSummary?: string;
+      };
     }
   | {
       type: 'usage';

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -16,16 +16,19 @@ export type {
 
 export type {
   AgentEvent,
+  AgentCapabilitySet,
   AgentInput,
   AgentSession,
   AgentSessionState,
+  ContentBlock,
   SessionConfig,
+  ToolCallStatus,
+  ToolResultContent,
   TurnEndReason,
   UsageRecord,
 } from './agent.js';
 
 export type {
-  AgentCapabilitySet,
   AgentEventHandler,
   AgentRuntime,
   EventHandler,

--- a/packages/protocol/src/interfaces.ts
+++ b/packages/protocol/src/interfaces.ts
@@ -2,6 +2,7 @@ import type {
   AgentEvent,
   AgentInput,
   AgentSession,
+  AgentCapabilitySet,
   SessionConfig,
 } from './agent.js';
 import type { NormalizedEvent } from './events.js';
@@ -23,14 +24,6 @@ export interface PlatformAdapter {
   edit(ref: MessageRef, message: OutboundMessage): Promise<void>;
   delete(ref: MessageRef): Promise<void>;
   react(ref: MessageRef, emoji: string): Promise<void>;
-}
-
-/** MVP 简化版能力声明；完整版见 docs/dev/spec/agent-runtime.md */
-export interface AgentCapabilitySet {
-  supportsThinking: boolean;
-  supportsStreaming: boolean;
-  supportsToolCallEvents: boolean;
-  supportsInterrupt: boolean;
 }
 
 /** docs/dev/spec/agent-runtime.md §AgentRuntime */


### PR DESCRIPTION
## Summary

- Extend `AgentEvent` to the stream-json protocol event set, including `text_delta`, `tool_call_started`, `tool_result`, and `tool_call_finished` with terminal status.
- Define protocol-level `ToolResultContent`, `ContentBlock`, and `ToolCallStatus` types without moving CC `_normalize_tool_result` logic out of PR-B scope.
- Add `AgentCapabilitySet.supportsStdinInterrupt` and align `session_started` payload with `workingDir` and `capabilities` while preserving `agentSessionId` compatibility.
- Apply the minimal claudecode cascade required by the protocol contract: if CC init does not report a string `cwd`, `session_started.payload.workingDir` falls back to the session/runtime working directory. This is not a full CC stream-json mapping implementation; `_normalize_tool_result` remains PR-B scope.

## Breaking Change

`session_started.payload.workingDir` is now required and `session_started.payload.capabilities` is required. Producers must include both fields when emitting `session_started`.

## Validation

- `corepack pnpm exec tsc --noEmit --module NodeNext --moduleResolution NodeNext --target ES2022 --types vitest --skipLibCheck --strict --noUncheckedIndexedAccess --noImplicitOverride --noFallthroughCasesInSwitch --isolatedModules packages/protocol/src/agent.test.ts`
- `corepack pnpm typecheck`
- `corepack pnpm exec vitest run packages/protocol/src/agent.test.ts packages/daemon/src/engine.test.ts packages/agent/claudecode/src/index.test.ts`
- `corepack pnpm test`

## Review Evidence

- Draft GAN: `/home/node/agent-nexus-epics/stream-json-migration/reviews/p3-draft-1779520799/`
  - R1 found the classifier/PR-B boundary issue.
  - R2 found the `turn_finished`/`TurnEndReason` PR-A scope declaration gap.
  - R3 marked the draft `接近最优`.
- PR diff GAN: `/home/node/agent-nexus-epics/stream-json-migration/reviews/p3-pr92-diff-1779520799/`

Part of #56.

Co-Authored-By: GPT-5 Codex <noreply@openai.com>