### PR TITLE
feat(platform-discord): 让 stream-json 回复在 Discord 原地更新

### DIFF
--- a/packages/platform/discord/src/index.test.ts
+++ b/packages/platform/discord/src/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Message } from 'discord.js';
 import {
   buildBotMentionRegex,
@@ -9,6 +9,28 @@ import {
   SLICE_SIZE,
   type ParsedInbound,
 } from './index.js';
+
+const discordMock = vi.hoisted(() => ({
+  channelsFetch: vi.fn(),
+  clientDestroy: vi.fn(async () => undefined),
+  clientLogin: vi.fn(async () => 'logged-in'),
+  clientOn: vi.fn(),
+}));
+
+vi.mock('discord.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('discord.js')>();
+  return {
+    ...actual,
+    Client: vi.fn(() => ({
+      channels: { fetch: discordMock.channelsFetch },
+      destroy: discordMock.clientDestroy,
+      login: discordMock.clientLogin,
+      on: discordMock.clientOn,
+      application: { commands: undefined },
+      user: { id: '900000000000000001', tag: 'bot#0000' },
+    })),
+  };
+});
 
 /** 解包 `kind: 'event'`；otherwise 抛——让断言失败时直接看到 drop reason。 */
 function expectEvent(r: ParsedInbound) {
@@ -25,6 +47,10 @@ const OTHER_ID = '900000000000000002';
 // 让既有测试聚焦于"非 allowlist 维度"（mention / bot guard / self / system）；
 // allowlist 自身的 fail-closed 行为在末尾的独立 describe 块里测。
 const ALLOWED: readonly string[] = [OTHER_ID, 'U7', 'U-init', 'U_X'];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
 
 function makeLogger() {
   return {
@@ -69,6 +95,35 @@ function makeMsg(overrides: {
       bot: authorBot,
     },
   } as unknown as Message;
+}
+
+function makePlatform() {
+  return createDiscordPlatform({
+    token: 'test-token',
+    botUserId: BOT_ID,
+    logger: makeLogger(),
+    statePath: '/tmp/agent-nexus-discord-state-test.json',
+    allowedUserIds: ALLOWED,
+  });
+}
+
+function makeTextChannel(overrides: {
+  edit?: ReturnType<typeof vi.fn>;
+  delete?: ReturnType<typeof vi.fn>;
+  send?: ReturnType<typeof vi.fn>;
+  sendTyping?: ReturnType<typeof vi.fn>;
+  sendable?: boolean;
+} = {}) {
+  return {
+    isTextBased: () => true,
+    isSendable: () => overrides.sendable ?? true,
+    messages: {
+      edit: overrides.edit ?? vi.fn(async (id: string) => ({ id })),
+      delete: overrides.delete ?? vi.fn(async () => undefined),
+    },
+    send: overrides.send ?? vi.fn(async () => ({ id: 'new-1' })),
+    sendTyping: overrides.sendTyping ?? vi.fn(async () => undefined),
+  };
 }
 
 describe('buildSlices', () => {
@@ -213,22 +268,279 @@ describe('PartialSendError', () => {
   });
 });
 
-describe('typing no-op contract', () => {
-  it('supportsTypingIndicator=false 时 setTyping / clearTyping 幂等不抛', async () => {
+describe('edit / typing capabilities', () => {
+  it('声明 supportsEdit=true 和 supportsTypingIndicator=true', () => {
+    const platform = makePlatform();
+
+    expect(platform.capabilities()).toMatchObject({
+      supportsEdit: true,
+      supportsTypingIndicator: true,
+    });
+  });
+
+  it('edit 单片消息：用 MessageManager.edit 更新已有 message id', async () => {
+    const edit = vi.fn(async (id: string) => ({ id }));
+    discordMock.channelsFetch.mockResolvedValueOnce(makeTextChannel({ edit }));
+    const platform = makePlatform();
+    const ref = {
+      platform: 'discord',
+      channelId: 'C1',
+      messageId: 'm-1',
+      messageIds: ['m-1'],
+      sentAt: new Date(0),
+    };
+
+    await platform.edit(ref, {
+      text: 'updated',
+      traceId: 't-1',
+      sessionKey: { platform: 'discord', channelId: 'C1', initiatorUserId: OTHER_ID },
+    });
+
+    expect(edit).toHaveBeenCalledWith('m-1', 'updated');
+    expect(ref.messageIds).toEqual(['m-1']);
+    expect(ref.messageId).toBe('m-1');
+  });
+
+  it('edit 增长到多片：追加发送新 slice 并回写 MessageRef', async () => {
+    const edit = vi.fn(async (id: string) => ({ id }));
+    const send = vi.fn(async () => ({ id: 'm-2' }));
+    discordMock.channelsFetch.mockResolvedValueOnce(makeTextChannel({ edit, send }));
+    const platform = makePlatform();
+    const ref = {
+      platform: 'discord',
+      channelId: 'C1',
+      messageId: 'm-1',
+      messageIds: ['m-1'],
+      sentAt: new Date(0),
+    };
+    const text = 'x'.repeat(SLICE_SIZE + 1);
+
+    await platform.edit(ref, {
+      text,
+      traceId: 't-1',
+      sessionKey: { platform: 'discord', channelId: 'C1', initiatorUserId: OTHER_ID },
+    });
+
+    expect(edit).toHaveBeenCalledWith('m-1', 'x'.repeat(SLICE_SIZE));
+    expect(send).toHaveBeenCalledWith('x');
+    expect(ref.messageIds).toEqual(['m-1', 'm-2']);
+    expect(ref.messageId).toBe('m-2');
+  });
+
+  it('edit 收缩到更少片：删除多余旧片并回写 MessageRef', async () => {
+    const edit = vi.fn(async (id: string) => ({ id }));
+    const deleteMessage = vi.fn(async () => undefined);
+    discordMock.channelsFetch.mockResolvedValueOnce(makeTextChannel({ edit, delete: deleteMessage }));
+    const platform = makePlatform();
+    const ref = {
+      platform: 'discord',
+      channelId: 'C1',
+      messageId: 'm-2',
+      messageIds: ['m-1', 'm-2'],
+      sentAt: new Date(0),
+    };
+
+    await platform.edit(ref, {
+      text: 'short',
+      traceId: 't-1',
+      sessionKey: { platform: 'discord', channelId: 'C1', initiatorUserId: OTHER_ID },
+    });
+
+    expect(edit).toHaveBeenCalledWith('m-1', 'short');
+    expect(deleteMessage).toHaveBeenCalledWith('m-2');
+    expect(ref.messageIds).toEqual(['m-1']);
+    expect(ref.messageId).toBe('m-1');
+  });
+
+  it('edit 增长中途 send 失败：保留已发送新片 id，下一次从断点继续', async () => {
+    const edit = vi.fn(async (id: string) => ({ id }));
+    const sendErr = new Error('send extra failed');
+    const send = vi
+      .fn()
+      .mockResolvedValueOnce({ id: 'm-2' })
+      .mockRejectedValueOnce(sendErr)
+      .mockResolvedValueOnce({ id: 'm-3' });
+    discordMock.channelsFetch.mockResolvedValue(makeTextChannel({ edit, send }));
+    const platform = makePlatform();
+    const ref = {
+      platform: 'discord',
+      channelId: 'C1',
+      messageId: 'm-1',
+      messageIds: ['m-1'],
+      sentAt: new Date(0),
+    };
+    const text = 'x'.repeat(SLICE_SIZE * 2 + 1);
+
+    await expect(platform.edit(ref, {
+      text,
+      traceId: 't-1',
+      sessionKey: { platform: 'discord', channelId: 'C1', initiatorUserId: OTHER_ID },
+    })).rejects.toBe(sendErr);
+    expect(ref.messageIds).toEqual(['m-1', 'm-2']);
+    expect(ref.messageId).toBe('m-2');
+
+    await platform.edit(ref, {
+      text,
+      traceId: 't-2',
+      sessionKey: { platform: 'discord', channelId: 'C1', initiatorUserId: OTHER_ID },
+    });
+
+    expect(send).toHaveBeenCalledTimes(3);
+    expect(ref.messageIds).toEqual(['m-1', 'm-2', 'm-3']);
+    expect(ref.messageId).toBe('m-3');
+  });
+
+  it('edit 收缩中途 delete 失败：已删除 id 先从 ref 移除，下一次从断点继续', async () => {
+    const edit = vi.fn(async (id: string) => ({ id }));
+    const deleteErr = new Error('delete failed');
+    const deleteMessage = vi
+      .fn()
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(deleteErr)
+      .mockResolvedValueOnce(undefined);
+    discordMock.channelsFetch.mockResolvedValue(makeTextChannel({ edit, delete: deleteMessage }));
+    const platform = makePlatform();
+    const ref = {
+      platform: 'discord',
+      channelId: 'C1',
+      messageId: 'm-3',
+      messageIds: ['m-1', 'm-2', 'm-3'],
+      sentAt: new Date(0),
+    };
+
+    await expect(platform.edit(ref, {
+      text: 'short',
+      traceId: 't-1',
+      sessionKey: { platform: 'discord', channelId: 'C1', initiatorUserId: OTHER_ID },
+    })).rejects.toBe(deleteErr);
+    expect(ref.messageIds).toEqual(['m-1', 'm-3']);
+    expect(ref.messageId).toBe('m-3');
+
+    await platform.edit(ref, {
+      text: 'short',
+      traceId: 't-2',
+      sessionKey: { platform: 'discord', channelId: 'C1', initiatorUserId: OTHER_ID },
+    });
+
+    expect(deleteMessage).toHaveBeenNthCalledWith(1, 'm-2');
+    expect(deleteMessage).toHaveBeenNthCalledWith(2, 'm-3');
+    expect(deleteMessage).toHaveBeenNthCalledWith(3, 'm-3');
+    expect(ref.messageIds).toEqual(['m-1']);
+    expect(ref.messageId).toBe('m-1');
+  });
+
+  it('同一 MessageRef 的并发 edit 串行化，增长片只发送一次', async () => {
+    let releaseFirstEdit: (() => void) | undefined;
+    const firstEditStarted = new Promise<void>((resolve) => {
+      const edit = vi.fn(async (id: string) => {
+        if (id === 'm-1' && edit.mock.calls.length === 1) {
+          resolve();
+          await new Promise<void>((release) => {
+            releaseFirstEdit = release;
+          });
+        }
+        return { id };
+      });
+      const send = vi.fn(async () => ({ id: 'm-2' }));
+      discordMock.channelsFetch.mockResolvedValue(makeTextChannel({ edit, send }));
+    });
+    const platform = makePlatform();
+    const ref = {
+      platform: 'discord',
+      channelId: 'C1',
+      messageId: 'm-1',
+      messageIds: ['m-1'],
+      sentAt: new Date(0),
+    };
+    const text = 'x'.repeat(SLICE_SIZE + 1);
+
+    const p1 = platform.edit(ref, {
+      text,
+      traceId: 't-1',
+      sessionKey: { platform: 'discord', channelId: 'C1', initiatorUserId: OTHER_ID },
+    });
+    await firstEditStarted;
+    const p2 = platform.edit(ref, {
+      text,
+      traceId: 't-2',
+      sessionKey: { platform: 'discord', channelId: 'C1', initiatorUserId: OTHER_ID },
+    });
+
+    releaseFirstEdit?.();
+    await Promise.all([p1, p2]);
+
+    const channel = await discordMock.channelsFetch.mock.results[0]!.value;
+    expect(channel.send).toHaveBeenCalledTimes(1);
+    expect(ref.messageIds).toEqual(['m-1', 'm-2']);
+  });
+
+  it('setTyping 调用 Discord sendTyping', async () => {
+    const sendTyping = vi.fn(async () => undefined);
+    discordMock.channelsFetch.mockResolvedValueOnce(makeTextChannel({ sendTyping }));
+    const platform = makePlatform();
+
+    await platform.setTyping({
+      platform: 'discord',
+      channelId: 'C1',
+      initiatorUserId: OTHER_ID,
+    });
+
+    expect(sendTyping).toHaveBeenCalledTimes(1);
+  });
+
+  it('setTyping 在 fetch 或 sendTyping 失败时吞错并写 debug', async () => {
+    const logger = makeLogger();
     const platform = createDiscordPlatform({
       token: 'test-token',
       botUserId: BOT_ID,
-      logger: makeLogger(),
+      logger,
       statePath: '/tmp/agent-nexus-discord-state-test.json',
       allowedUserIds: ALLOWED,
     });
+    const fetchErr = new Error('fetch failed');
+    discordMock.channelsFetch.mockRejectedValueOnce(fetchErr);
 
-    expect(platform.capabilities().supportsTypingIndicator).toBe(false);
     await expect(platform.setTyping({
       platform: 'discord',
       channelId: 'C1',
       initiatorUserId: OTHER_ID,
     })).resolves.toBeUndefined();
+
+    expect(logger.debug).toHaveBeenCalledWith(
+      { err: fetchErr, channelId: 'C1' },
+      'discord_typing_failed',
+    );
+  });
+
+  it('setTyping 在 sendTyping 失败时也吞错并写 debug', async () => {
+    const logger = makeLogger();
+    const typingErr = new Error('typing failed');
+    discordMock.channelsFetch.mockResolvedValueOnce(
+      makeTextChannel({ sendTyping: vi.fn(async () => Promise.reject(typingErr)) }),
+    );
+    const platform = createDiscordPlatform({
+      token: 'test-token',
+      botUserId: BOT_ID,
+      logger,
+      statePath: '/tmp/agent-nexus-discord-state-test.json',
+      allowedUserIds: ALLOWED,
+    });
+
+    await expect(platform.setTyping({
+      platform: 'discord',
+      channelId: 'C1',
+      initiatorUserId: OTHER_ID,
+    })).resolves.toBeUndefined();
+
+    expect(logger.debug).toHaveBeenCalledWith(
+      { err: typingErr, channelId: 'C1' },
+      'discord_typing_failed',
+    );
+  });
+
+  it('clearTyping 幂等不抛', async () => {
+    const platform = makePlatform();
+
     await expect(platform.clearTyping({
       platform: 'discord',
       channelId: 'C1',

--- a/packages/platform/discord/src/index.test.ts
+++ b/packages/platform/discord/src/index.test.ts
@@ -327,6 +327,71 @@ describe('edit / typing capabilities', () => {
     expect(ref.messageId).toBe('m-2');
   });
 
+  it('edit 多片数量不变：只 edit 既有片，不 send / delete，ref 不变', async () => {
+    const edit = vi.fn(async (id: string) => ({ id }));
+    const send = vi.fn(async () => ({ id: 'new' }));
+    const deleteMessage = vi.fn(async () => undefined);
+    discordMock.channelsFetch.mockResolvedValueOnce(makeTextChannel({ edit, send, delete: deleteMessage }));
+    const platform = makePlatform();
+    const ref = {
+      platform: 'discord',
+      channelId: 'C1',
+      messageId: 'm-2',
+      messageIds: ['m-1', 'm-2'],
+      sentAt: new Date(0),
+    };
+    const text = 'y'.repeat(SLICE_SIZE + 1);
+
+    await platform.edit(ref, {
+      text,
+      traceId: 't-1',
+      sessionKey: { platform: 'discord', channelId: 'C1', initiatorUserId: OTHER_ID },
+    });
+
+    expect(edit).toHaveBeenNthCalledWith(1, 'm-1', 'y'.repeat(SLICE_SIZE));
+    expect(edit).toHaveBeenNthCalledWith(2, 'm-2', 'y');
+    expect(send).not.toHaveBeenCalled();
+    expect(deleteMessage).not.toHaveBeenCalled();
+    expect(ref.messageIds).toEqual(['m-1', 'm-2']);
+    expect(ref.messageId).toBe('m-2');
+  });
+
+  it('edit 在 channel 不存在或非 text-based 时拒绝', async () => {
+    discordMock.channelsFetch.mockResolvedValueOnce(null);
+    const platform = makePlatform();
+
+    await expect(platform.edit({
+      platform: 'discord',
+      channelId: 'missing',
+      messageId: 'm-1',
+      messageIds: ['m-1'],
+      sentAt: new Date(0),
+    }, {
+      text: 'updated',
+      traceId: 't-1',
+      sessionKey: { platform: 'discord', channelId: 'missing', initiatorUserId: OTHER_ID },
+    })).rejects.toThrow('not text-based or not found');
+  });
+
+  it('edit 增长到新片但 channel 不可 send 时拒绝', async () => {
+    discordMock.channelsFetch.mockResolvedValueOnce(
+      makeTextChannel({ sendable: false }),
+    );
+    const platform = makePlatform();
+
+    await expect(platform.edit({
+      platform: 'discord',
+      channelId: 'C1',
+      messageId: 'm-1',
+      messageIds: ['m-1'],
+      sentAt: new Date(0),
+    }, {
+      text: 'z'.repeat(SLICE_SIZE + 1),
+      traceId: 't-1',
+      sessionKey: { platform: 'discord', channelId: 'C1', initiatorUserId: OTHER_ID },
+    })).rejects.toThrow('cannot send extra edit slices');
+  });
+
   it('edit 收缩到更少片：删除多余旧片并回写 MessageRef', async () => {
     const edit = vi.fn(async (id: string) => ({ id }));
     const deleteMessage = vi.fn(async () => undefined);

--- a/packages/platform/discord/src/index.ts
+++ b/packages/platform/discord/src/index.ts
@@ -3,7 +3,7 @@ export { parseDiscordConfig, type DiscordConfig, DiscordConfigError } from './co
 // TODO MVP 跳过：
 // - DM 消息（intents 没开 DirectMessages）
 // - 长文本切片保留代码块边界 → docs/dev/spec/message-protocol.md §文本切片
-// - edit / delete / react / typing → spec/platform-adapter.md 各对应段
+// - delete / react → spec/platform-adapter.md 各对应段
 // - threads → 同上
 
 import { randomUUID } from 'node:crypto';
@@ -242,6 +242,23 @@ export function createDiscordPlatform(opts: DiscordPlatformOptions): PlatformAda
   let stopped = false;
   // 启动时从 state 文件读，缺省 'mention'。运行时由 /reply-mode 切换更新。
   let replyMode: ReplyMode = 'mention';
+  const editLocks = new WeakMap<MessageRef, Promise<void>>();
+
+  const runSerializedEdit = async (
+    ref: MessageRef,
+    task: () => Promise<void>,
+  ): Promise<void> => {
+    const prev = editLocks.get(ref) ?? Promise.resolve();
+    const next = prev.catch(() => {}).then(task);
+    editLocks.set(ref, next);
+    try {
+      await next;
+    } finally {
+      if (editLocks.get(ref) === next) {
+        editLocks.delete(ref);
+      }
+    }
+  };
 
   return {
     name() {
@@ -251,7 +268,7 @@ export function createDiscordPlatform(opts: DiscordPlatformOptions): PlatformAda
     capabilities(): CapabilitySet {
       return {
         maxTextLength: 2000,
-        supportsEdit: false,
+        supportsEdit: true,
         supportsDelete: false,
         supportsReactions: false,
         supportsEmbeds: false,
@@ -260,7 +277,7 @@ export function createDiscordPlatform(opts: DiscordPlatformOptions): PlatformAda
         supportsEphemeral: false,
         supportsAttachments: false,
         maxAttachmentsPerMessage: 0,
-        supportsTypingIndicator: false,
+        supportsTypingIndicator: true,
       };
     },
 
@@ -403,8 +420,49 @@ export function createDiscordPlatform(opts: DiscordPlatformOptions): PlatformAda
       };
     },
 
-    async edit(): Promise<void> {
-      throw new Error('platform-discord MVP: edit not supported');
+    async edit(ref: MessageRef, message: OutboundMessage): Promise<void> {
+      await runSerializedEdit(ref, async () => {
+        const channel = await client.channels.fetch(ref.channelId);
+        if (!channel || !channel.isTextBased()) {
+          throw new Error(
+            `platform-discord: channel ${ref.channelId} is not text-based or not found`,
+          );
+        }
+
+        const slices = buildSlices(message.text);
+        const existingIds = [...ref.messageIds];
+
+        for (let i = 0; i < Math.min(slices.length, existingIds.length); i++) {
+          await channel.messages.edit(existingIds[i]!, slices[i]!);
+        }
+
+        if (slices.length > existingIds.length) {
+          if (!channel.isSendable()) {
+            throw new Error(
+              `platform-discord: channel ${ref.channelId} cannot send extra edit slices`,
+            );
+          }
+          for (const slice of slices.slice(existingIds.length)) {
+            const sent = await channel.send(slice);
+            ref.messageIds.push(sent.id);
+            ref.messageId = sent.id;
+          }
+        }
+
+        if (existingIds.length > slices.length) {
+          for (const id of existingIds.slice(slices.length)) {
+            await channel.messages.delete(id);
+            const index = ref.messageIds.indexOf(id);
+            if (index >= 0) ref.messageIds.splice(index, 1);
+          }
+        }
+
+        const lastId = ref.messageIds[ref.messageIds.length - 1];
+        if (lastId === undefined) {
+          throw new Error('platform-discord: edit produced no message refs');
+        }
+        ref.messageId = lastId;
+      });
     },
 
     async delete(): Promise<void> {
@@ -415,12 +473,34 @@ export function createDiscordPlatform(opts: DiscordPlatformOptions): PlatformAda
       throw new Error('platform-discord MVP: react not supported');
     },
 
-    async setTyping(): Promise<void> {
-      // P6 will enable supportsTypingIndicator and wire the Discord typing API.
+    async setTyping(sessionKey: SessionKey): Promise<void> {
+      try {
+        const channel = await client.channels.fetch(sessionKey.channelId);
+        if (!channel || !channel.isTextBased()) {
+          logger.debug(
+            { channelId: sessionKey.channelId },
+            'discord_typing_channel_unavailable',
+          );
+          return;
+        }
+        if (!('sendTyping' in channel) || typeof channel.sendTyping !== 'function') {
+          logger.debug(
+            { channelId: sessionKey.channelId },
+            'discord_typing_channel_unavailable',
+          );
+          return;
+        }
+        await channel.sendTyping();
+      } catch (err) {
+        logger.debug(
+          { err, channelId: sessionKey.channelId },
+          'discord_typing_failed',
+        );
+      }
     },
 
     async clearTyping(): Promise<void> {
-      // No-op while supportsTypingIndicator=false.
+      // Discord has no explicit clear API; typing expires automatically.
     },
   };
 }


### PR DESCRIPTION
## Summary

P6 / PR-D 把 P5 daemon 已消费的 edit/typing capability 接到 Discord adapter：stream-json 回复现在可以通过 Discord message edit 原地更新，typing 周期调用也会落到 Discord `sendTyping()`。

本 PR：
- 将 Discord capability 改为 `supportsEdit: true` 和 `supportsTypingIndicator: true`。
- 实现 `edit(ref, message)`：按 `buildSlices()` 更新已有消息片，文本增长时追加新片并回写 `MessageRef`，文本收缩时删除多余旧片并回写 `MessageRef`。
- 对同一个 `MessageRef` 串行化 edit，避免 daemon 的节流 edit 与 final edit 并发触发重复追加消息。
- 实现 `setTyping(sessionKey)` 到 Discord `sendTyping()`，失败只写 debug 并吞掉；`clearTyping()` 保持 Discord 平台限制下的幂等 no-op。
- 用 hoisted `discord.js` Client mock 直接覆盖 `createDiscordPlatform().edit/setTyping/clearTyping`，不再只测复制 helper。

## Why

这是 ADR-0012 PR-D：P5 daemon 已经会在 `supportsEdit` / `supportsTypingIndicator` 为 true 时调用 platform primitive；Discord adapter 必须真实实现这些能力，才能让 stream-json 主路径在 IM 端显示流式文本和 typing。

ADR: `docs/dev/adr/0012-claudecode-stream-json-mainline.md` §决策点 3 / PR-C 最小集成契约
Spec: `docs/dev/spec/platform-adapter.md`、`docs/dev/spec/infra/cost-and-limits.md`

## Test plan

- [x] Tests: `packages/platform/discord/src/index.test.ts` 覆盖 capability、单片 edit、多片等量 edit、多片增长/收缩、错误分支、partial failure retry、同 ref 并发 edit 串行、typing 成功/失败吞吐、clearTyping 幂等。
- [x] `corepack pnpm vitest run packages/platform/discord/src/index.test.ts` — 61 tests passed
- [x] `corepack pnpm test` — 13 files passed, 225 tests passed
- [x] `corepack pnpm typecheck` — passed
- [x] `git diff --check` — passed

## Review notes

- Independent agent review: N/A。P6 主要是单 adapter 落地；按 GOAL 要求使用 adversarial review 覆盖 draft 和 PR diff。
- Deep review: `/home/node/agent-nexus-epics/stream-json-migration/reviews/p6-draft-1779540450/` — 3-round draft GAN。Round 1/2 找到长回复 MessageRef 增长、真实 mock 覆盖、partial failure 与并发 edit 问题；Round 3 判定无 blocker/important，建议收口。
- PR diff review: `/home/node/agent-nexus-epics/stream-json-migration/reviews/p6-pr97-diff-1779541577/` — Round 1 found one important missing edit error-path test; fixed in commit `b1f933e`; Round 2 verified resolved with no new blocker/important and recommended merge.

## Out of scope

- Discord delete/react/embed/thread/attachment 能力。
- P7 `scripts/verify-stream-json.sh` 端到端验证。
- 长文本切片保留代码块/grapheme cluster 边界优化。