### PR TITLE
feat(daemon): 让 stream-json turn 通过长驻 session 流式回送

### DIFF
--- a/packages/daemon/src/engine.test.ts
+++ b/packages/daemon/src/engine.test.ts
@@ -68,11 +68,16 @@ function makeEvent(text: string, overrides: Partial<NormalizedEvent> = {}): Norm
   };
 }
 
-function makePlatform(): PlatformAdapter & {
+function makePlatform(capOverrides: Partial<CapabilitySet> = {}): PlatformAdapter & {
+  capabilities: ReturnType<typeof vi.fn>;
   send: ReturnType<typeof vi.fn>;
+  edit: ReturnType<typeof vi.fn>;
+  setTyping: ReturnType<typeof vi.fn>;
+  clearTyping: ReturnType<typeof vi.fn>;
   start: ReturnType<typeof vi.fn>;
   stop: ReturnType<typeof vi.fn>;
 } {
+  const caps = { ...platformCaps, ...capOverrides };
   const ref: MessageRef = {
     platform: 'discord',
     channelId: 'C1',
@@ -82,13 +87,15 @@ function makePlatform(): PlatformAdapter & {
   };
   return {
     name: () => 'mock-platform',
-    capabilities: () => platformCaps,
+    capabilities: vi.fn(() => caps),
     start: vi.fn(async (_h: EventHandler) => {}),
     stop: vi.fn(async () => {}),
     send: vi.fn(async (_k: SessionKey, _m: OutboundMessage) => ref),
     edit: vi.fn(async () => {}),
     delete: vi.fn(async () => {}),
     react: vi.fn(async () => {}),
+    setTyping: vi.fn(async () => {}),
+    clearTyping: vi.fn(async () => {}),
   };
 }
 
@@ -99,7 +106,7 @@ function makePlatform(): PlatformAdapter & {
  * - `queueEventsAfter(events, ms)` 入队一组并在事件分发前等 `ms` 毫秒（用于显式制造异步窗口）
  */
 function makeAgent() {
-  const handlers = new Map<AgentSession, AgentEventHandler>();
+  const handlers = new Map<AgentSession, AgentEventHandler[]>();
   type QueueEntry = { events: AgentEvent[]; delayMs: number };
   const queue: QueueEntry[] = [];
   let counter = 0;
@@ -126,19 +133,30 @@ function makeAgent() {
   const isAlive = vi.fn(() => true);
 
   const onEvent = vi.fn((s: AgentSession, h: AgentEventHandler) => {
-    handlers.set(s, h);
+    const existing = handlers.get(s) ?? [];
+    existing.push(h);
+    handlers.set(s, existing);
   });
 
   const sendInput = vi.fn(async (s: AgentSession, _input: AgentInput) => {
-    const h = handlers.get(s);
-    if (!h) return;
+    const sessionHandlers = handlers.get(s);
+    if (!sessionHandlers) return;
     const entry = queue.shift();
     if (!entry) return;
     if (entry.delayMs > 0) {
       await new Promise((r) => setTimeout(r, entry.delayMs));
     }
     for (const e of entry.events) {
-      await h(e);
+      for (const h of sessionHandlers) {
+        try {
+          const ret = h(e);
+          if (ret && typeof (ret as Promise<void>).then === 'function') {
+            void (ret as Promise<void>).catch(() => {});
+          }
+        } catch (err) {
+          return Promise.reject(err);
+        }
+      }
     }
   });
 
@@ -159,6 +177,7 @@ function makeAgent() {
     runtime,
     startSession,
     stopSession,
+    isAlive,
     onEvent,
     sendInput,
     queueEvents(events: AgentEvent[]): void {
@@ -246,10 +265,10 @@ describe('Engine', () => {
     const out = sendArgs[1] as OutboundMessage;
     expect(out.text).toBe('hi from agent');
 
-    expect(agent.stopSession).toHaveBeenCalledTimes(1);
+    expect(agent.stopSession).not.toHaveBeenCalled();
   });
 
-  it('第二轮：复用同 sessionKey，agent.startSession 收到 prev agentSessionId 作 resumeFromAgentSessionId', async () => {
+  it('第二轮：复用同 sessionKey 的活跃 AgentSession，不重新 startSession', async () => {
     const platform = makePlatform();
     const agent = makeAgent();
     const store = new SessionStore();
@@ -273,7 +292,45 @@ describe('Engine', () => {
     await dispatchHandler(makeEvent('first prompt'));
     expect(store.get(SESSION_KEY)?.agentSessionId).toBe('sid-123');
 
-    // 第二轮：startSession 必须收到 sid-123 作 resume
+    const firstSession = agent.sendInput.mock.calls[0]![0] as AgentSession;
+
+    // 第二轮：活跃 session 仍 alive，直接复用同一 AgentSession
+    agent.queueEvents([
+      ev('text_final', { text: 'second' }),
+      ev('turn_finished', { reason: 'stop', turnSequence: 2 }),
+    ]);
+    await dispatchHandler(makeEvent('second prompt'));
+
+    expect(agent.startSession).toHaveBeenCalledTimes(1);
+    expect(agent.onEvent).toHaveBeenCalledTimes(1);
+    expect(agent.sendInput.mock.calls[1]![0]).toBe(firstSession);
+    expect(store.get(SESSION_KEY)?.agentSessionId).toBe('sid-123');
+    expect(agent.stopSession).not.toHaveBeenCalled();
+  });
+
+  it('第二轮发现活跃 AgentSession 不 alive：关闭旧句柄并用 store 里的 agentSessionId resume 新 session', async () => {
+    const platform = makePlatform();
+    const agent = makeAgent();
+    const store = new SessionStore();
+    const engine = new Engine({
+      platform,
+      agent: agent.runtime,
+      logger: SILENT_LOGGER,
+      sessionStore: store,
+      defaultSessionConfig: DEFAULT_CFG,
+    });
+
+    await engine.start();
+    const dispatchHandler = (platform.start as ReturnType<typeof vi.fn>).mock.calls[0]![0] as EventHandler;
+
+    agent.queueEvents([
+      ev('session_started', { agentSessionId: 'sid-123' }),
+      ev('text_final', { text: 'first' }),
+      ev('turn_finished', { reason: 'stop', turnSequence: 1 }),
+    ]);
+    await dispatchHandler(makeEvent('first prompt'));
+
+    agent.isAlive.mockReturnValueOnce(false);
     agent.queueEvents([
       ev('session_started', { agentSessionId: 'sid-456' }),
       ev('text_final', { text: 'second' }),
@@ -281,10 +338,10 @@ describe('Engine', () => {
     ]);
     await dispatchHandler(makeEvent('second prompt'));
 
+    expect(agent.stopSession).toHaveBeenCalledTimes(1);
     expect(agent.startSession).toHaveBeenCalledTimes(2);
     const cfg2 = agent.startSession.mock.calls[1]![1] as SessionConfig;
     expect(cfg2.resumeFromAgentSessionId).toBe('sid-123');
-
     expect(store.get(SESSION_KEY)?.agentSessionId).toBe('sid-456');
   });
 
@@ -380,7 +437,6 @@ describe('Engine', () => {
     );
     // 第二条 dispatch 紧随其后
     agent.queueEvents([
-      ev('session_started', { agentSessionId: 'sid-second' }),
       ev('text_final', { text: 'second reply' }),
       ev('turn_finished', { reason: 'stop', turnSequence: 2 }),
     ]);
@@ -389,12 +445,13 @@ describe('Engine', () => {
     const p2 = dispatchHandler(makeEvent('second'));
     await Promise.all([p1, p2]);
 
-    expect(agent.startSession).toHaveBeenCalledTimes(2);
-    const cfg2 = agent.startSession.mock.calls[1]![1] as SessionConfig;
-    expect(cfg2.resumeFromAgentSessionId).toBe('sid-first');
+    expect(agent.startSession).toHaveBeenCalledTimes(1);
+    expect(agent.onEvent).toHaveBeenCalledTimes(1);
+    expect(agent.sendInput).toHaveBeenCalledTimes(2);
+    expect(agent.sendInput.mock.calls[1]![0]).toBe(agent.sendInput.mock.calls[0]![0]);
 
-    // store 终态是第二轮写入的 sid-second（顺序写）
-    expect(store.get(SESSION_KEY)?.agentSessionId).toBe('sid-second');
+    // store 仍保留当前活跃 agent session id；第二轮未重启 session。
+    expect(store.get(SESSION_KEY)?.agentSessionId).toBe('sid-first');
   });
 
   it('不同 SessionKey 并发不串行：互不阻塞', async () => {
@@ -570,6 +627,233 @@ describe('Engine', () => {
     expect(agent.startSession).toHaveBeenCalledTimes(1);
   });
 
+  it('supportsEdit=false：text_delta 只缓冲，turn_finished 发送 text_final 且不调用 edit/typing', async () => {
+    const platform = makePlatform();
+    const agent = makeAgent();
+    const store = new SessionStore();
+    const engine = new Engine({
+      platform,
+      agent: agent.runtime,
+      logger: SILENT_LOGGER,
+      sessionStore: store,
+      defaultSessionConfig: DEFAULT_CFG,
+    });
+
+    await engine.start();
+    const dispatchHandler = (platform.start as ReturnType<typeof vi.fn>).mock.calls[0]![0] as EventHandler;
+
+    agent.queueEvents([
+      ev('text_delta', { text: 'hel' }),
+      ev('text_delta', { text: 'lo' }),
+      ev('text_final', { text: 'hello' }),
+      ev('turn_finished', { reason: 'stop', turnSequence: 1 }),
+    ]);
+
+    await dispatchHandler(makeEvent('hello'));
+
+    expect(platform.send).toHaveBeenCalledTimes(1);
+    expect((platform.send.mock.calls[0]![1] as OutboundMessage).text).toBe('hello');
+    expect(platform.edit).not.toHaveBeenCalled();
+    expect(platform.setTyping).not.toHaveBeenCalled();
+    expect(platform.clearTyping).not.toHaveBeenCalled();
+  });
+
+  it('supportsEdit=true：首个 text_delta send 建 ref，turn_finished 立即 final edit 且不 double append text_final', async () => {
+    const platform = makePlatform({ supportsEdit: true });
+    const agent = makeAgent();
+    const store = new SessionStore();
+    const engine = new Engine({
+      platform,
+      agent: agent.runtime,
+      logger: SILENT_LOGGER,
+      sessionStore: store,
+      defaultSessionConfig: DEFAULT_CFG,
+      streaming: { streamEditThrottleMs: 1000 },
+    });
+
+    await engine.start();
+    const dispatchHandler = (platform.start as ReturnType<typeof vi.fn>).mock.calls[0]![0] as EventHandler;
+
+    agent.queueEvents([
+      ev('text_delta', { text: 'he' }),
+      ev('text_delta', { text: 'llo' }),
+      ev('text_final', { text: 'hello' }),
+      ev('turn_finished', { reason: 'stop', turnSequence: 1 }),
+    ]);
+
+    await dispatchHandler(makeEvent('hello'));
+
+    expect(platform.send).toHaveBeenCalledTimes(1);
+    expect((platform.send.mock.calls[0]![1] as OutboundMessage).text).toBe('he');
+    expect(platform.edit).toHaveBeenCalledTimes(1);
+    expect((platform.edit.mock.calls[0]![1] as OutboundMessage).text).toBe('hello');
+  });
+
+  it('tool event 在无文本时产生最小可见性，final edit 覆盖为最终回复', async () => {
+    const platform = makePlatform({ supportsEdit: true });
+    const agent = makeAgent();
+    const store = new SessionStore();
+    const engine = new Engine({
+      platform,
+      agent: agent.runtime,
+      logger: SILENT_LOGGER,
+      sessionStore: store,
+      defaultSessionConfig: DEFAULT_CFG,
+    });
+
+    await engine.start();
+    const dispatchHandler = (platform.start as ReturnType<typeof vi.fn>).mock.calls[0]![0] as EventHandler;
+
+    agent.queueEvents([
+      ev('tool_call_started', {
+        callId: 'tool-1',
+        toolName: 'Bash',
+        inputSummary: 'npm test',
+      }),
+      ev('tool_result', {
+        callId: 'tool-1',
+        resultSequence: 1,
+        content: { kind: 'text', text: 'private output' },
+        isError: false,
+      }),
+      ev('text_final', { text: 'done' }),
+      ev('turn_finished', { reason: 'stop', turnSequence: 1 }),
+    ]);
+
+    await dispatchHandler(makeEvent('run tests'));
+
+    expect(platform.send).toHaveBeenCalledTimes(1);
+    expect((platform.send.mock.calls[0]![1] as OutboundMessage).text).toBe(
+      '[tool: Bash] started',
+    );
+    expect(platform.edit).toHaveBeenCalledTimes(1);
+    expect((platform.edit.mock.calls[0]![1] as OutboundMessage).text).toBe('done');
+  });
+
+  it('supportsEdit=false：tool event 以单独状态消息满足可见性且不泄露 tool_result 内容', async () => {
+    const platform = makePlatform();
+    const agent = makeAgent();
+    const store = new SessionStore();
+    const engine = new Engine({
+      platform,
+      agent: agent.runtime,
+      logger: SILENT_LOGGER,
+      sessionStore: store,
+      defaultSessionConfig: DEFAULT_CFG,
+    });
+
+    await engine.start();
+    const dispatchHandler = (platform.start as ReturnType<typeof vi.fn>).mock.calls[0]![0] as EventHandler;
+
+    agent.queueEvents([
+      ev('tool_result', {
+        callId: 'tool-1',
+        resultSequence: 1,
+        content: { kind: 'text', text: 'secret result' },
+        isError: false,
+      }),
+      ev('text_final', { text: 'done' }),
+      ev('turn_finished', { reason: 'stop', turnSequence: 1 }),
+    ]);
+
+    await dispatchHandler(makeEvent('run tool'));
+
+    expect(platform.send).toHaveBeenCalledTimes(2);
+    expect((platform.send.mock.calls[0]![1] as OutboundMessage).text).toBe(
+      '[tool: tool-1] result',
+    );
+    expect((platform.send.mock.calls[0]![1] as OutboundMessage).text).not.toContain(
+      'secret result',
+    );
+    expect((platform.send.mock.calls[1]![1] as OutboundMessage).text).toBe('done');
+    expect(platform.edit).not.toHaveBeenCalled();
+  });
+
+  it('supportsTypingIndicator=true：turn start setTyping，周期续期，turn end clearTyping 并停 timer', async () => {
+    vi.useFakeTimers();
+    try {
+      const platform = makePlatform({ supportsTypingIndicator: true });
+      const agent = makeAgent();
+      const store = new SessionStore();
+      const engine = new Engine({
+        platform,
+        agent: agent.runtime,
+        logger: SILENT_LOGGER,
+        sessionStore: store,
+        defaultSessionConfig: DEFAULT_CFG,
+        streaming: { typingRefreshMs: 10 },
+      });
+
+      await engine.start();
+      const dispatchHandler = (platform.start as ReturnType<typeof vi.fn>).mock.calls[0]![0] as EventHandler;
+
+      agent.queueEventsAfter(
+        [
+          ev('text_final', { text: 'slow reply' }),
+          ev('turn_finished', { reason: 'stop', turnSequence: 1 }),
+        ],
+        25,
+      );
+
+      const dispatchPromise = dispatchHandler(makeEvent('slow'));
+      await vi.advanceTimersByTimeAsync(0);
+      expect(platform.setTyping).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(10);
+      expect(platform.setTyping).toHaveBeenCalledTimes(2);
+
+      await vi.advanceTimersByTimeAsync(10);
+      expect(platform.setTyping).toHaveBeenCalledTimes(3);
+
+      await vi.advanceTimersByTimeAsync(10);
+      await dispatchPromise;
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(platform.clearTyping).toHaveBeenCalledTimes(1);
+      const typingCallsAfterClear = platform.setTyping.mock.calls.length;
+      await vi.advanceTimersByTimeAsync(30);
+      expect(platform.setTyping).toHaveBeenCalledTimes(typingCallsAfterClear);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('sendInput reject 且无 agent error 时仍清理 typing timer', async () => {
+    vi.useFakeTimers();
+    try {
+      const platform = makePlatform({ supportsTypingIndicator: true });
+      const agent = makeAgent();
+      const sendErr = new Error('send failed');
+      agent.sendInput.mockRejectedValueOnce(sendErr);
+      const store = new SessionStore();
+      const engine = new Engine({
+        platform,
+        agent: agent.runtime,
+        logger: SILENT_LOGGER,
+        sessionStore: store,
+        defaultSessionConfig: DEFAULT_CFG,
+        streaming: { typingRefreshMs: 10 },
+      });
+
+      await engine.start();
+      const dispatchHandler = (platform.start as ReturnType<typeof vi.fn>).mock.calls[0]![0] as EventHandler;
+
+      const dispatchPromise = dispatchHandler(makeEvent('hello'));
+      await vi.advanceTimersByTimeAsync(0);
+      await dispatchPromise;
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(platform.setTyping).toHaveBeenCalledTimes(1);
+      expect(platform.clearTyping).toHaveBeenCalledTimes(1);
+
+      const typingCallsAfterClear = platform.setTyping.mock.calls.length;
+      await vi.advanceTimersByTimeAsync(30);
+      expect(platform.setTyping).toHaveBeenCalledTimes(typingCallsAfterClear);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('error 路径：agent emit error → platform.send 收到 [agent error: ...]', async () => {
     const platform = makePlatform();
     const agent = makeAgent();
@@ -636,6 +920,14 @@ describe('Engine', () => {
     expect(dispatchFailedLog).toBeUndefined();
   }
 
+  function assertNoHandlerOrDispatchFailure(mockLogger: Logger): void {
+    const errorCalls = (mockLogger.error as ReturnType<typeof vi.fn>).mock.calls;
+    const handlerErrLog = errorCalls.find(([, msg]) => msg === 'agent_event_handler_failed');
+    expect(handlerErrLog).toBeUndefined();
+    const dispatchFailedLog = errorCalls.find(([, msg]) => msg === 'dispatch_failed');
+    expect(dispatchFailedLog).toBeUndefined();
+  }
+
   it('platform.send 失败（/new ack 路径）：错误被吞 + 写 platform_send_failed 含 traceId/sessionKey/err', async () => {
     const platform = makePlatform();
     const sendErr = new Error('platform down /new');
@@ -696,7 +988,7 @@ describe('Engine', () => {
     expect(agent.stopSession).toHaveBeenCalledTimes(1);
   });
 
-  it('platform.send 失败（turn_finished 回送路径）：错误被吞 + 写 platform_send_failed + 仍走 stopSession', async () => {
+  it('platform.send 失败（turn_finished 回送路径）：错误被吞 + 写 platform_send_failed + 不关闭长驻 session', async () => {
     const platform = makePlatform();
     const sendErr = new Error('platform down turn_finished');
     (platform.send as ReturnType<typeof vi.fn>).mockRejectedValueOnce(sendErr);
@@ -725,19 +1017,50 @@ describe('Engine', () => {
     await expect(dispatchHandler(makeEvent('hello'))).resolves.toBeUndefined();
 
     assertSendFailedLog(mockLogger, sendErr);
-    expect(agent.stopSession).toHaveBeenCalledTimes(1);
+    expect(agent.stopSession).not.toHaveBeenCalled();
   });
 
-  it('agent.stopSession 抛出：错误被吞 + 写 agent_stop_session_failed 含 traceId/sessionKey/err', async () => {
-    // 7a1f916 改了 stopSession 失败日志字段（加了 traceId/sessionKey），
-    // 这里 lock 住，防止后续误删字段或 inline 时漏带 context。
-    const platform = makePlatform();
+  it('platform.edit 失败（final edit 路径）：错误被吞 + 写 platform_edit_failed', async () => {
+    const platform = makePlatform({ supportsEdit: true });
+    const editErr = new Error('platform down edit');
+    platform.edit.mockRejectedValueOnce(editErr);
+
     const agent = makeAgent();
-    const stopErr = new Error('stop boom');
-    (agent.stopSession as ReturnType<typeof vi.fn>).mockImplementationOnce(() => {
-      throw stopErr;
+    const store = new SessionStore();
+    const mockLogger = makeMockLogger();
+
+    const engine = new Engine({
+      platform,
+      agent: agent.runtime,
+      logger: mockLogger,
+      sessionStore: store,
+      defaultSessionConfig: DEFAULT_CFG,
     });
 
+    agent.queueEvents([
+      ev('text_delta', { text: 'reply' }),
+      ev('turn_finished', { reason: 'stop', turnSequence: 1 }),
+    ]);
+
+    await engine.start();
+    const dispatchHandler = (platform.start as ReturnType<typeof vi.fn>).mock.calls[0]![0] as EventHandler;
+
+    await expect(dispatchHandler(makeEvent('hello'))).resolves.toBeUndefined();
+
+    const errorCalls = (mockLogger.error as ReturnType<typeof vi.fn>).mock.calls;
+    const editFailedLog = errorCalls.find(([, msg]) => msg === 'platform_edit_failed');
+    expect(editFailedLog).toBeDefined();
+    expect(editFailedLog![0]).toMatchObject({
+      traceId: 't-1',
+      err: editErr,
+    });
+    expect(editFailedLog![0]).toHaveProperty('sessionKey');
+    assertNoHandlerOrDispatchFailure(mockLogger);
+  });
+
+  it('agent.stopSession 抛出（/new 关闭旧 session）：错误被吞 + 写 agent_stop_session_failed 含 traceId/sessionKey/err', async () => {
+    const platform = makePlatform();
+    const agent = makeAgent();
     const store = new SessionStore();
     const mockLogger = {
       info: vi.fn(),
@@ -767,6 +1090,14 @@ describe('Engine', () => {
     const dispatchHandler = (platform.start as ReturnType<typeof vi.fn>).mock.calls[0]![0] as EventHandler;
 
     await expect(dispatchHandler(makeEvent('hello'))).resolves.toBeUndefined();
+    expect(agent.stopSession).not.toHaveBeenCalled();
+
+    const stopErr = new Error('stop boom');
+    (agent.stopSession as ReturnType<typeof vi.fn>).mockImplementationOnce(() => {
+      throw stopErr;
+    });
+
+    await expect(dispatchHandler(makeEvent('/new'))).resolves.toBeUndefined();
 
     const errorCalls = (mockLogger.error as ReturnType<typeof vi.fn>).mock.calls;
     const stopFailedLog = errorCalls.find(([, msg]) => msg === 'agent_stop_session_failed');
@@ -780,5 +1111,37 @@ describe('Engine', () => {
     // 同步 throw 应被本地 catch 兜住，不应升级成 handlerErr / agent_event_handler_failed
     const handlerErrLog = errorCalls.find(([, msg]) => msg === 'agent_event_handler_failed');
     expect(handlerErrLog).toBeUndefined();
+  });
+
+  it('engine.stop 关闭仍活跃的 agent session 并清空 store', async () => {
+    const platform = makePlatform();
+    const agent = makeAgent();
+    const store = new SessionStore();
+    const engine = new Engine({
+      platform,
+      agent: agent.runtime,
+      logger: SILENT_LOGGER,
+      sessionStore: store,
+      defaultSessionConfig: DEFAULT_CFG,
+    });
+
+    agent.queueEvents([
+      ev('session_started', { agentSessionId: 'sid-1' }),
+      ev('text_final', { text: 'reply' }),
+      ev('turn_finished', { reason: 'stop', turnSequence: 1 }),
+    ]);
+
+    await engine.start();
+    const dispatchHandler = (platform.start as ReturnType<typeof vi.fn>).mock.calls[0]![0] as EventHandler;
+    await dispatchHandler(makeEvent('hello'));
+
+    expect(store.get(SESSION_KEY)?.agentSessionId).toBe('sid-1');
+    expect(agent.stopSession).not.toHaveBeenCalled();
+
+    await engine.stop();
+
+    expect(platform.stop).toHaveBeenCalledTimes(1);
+    expect(agent.stopSession).toHaveBeenCalledTimes(1);
+    expect(store.get(SESSION_KEY)).toBeUndefined();
   });
 });

--- a/packages/daemon/src/engine.ts
+++ b/packages/daemon/src/engine.ts
@@ -2,6 +2,8 @@ import { randomUUID } from 'node:crypto';
 import type {
   AgentEvent,
   AgentRuntime,
+  AgentSession,
+  MessageRef,
   NormalizedEvent,
   PlatformAdapter,
   SessionConfig,
@@ -20,6 +22,22 @@ export interface EngineDeps {
     SessionConfig,
     'resumeFromAgentSessionId' | 'sessionId'
   >;
+  streaming?: {
+    streamEditThrottleMs?: number;
+    typingRefreshMs?: number;
+  };
+}
+
+const DEFAULT_STREAM_EDIT_THROTTLE_MS = 1500;
+const DEFAULT_TYPING_REFRESH_MS = 8000;
+
+interface ActiveAgentSession {
+  session: AgentSession;
+  currentTurn?: {
+    eventId: string;
+    pending: Set<Promise<void>>;
+    handle(event: AgentEvent): Promise<void>;
+  };
 }
 
 /**
@@ -42,6 +60,9 @@ export class Engine {
     SessionConfig,
     'resumeFromAgentSessionId' | 'sessionId'
   >;
+  private readonly streamEditThrottleMs: number;
+  private readonly typingRefreshMs: number;
+  private readonly agentSessions = new Map<string, ActiveAgentSession>();
   /**
    * Per-SessionKey 串行队列：同 key 的 dispatch 必须按到达序排队执行，
    * 否则两条并发 inbound 会同时读到陈旧 prevAgentSessionId 各自启新 session、
@@ -64,6 +85,10 @@ export class Engine {
     this.logger = deps.logger;
     this.sessionStore = deps.sessionStore;
     this.defaultSessionConfig = deps.defaultSessionConfig;
+    this.streamEditThrottleMs =
+      deps.streaming?.streamEditThrottleMs ?? DEFAULT_STREAM_EDIT_THROTTLE_MS;
+    this.typingRefreshMs =
+      deps.streaming?.typingRefreshMs ?? DEFAULT_TYPING_REFRESH_MS;
   }
 
   async start(): Promise<void> {
@@ -72,8 +97,14 @@ export class Engine {
 
   async stop(): Promise<void> {
     await this.platform.stop();
-    // agent 是 stateless 句柄式实现；无 per-runtime 全局 teardown，
-    // 各 session 在 turn_finished 时已 stopSession。
+    for (const [sessionKey, active] of this.agentSessions) {
+      try {
+        this.agent.stopSession(active.session);
+      } catch (err) {
+        this.logger.error({ sessionKey, err }, 'agent_stop_session_failed');
+      }
+    }
+    this.agentSessions.clear();
     this.sessionStore.clearAll();
   }
 
@@ -138,6 +169,7 @@ export class Engine {
       const trimmed = rawText.trim();
       let prompt: string;
       if (trimmed === '/new' || trimmed.startsWith('/new ')) {
+        this.stopActiveSession(sessionKeyStr, event.traceId);
         this.sessionStore.delete(event.sessionKey);
         const remainder = trimmed === '/new' ? '' : trimmed.slice(5).trim();
         if (remainder.length === 0) {
@@ -160,19 +192,211 @@ export class Engine {
         prompt = rawText;
       }
 
-      const prevAgentSessionId = this.sessionStore.get(
-        event.sessionKey,
-      )?.agentSessionId;
-      const config: SessionConfig = {
-        ...this.defaultSessionConfig,
-        sessionId: randomUUID(),
-        resumeFromAgentSessionId: prevAgentSessionId,
+      const platformCaps = this.platform.capabilities();
+      let session: AgentSession | undefined;
+      let buf = '';
+      let sawDelta = false;
+      let errored = false;
+      let messageRef: MessageRef | undefined;
+      let creatingRef: Promise<MessageRef | undefined> | undefined;
+      let lastEditAt = 0;
+      let pendingEditTimer: ReturnType<typeof setTimeout> | undefined;
+      let typingInterval: ReturnType<typeof setInterval> | undefined;
+      let typingActive = false;
+      let toolStatus: string | undefined;
+
+      const safeSend = async (text: string): Promise<MessageRef | undefined> => {
+        try {
+          return await this.platform.send(event.sessionKey, {
+            text,
+            traceId: event.traceId,
+            sessionKey: event.sessionKey,
+          });
+        } catch (sendErr) {
+          this.logger.error(
+            {
+              traceId: event.traceId,
+              sessionKey: sessionKeyStr,
+              err: sendErr,
+            },
+            'platform_send_failed',
+          );
+          return undefined;
+        }
       };
 
-      const session = this.agent.startSession(event.sessionKey, config);
+      const safeEdit = async (
+        ref: MessageRef,
+        text: string,
+      ): Promise<void> => {
+        try {
+          await this.platform.edit(ref, {
+            text,
+            traceId: event.traceId,
+            sessionKey: event.sessionKey,
+          });
+        } catch (editErr) {
+          this.logger.error(
+            {
+              traceId: event.traceId,
+              sessionKey: sessionKeyStr,
+              err: editErr,
+            },
+            'platform_edit_failed',
+          );
+        }
+      };
 
-      let buf = '';
-      let errored = false;
+      const renderVisibleText = (): string => {
+        if (toolStatus && buf.length > 0) return `${buf}\n\n${toolStatus}`;
+        return buf.length > 0 ? buf : (toolStatus ?? '[working]');
+      };
+
+      const ensureMessageRef = (
+        text: string,
+      ): { promise: Promise<MessageRef | undefined>; createdHere: boolean } => {
+        if (messageRef) {
+          return { promise: Promise.resolve(messageRef), createdHere: false };
+        }
+        if (creatingRef) {
+          return { promise: creatingRef, createdHere: false };
+        }
+        creatingRef = safeSend(text)
+          .then((ref) => {
+            if (ref) messageRef = ref;
+            return ref;
+          })
+          .finally(() => {
+            creatingRef = undefined;
+          });
+        return { promise: creatingRef, createdHere: true };
+      };
+
+      const flushEdit = async (text = renderVisibleText()): Promise<void> => {
+        if (!platformCaps.supportsEdit) return;
+        const { promise, createdHere } = ensureMessageRef(text);
+        const ref = await promise;
+        if (!ref) return;
+        if (!createdHere) await safeEdit(ref, text);
+        lastEditAt = Date.now();
+      };
+
+      const cancelPendingEdit = (): void => {
+        if (!pendingEditTimer) return;
+        clearTimeout(pendingEditTimer);
+        pendingEditTimer = undefined;
+      };
+
+      const scheduleEdit = async (): Promise<void> => {
+        if (!platformCaps.supportsEdit) return;
+        if (!messageRef) {
+          if (!creatingRef) await flushEdit();
+          return;
+        }
+        const elapsed = Date.now() - lastEditAt;
+        if (elapsed >= this.streamEditThrottleMs) {
+          await flushEdit();
+          return;
+        }
+        if (pendingEditTimer) return;
+        pendingEditTimer = setTimeout(() => {
+          pendingEditTimer = undefined;
+          void flushEdit();
+        }, this.streamEditThrottleMs - elapsed);
+      };
+
+      const clearTyping = (): void => {
+        if (!typingActive) return;
+        typingActive = false;
+        if (typingInterval) {
+          clearInterval(typingInterval);
+          typingInterval = undefined;
+        }
+        Promise.resolve()
+          .then(() => this.platform.clearTyping(event.sessionKey))
+          .catch((typingErr) => {
+            this.logger.debug(
+              {
+                traceId: event.traceId,
+                sessionKey: sessionKeyStr,
+                err: typingErr,
+              },
+              'platform_typing_failed',
+            );
+          });
+      };
+
+      const setTyping = (): void => {
+        Promise.resolve()
+          .then(() => this.platform.setTyping(event.sessionKey))
+          .catch((typingErr) => {
+            this.logger.debug(
+              {
+                traceId: event.traceId,
+                sessionKey: sessionKeyStr,
+                err: typingErr,
+              },
+              'platform_typing_failed',
+            );
+          });
+      };
+
+      const startTyping = (): void => {
+        if (!platformCaps.supportsTypingIndicator || typingActive) return;
+        typingActive = true;
+        setTyping();
+        typingInterval = setInterval(setTyping, this.typingRefreshMs);
+      };
+
+      const finalizeReply = async (): Promise<void> => {
+        cancelPendingEdit();
+        const text = buf.length > 0 ? buf : '[empty response]';
+        if (platformCaps.supportsEdit) {
+          await flushEdit(text);
+        } else {
+          messageRef = await safeSend(text);
+        }
+        this.logger.info(
+          {
+            traceId: event.traceId,
+            sessionKey: sessionKeyStr,
+            length: text.length,
+          },
+          'outbound',
+        );
+        this.logger.debug(
+          {
+            traceId: event.traceId,
+            sessionKey: sessionKeyStr,
+            text,
+          },
+          'outbound',
+        );
+      };
+
+      const ensureToolVisible = async (status: string): Promise<void> => {
+        if (toolStatus) return;
+        toolStatus = status;
+        if (platformCaps.supportsEdit) {
+          await flushEdit();
+          return;
+        }
+        messageRef = await safeSend(toolStatus);
+      };
+
+      const closeSession = (): void => {
+        if (!session) return;
+        const current = this.agentSessions.get(sessionKeyStr);
+        if (current?.session === session) this.agentSessions.delete(sessionKeyStr);
+        try {
+          this.agent.stopSession(session);
+        } catch (stopErr) {
+          this.logger.error(
+            { traceId: event.traceId, sessionKey: sessionKeyStr, err: stopErr },
+            'agent_stop_session_failed',
+          );
+        }
+      };
 
       const handler = async (e: AgentEvent): Promise<void> => {
         try {
@@ -186,13 +410,44 @@ export class Engine {
             }
             return;
           }
-          if (e.type === 'text_final') {
-            // 期望只来一条；多条按到达顺序 concat
+          if (e.type === 'text_delta') {
+            sawDelta = true;
             buf += e.payload.text;
+            await scheduleEdit();
+            return;
+          }
+          if (e.type === 'text_final') {
+            if (sawDelta) {
+              buf = e.payload.text;
+            } else {
+              // 期望只来一条；多条按到达顺序 concat
+              buf += e.payload.text;
+            }
+            await scheduleEdit();
+            return;
+          }
+          if (e.type === 'tool_call_started') {
+            await ensureToolVisible(`[tool: ${e.payload.toolName}] started`);
+            return;
+          }
+          if (e.type === 'tool_call_progress') {
+            await ensureToolVisible(`[tool: ${e.payload.callId}] running`);
+            return;
+          }
+          if (e.type === 'tool_result') {
+            await ensureToolVisible(`[tool: ${e.payload.callId}] result`);
+            return;
+          }
+          if (e.type === 'tool_call_finished') {
+            await ensureToolVisible(
+              `[tool: ${e.payload.toolName}] ${e.payload.status}`,
+            );
             return;
           }
           if (e.type === 'error') {
             errored = true;
+            cancelPendingEdit();
+            clearTyping();
             this.logger.error(
               {
                 traceId: event.traceId,
@@ -204,20 +459,9 @@ export class Engine {
               'agent_error',
             );
             try {
-              await this.platform.send(event.sessionKey, {
-                text: `[agent error: ${e.payload.errorKind}] ${e.payload.message}`,
-                traceId: event.traceId,
-                sessionKey: event.sessionKey,
-              });
-            } catch (sendErr) {
-              this.logger.error(
-                {
-                  traceId: event.traceId,
-                  sessionKey: sessionKeyStr,
-                  err: sendErr,
-                },
-                'platform_send_failed',
-              );
+              await safeSend(`[agent error: ${e.payload.errorKind}] ${e.payload.message}`);
+            } finally {
+              closeSession();
             }
             this.logger.info(
               {
@@ -230,52 +474,23 @@ export class Engine {
             return;
           }
           if (e.type === 'turn_finished') {
+            clearTyping();
             if (!errored) {
-              const text = buf.length > 0 ? buf : '[empty response]';
-              try {
-                await this.platform.send(event.sessionKey, {
-                  text,
-                  traceId: event.traceId,
-                  sessionKey: event.sessionKey,
-                });
-              } catch (sendErr) {
-                this.logger.error(
-                  {
-                    traceId: event.traceId,
-                    sessionKey: sessionKeyStr,
-                    err: sendErr,
-                  },
-                  'platform_send_failed',
-                );
-              }
-              this.logger.info(
-                {
-                  traceId: event.traceId,
-                  sessionKey: sessionKeyStr,
-                  length: text.length,
-                },
-                'outbound',
-              );
-              this.logger.debug(
-                {
-                  traceId: event.traceId,
-                  sessionKey: sessionKeyStr,
-                  text,
-                },
-                'outbound',
-              );
-            }
-            try {
-              this.agent.stopSession(session);
-            } catch (stopErr) {
-              this.logger.error(
-                { traceId: event.traceId, sessionKey: sessionKeyStr, err: stopErr },
-                'agent_stop_session_failed',
-              );
+              await finalizeReply();
             }
             return;
           }
-          // usage / session_stopped: MVP 不处理
+          if (e.type === 'session_stopped') {
+            clearTyping();
+            if (
+              session &&
+              this.agentSessions.get(sessionKeyStr)?.session === session
+            ) {
+              this.agentSessions.delete(sessionKeyStr);
+            }
+            return;
+          }
+          // usage / thinking: MVP 不处理
         } catch (handlerErr) {
           this.logger.error(
             {
@@ -288,13 +503,36 @@ export class Engine {
         }
       };
 
-      this.agent.onEvent(session, handler);
+      const activeSession = this.getOrStartSession(event, sessionKeyStr);
+      session = activeSession.session;
+      activeSession.currentTurn = {
+        eventId: event.eventId,
+        pending: new Set(),
+        handle: handler,
+      };
+      const turnState = activeSession.currentTurn;
 
-      await this.agent.sendInput(session, {
-        type: 'user_message',
-        text: prompt,
-        traceId: event.traceId,
-      });
+      startTyping();
+      let sendInputErr: unknown;
+      try {
+        await this.agent.sendInput(session, {
+          type: 'user_message',
+          text: prompt,
+          traceId: event.traceId,
+        });
+      } catch (err) {
+        sendInputErr = err;
+      } finally {
+        while (turnState.pending.size > 0) {
+          await Promise.all([...turnState.pending]);
+        }
+        clearTyping();
+        cancelPendingEdit();
+        if (activeSession.currentTurn?.eventId === event.eventId) {
+          activeSession.currentTurn = undefined;
+        }
+      }
+      if (sendInputErr) throw sendInputErr;
     } catch (err) {
       this.logger.error(
         {
@@ -307,4 +545,93 @@ export class Engine {
     }
   }
 
+  private getOrStartSession(
+    event: NormalizedEvent,
+    sessionKeyStr: string,
+  ): ActiveAgentSession {
+    const active = this.agentSessions.get(sessionKeyStr);
+    if (active) {
+      try {
+        if (this.agent.isAlive(active.session)) return active;
+      } catch (err) {
+        this.logger.warn(
+          { traceId: event.traceId, sessionKey: sessionKeyStr, err },
+          'agent_is_alive_failed',
+        );
+      }
+      try {
+        this.agent.stopSession(active.session);
+      } catch (err) {
+        this.logger.error(
+          { traceId: event.traceId, sessionKey: sessionKeyStr, err },
+          'agent_stop_session_failed',
+        );
+      }
+      this.agentSessions.delete(sessionKeyStr);
+    }
+
+    const prevAgentSessionId = this.sessionStore.get(
+      event.sessionKey,
+    )?.agentSessionId;
+    const config: SessionConfig = {
+      ...this.defaultSessionConfig,
+      sessionId: randomUUID(),
+      resumeFromAgentSessionId: prevAgentSessionId,
+    };
+    const session = this.agent.startSession(event.sessionKey, config);
+    const activeSession: ActiveAgentSession = { session };
+    this.agentSessions.set(sessionKeyStr, activeSession);
+    this.agent.onEvent(session, async (agentEvent) => {
+      const current = this.agentSessions.get(sessionKeyStr);
+      if (current !== activeSession) return;
+      const turn = current.currentTurn;
+      if (!turn) {
+        if (agentEvent.type === 'session_stopped') {
+          this.agentSessions.delete(sessionKeyStr);
+          return;
+        }
+        this.logger.debug(
+          {
+            traceId: agentEvent.traceId,
+            sessionKey: sessionKeyStr,
+            eventType: agentEvent.type,
+          },
+          'agent_event_without_turn',
+        );
+        return;
+      }
+      const handled = turn
+        .handle(agentEvent)
+        .catch((err) => {
+          this.logger.error(
+            {
+              traceId: agentEvent.traceId,
+              sessionKey: sessionKeyStr,
+              err,
+            },
+            'agent_event_handler_failed',
+          );
+        });
+      const tracked = handled.finally(() => {
+        turn.pending.delete(tracked);
+      });
+      turn.pending.add(tracked);
+      await tracked;
+    });
+    return activeSession;
+  }
+
+  private stopActiveSession(sessionKeyStr: string, traceId: string): void {
+    const active = this.agentSessions.get(sessionKeyStr);
+    if (!active) return;
+    this.agentSessions.delete(sessionKeyStr);
+    try {
+      this.agent.stopSession(active.session);
+    } catch (err) {
+      this.logger.error(
+        { traceId, sessionKey: sessionKeyStr, err },
+        'agent_stop_session_failed',
+      );
+    }
+  }
 }

--- a/packages/platform/discord/src/index.test.ts
+++ b/packages/platform/discord/src/index.test.ts
@@ -3,6 +3,7 @@ import type { Message } from 'discord.js';
 import {
   buildBotMentionRegex,
   buildSlices,
+  createDiscordPlatform,
   parseInbound,
   PartialSendError,
   SLICE_SIZE,
@@ -24,6 +25,18 @@ const OTHER_ID = '900000000000000002';
 // 让既有测试聚焦于"非 allowlist 维度"（mention / bot guard / self / system）；
 // allowlist 自身的 fail-closed 行为在末尾的独立 describe 块里测。
 const ALLOWED: readonly string[] = [OTHER_ID, 'U7', 'U-init', 'U_X'];
+
+function makeLogger() {
+  return {
+    trace: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    fatal: vi.fn(),
+    child: vi.fn(),
+  };
+}
 
 function makeMsg(overrides: {
   content: string;
@@ -197,6 +210,30 @@ describe('PartialSendError', () => {
     expect(ownKeys).toContain('sentIds');
     expect(ownKeys).toContain('totalSlices');
     expect(ownKeys).toContain('cause');
+  });
+});
+
+describe('typing no-op contract', () => {
+  it('supportsTypingIndicator=false 时 setTyping / clearTyping 幂等不抛', async () => {
+    const platform = createDiscordPlatform({
+      token: 'test-token',
+      botUserId: BOT_ID,
+      logger: makeLogger(),
+      statePath: '/tmp/agent-nexus-discord-state-test.json',
+      allowedUserIds: ALLOWED,
+    });
+
+    expect(platform.capabilities().supportsTypingIndicator).toBe(false);
+    await expect(platform.setTyping({
+      platform: 'discord',
+      channelId: 'C1',
+      initiatorUserId: OTHER_ID,
+    })).resolves.toBeUndefined();
+    await expect(platform.clearTyping({
+      platform: 'discord',
+      channelId: 'C1',
+      initiatorUserId: OTHER_ID,
+    })).resolves.toBeUndefined();
   });
 });
 

--- a/packages/platform/discord/src/index.ts
+++ b/packages/platform/discord/src/index.ts
@@ -414,5 +414,13 @@ export function createDiscordPlatform(opts: DiscordPlatformOptions): PlatformAda
     async react(): Promise<void> {
       throw new Error('platform-discord MVP: react not supported');
     },
+
+    async setTyping(): Promise<void> {
+      // P6 will enable supportsTypingIndicator and wire the Discord typing API.
+    },
+
+    async clearTyping(): Promise<void> {
+      // No-op while supportsTypingIndicator=false.
+    },
   };
 }

--- a/packages/protocol/src/interfaces.ts
+++ b/packages/protocol/src/interfaces.ts
@@ -24,6 +24,8 @@ export interface PlatformAdapter {
   edit(ref: MessageRef, message: OutboundMessage): Promise<void>;
   delete(ref: MessageRef): Promise<void>;
   react(ref: MessageRef, emoji: string): Promise<void>;
+  setTyping(sessionKey: SessionKey): Promise<void>;
+  clearTyping(sessionKey: SessionKey): Promise<void>;
 }
 
 /** docs/dev/spec/agent-runtime.md §AgentRuntime */


### PR DESCRIPTION
## Summary

P5 / PR-C 接上 #94 的长驻 stream-json runtime：daemon 不再每个 turn 关闭 agent session，而是按 SessionKey 复用活跃 AgentSession，并把 stream-json 的文本、工具事件和 turn 终态映射到平台回送。

本 PR：
- 让 daemon 为每个 SessionKey 持有一个活跃 AgentSession，`/new` / `Engine.stop()` / error 才关闭 session。
- 用单个持久 agent event handler 路由到当前 turn，避免 Claude runtime EventEmitter listener 累积。
- 支持 `text_delta` 流式回送：`supportsEdit=true` 时先 send 建 ref，再节流 edit，`turn_finished` 立即 final flush。
- 支持 tool event 最小可见性，且不把完整 `tool_result` 内容转发到 IM。
- 增加 protocol typing primitive，daemon 按 `supportsTypingIndicator` gate `setTyping` / `clearTyping`；Discord adapter 先保持 unsupported no-op，真实能力留 P6。

## Why

这是 ADR-0012 PR-C 的 daemon engine 集成层，用来让 #94 的长驻 stream-json runtime 在 daemon 主路径上真正被复用，并让平台层能看到流式文本、typing 和工具事件。

ADR: `docs/dev/adr/0012-claudecode-stream-json-mainline.md` §PR-C 最小集成契约
Spec: `docs/dev/spec/message-protocol.md`、`docs/dev/spec/platform-adapter.md`、`docs/dev/spec/infra/cost-and-limits.md`

## Test plan

- [x] Tests: `packages/daemon/src/engine.test.ts` 覆盖 session 复用、listener 不累积、handler drain、edit final flush、typing 清理、tool 可见性和错误吞吐。
- [x] Tests: `packages/platform/discord/src/index.test.ts` 覆盖 typing unsupported no-op 合约。
- [x] `corepack pnpm vitest run packages/daemon/src/engine.test.ts` — 23 tests passed
- [x] `corepack pnpm vitest run packages/platform/discord/src/index.test.ts` — 48 tests passed
- [x] `corepack pnpm test` — 13 files passed, 212 tests passed
- [x] `corepack pnpm typecheck` — passed
- [x] `git diff --check` — passed

## Review notes

- Independent agent review: explorer subagent `019e54bc-953c-7cf1-8954-eda1e6516c1f` reviewed daemon entry points, mock shape, required tests, and confirmed P5 should stop closing session every turn.
- Deep review: `/home/node/agent-nexus-epics/stream-json-migration/reviews/p5-draft-1779538169/` — 3-round adversarial review. Round 1 found listener accumulation and concurrency blockers; fixes landed. Round 3 scope review found no new blocker/important and said further review would be overdone.
- PR diff review: `/home/node/agent-nexus-epics/stream-json-migration/reviews/p5-pr96-diff-1779539564/` — found one important missing Discord typing no-op test; fixed in commit `2743447`.

## Out of scope

- Enabling Discord `supportsEdit=true` / `supportsTypingIndicator=true` and wiring real Discord edit/typing APIs; that is P6.
- End-to-end IM verification script; that is P7.
- Idle timeout, `/end`, `/resume`, budget and full session persistence state machine.