### PR TITLE
feat(cli): 支持打包 npm 二进制入口

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,8 @@ jobs:
           set -e
 
           test "$code" -eq 1
-          grep -q "agent-nexus 配置缺失" "$tmp/agent-nexus.out"
+          grep -q "agent-nexus 配置模板已创建" "$tmp/agent-nexus.out"
           test "$(stat -c '%a' "$HOME/.agent-nexus")" = "700"
           test "$(stat -c '%a' "$HOME/.agent-nexus/secrets")" = "700"
+          test "$(stat -c '%a' "$HOME/.agent-nexus/config.json")" = "600"
+          test "$(stat -c '%a' "$HOME/.agent-nexus/secrets/DISCORD_BOT_TOKEN")" = "600"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,21 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - run: pnpm typecheck
+      - run: pnpm build
 
       - run: pnpm test
+
+      - run: pnpm pack:cli
+
+      - name: Smoke test packed CLI
+        run: |
+          tmp="$(mktemp -d)"
+          npm install --prefix "$tmp" packages/cli/agent-nexus-cli-*.tgz
+
+          set +e
+          "$tmp/node_modules/.bin/agent-nexus" >"$tmp/agent-nexus.out" 2>&1
+          code=$?
+          set -e
+
+          test "$code" -eq 1
+          grep -q "agent-nexus 配置缺失" "$tmp/agent-nexus.out"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,12 +35,15 @@ jobs:
       - name: Smoke test packed CLI
         run: |
           tmp="$(mktemp -d)"
-          npm install --prefix "$tmp" packages/cli/agent-nexus-cli-*.tgz
+          export HOME="$tmp/home"
+          npm install --prefix "$tmp/install" packages/cli/agent-nexus-cli-*.tgz
 
           set +e
-          "$tmp/node_modules/.bin/agent-nexus" >"$tmp/agent-nexus.out" 2>&1
+          "$tmp/install/node_modules/.bin/agent-nexus" >"$tmp/agent-nexus.out" 2>&1
           code=$?
           set -e
 
           test "$code" -eq 1
           grep -q "agent-nexus 配置缺失" "$tmp/agent-nexus.out"
+          test "$(stat -c '%a' "$HOME/.agent-nexus")" = "700"
+          test "$(stat -c '%a' "$HOME/.agent-nexus/secrets")" = "700"

--- a/README.md
+++ b/README.md
@@ -49,9 +49,10 @@ agent-nexus 让你在 IM（当前：Discord）里直接和本机 Claude Code 对
 
 ```bash
 pnpm install
-pnpm build         # tsc --build；产物 packages/*/dist/
+pnpm build         # tsc --build；CLI 入口会额外 bundle 成 npm bin
+pnpm pack:cli      # 产物 packages/cli/agent-nexus-cli-*.tgz
 pnpm test          # vitest 全量
-pnpm typecheck     # 等价 pnpm build
+pnpm typecheck     # 仅 tsc --build；不生成 npm bin bundle
 ```
 
 ### 3. 配置
@@ -112,7 +113,9 @@ pnpm dev
 
 ```bash
 pnpm build
-node packages/cli/dist/index.js
+pnpm pack:cli
+npm install -g packages/cli/agent-nexus-cli-*.tgz
+agent-nexus
 ```
 
 启动会先跑 CC CLI 兼容性 probe（`--version` + `--print` 探针），失败直接 `exit 1`；通过后连 Discord，看到 `discord_ready` 日志即可在频道里 `@bot ping`。

--- a/README.md
+++ b/README.md
@@ -57,14 +57,19 @@ pnpm typecheck     # 仅 tsc --build；不生成 npm bin bundle
 
 ### 3. 配置
 
-首次运行会自动创建配置目录 `~/.agent-nexus/` 和 `~/.agent-nexus/secrets/`，权限为 0700。
+首次运行会自动创建配置脚手架：
 
-写 `~/.agent-nexus/config.json`（至少含 `discord.botUserId` 和 `claudeCode.workingDir`）：
+- `~/.agent-nexus/` 和 `~/.agent-nexus/secrets/`，权限为 0700
+- `~/.agent-nexus/config.json` 模板，权限为 0600
+- `~/.agent-nexus/secrets/DISCORD_BOT_TOKEN` 空文件，权限为 0600
+
+编辑 `~/.agent-nexus/config.json`（至少填 `discord.botUserId`、`discord.allowedUserIds` 和 `claudeCode.workingDir`）：
 
 ```json
 {
   "discord": {
-    "botUserId": "1234567890123456789"
+    "botUserId": "1234567890123456789",
+    "allowedUserIds": ["2345678901234567890"]
   },
   "claudeCode": {
     "workingDir": "/path/to/your/repo",

--- a/README.md
+++ b/README.md
@@ -57,12 +57,7 @@ pnpm typecheck     # 仅 tsc --build；不生成 npm bin bundle
 
 ### 3. 配置
 
-配置目录 `~/.agent-nexus/`（权限 0700）：
-
-```bash
-mkdir -p ~/.agent-nexus/secrets
-chmod 700 ~/.agent-nexus ~/.agent-nexus/secrets
-```
+首次运行会自动创建配置目录 `~/.agent-nexus/` 和 `~/.agent-nexus/secrets/`，权限为 0700。
 
 写 `~/.agent-nexus/config.json`（至少含 `discord.botUserId` 和 `claudeCode.workingDir`）：
 

--- a/docs/dev/process/release.md
+++ b/docs/dev/process/release.md
@@ -1,38 +1,52 @@
 ---
 title: 发版流程
 type: process
-status: placeholder
-summary: 发版流程占位；本阶段尚无可发版产物，等 MVP 与 ADR-0004 后填写
+status: active
+summary: npm CLI 二进制包的本地打包、验证与发布前检查流程；版本号和正式发布渠道仍需单独 ADR 决策
 tags: [release, process]
 related:
   - dev/process/commit-and-branch
   - dev/adr/0004-language-runtime
 ---
 
-# 发版流程（占位）
+# 发版流程
 
-> **状态**：占位。本阶段（文档与规范骨架）尚无可发版的产物。本文件在 MVP 具备可运行工件、且 ADR 0004 语言选型完成后填写。
+## 当前产物
 
-## 本阶段等同发版的事
+MVP 的可安装产物是 `@agent-nexus/cli` npm 包。该包提供 `agent-nexus` 二进制入口，并在打包时把 monorepo 内部 `@agent-nexus/*` package bundle 进 `dist/index.js`；运行时只依赖 npm 可安装的第三方包。
 
-在没有代码发版概念之前，以下事件需要在 `CHANGELOG.md` 的 `[Unreleased]` 下记录：
+本流程只定义本地 tarball 与 npm 包发布前检查。正式版本号策略、tag 策略、npm organization / channel 与 release announcement 仍需单独 ADR 或 owner 决策。
 
-- 新增 / 修改 / 删除 ADR
-- 新增 / 修改 / 删除 spec
-- 新增 / 修改重大流程规范（process/）
+## 本地打包
 
-## MVP 后需要补齐的内容
+```bash
+pnpm install
+pnpm build
+pnpm pack:cli
+```
 
-下列条目在第一次发版前至少需要有草案：
+`pnpm pack:cli` 产物位于 `packages/cli/agent-nexus-cli-*.tgz`。
 
-- 版本号策略（语义化版本 / 日期版本）
-- 发布 artifact 形态（二进制 / 包 / Docker 镜像 / 桌面安装包）
-- 发布渠道（GitHub Release / npm / crate / PyPI / Homebrew / 其他）
-- 发版检查清单（CHANGELOG 完整、ADR/spec 同步、测试全绿、security review、license 核对）
-- 版本回滚策略
-- 发版公告模板
+## 安装验证
 
-## 目前的约束
+每次改变 CLI 入口、package metadata、bundle 配置或运行时依赖时，PR 必须验证 tarball 安装后的二进制入口：
 
-- 任何对"发版"的讨论必须先进 ADR（例如"采用什么版本号策略"是 ADR 题目）。
-- 禁止在本文件完善前打任何 git tag。
+```bash
+tmp="$(mktemp -d)"
+npm install --prefix "$tmp" packages/cli/agent-nexus-cli-*.tgz
+"$tmp/node_modules/.bin/agent-nexus"
+```
+
+在没有真实 `~/.agent-nexus/config.json` 和 Discord token 的环境里，二进制可以以配置缺失错误退出；验收重点是 npm 安装成功、bin shim 能启动到应用自己的配置校验，而不是因 workspace 依赖或 shebang / 权限问题在 Node loader 阶段失败。
+
+## 发布前检查
+
+发布候选必须至少通过：
+
+- `pnpm build`
+- `pnpm test`
+- `pnpm pack:cli`
+- tarball 安装验证
+- `git diff --check`
+
+涉及 ADR、spec、process 或 security 文档的发布 PR 仍按对应 owner 文档要求补 review 证据；本流程不降低代码 review 与安全 review 要求。

--- a/package.json
+++ b/package.json
@@ -8,8 +8,9 @@
   },
   "packageManager": "pnpm@10.33.2",
   "scripts": {
-    "dev": "pnpm --filter @agent-nexus/cli dev",
-    "build": "tsc --build",
+    "dev": "corepack pnpm --filter @agent-nexus/cli dev",
+    "build": "tsc --build && corepack pnpm --filter @agent-nexus/cli bundle",
+    "pack:cli": "corepack pnpm --dir packages/cli pack",
     "typecheck": "tsc --build",
     "test": "vitest run",
     "test:watch": "vitest"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,22 +1,38 @@
 {
   "name": "@agent-nexus/cli",
   "version": "0.0.0",
-  "private": true,
+  "private": false,
   "type": "module",
+  "license": "MIT",
   "bin": {
     "agent-nexus": "./dist/index.js"
   },
   "main": "./dist/index.js",
+  "files": [
+    "dist/index.js"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
-    "build": "tsc --build",
+    "build": "tsc --build && npm run bundle",
+    "bundle": "esbuild src/index.ts --bundle --platform=node --format=esm --target=node20 --conditions=development --external:discord.js --external:execa --external:pino --external:pino-pretty --outfile=dist/index.js && node -e \"require('node:fs').chmodSync('dist/index.js', 0o755)\"",
     "typecheck": "tsc --build",
     "test": "vitest run",
-    "dev": "tsx watch --conditions=development src/index.ts"
+    "dev": "tsx watch --conditions=development src/index.ts",
+    "prepack": "npm run build"
   },
   "dependencies": {
+    "discord.js": "^14.16.0",
+    "execa": "^9.5.0",
+    "pino": "^9.5.0",
+    "pino-pretty": "^11.3.0"
+  },
+  "devDependencies": {
     "@agent-nexus/agent-claudecode": "workspace:*",
     "@agent-nexus/daemon": "workspace:*",
     "@agent-nexus/platform-discord": "workspace:*",
-    "@agent-nexus/protocol": "workspace:*"
+    "@agent-nexus/protocol": "workspace:*",
+    "esbuild": "^0.27.7"
   }
 }

--- a/packages/cli/src/config.test.ts
+++ b/packages/cli/src/config.test.ts
@@ -1,4 +1,12 @@
-import { mkdtemp, rm, writeFile, chmod, mkdir, stat } from 'node:fs/promises';
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  writeFile,
+} from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -35,22 +43,28 @@ describe('config loader', () => {
     await rm(tmp, { recursive: true, force: true });
   });
 
-  it('loadConfig 缺 config.json → ConfigError，hint 含 path', async () => {
-    await expect(loadConfig()).rejects.toBeInstanceOf(ConfigError);
-    await expect(loadConfig()).rejects.toThrow(/config\.json/);
-  });
-
-  it('loadConfig 首次运行自动创建 config root 和 secrets 目录', async () => {
+  it('loadConfig 首次运行自动创建 config 模板和 token 文件', async () => {
     await rm(join(tmp, '.agent-nexus'), { recursive: true, force: true });
 
     await expect(loadConfig()).rejects.toBeInstanceOf(ConfigError);
+    await expect(loadConfig()).rejects.toThrow(/config\.json/);
 
     const root = await stat(join(tmp, '.agent-nexus'));
     const secrets = await stat(join(tmp, '.agent-nexus', 'secrets'));
+    const config = await stat(join(tmp, '.agent-nexus', 'config.json'));
+    const token = await stat(
+      join(tmp, '.agent-nexus', 'secrets', 'DISCORD_BOT_TOKEN'),
+    );
+    const configText = await readFile(join(tmp, '.agent-nexus', 'config.json'), 'utf8');
+
     expect(root.isDirectory()).toBe(true);
     expect(secrets.isDirectory()).toBe(true);
     expect(root.mode & 0o777).toBe(0o700);
     expect(secrets.mode & 0o777).toBe(0o700);
+    expect(config.mode & 0o777).toBe(0o600);
+    expect(token.mode & 0o777).toBe(0o600);
+    expect(configText).toMatch(/allowedUserIds/);
+    expect(configText).toMatch(/workingDir/);
   });
 
   it('loadConfig 缺 discord.botUserId → ConfigError（含字段名）', async () => {
@@ -134,6 +148,10 @@ describe('config loader', () => {
     await expect(loadDiscordToken()).rejects.toBeInstanceOf(
       SecretsPermissionError,
     );
+    const token = await stat(
+      join(tmp, '.agent-nexus', 'secrets', 'DISCORD_BOT_TOKEN'),
+    );
+    expect(token.mode & 0o777).toBe(0o600);
   });
 
   it('loadDiscordToken 权限非 0600 → SecretsPermissionError', async () => {

--- a/packages/cli/src/config.test.ts
+++ b/packages/cli/src/config.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, writeFile, chmod, mkdir } from 'node:fs/promises';
+import { mkdtemp, rm, writeFile, chmod, mkdir, stat } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -38,6 +38,19 @@ describe('config loader', () => {
   it('loadConfig 缺 config.json → ConfigError，hint 含 path', async () => {
     await expect(loadConfig()).rejects.toBeInstanceOf(ConfigError);
     await expect(loadConfig()).rejects.toThrow(/config\.json/);
+  });
+
+  it('loadConfig 首次运行自动创建 config root 和 secrets 目录', async () => {
+    await rm(join(tmp, '.agent-nexus'), { recursive: true, force: true });
+
+    await expect(loadConfig()).rejects.toBeInstanceOf(ConfigError);
+
+    const root = await stat(join(tmp, '.agent-nexus'));
+    const secrets = await stat(join(tmp, '.agent-nexus', 'secrets'));
+    expect(root.isDirectory()).toBe(true);
+    expect(secrets.isDirectory()).toBe(true);
+    expect(root.mode & 0o777).toBe(0o700);
+    expect(secrets.mode & 0o777).toBe(0o700);
   });
 
   it('loadConfig 缺 discord.botUserId → ConfigError（含字段名）', async () => {

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdir, readFile, stat } from 'node:fs/promises';
+import { chmod, mkdir, readFile, stat, writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -55,22 +55,33 @@ export function defaultDiscordStatePath(): string {
 }
 
 const CONFIG_HINT = (path: string) => `\
-agent-nexus 配置缺失：${path}
-配置目录已自动创建。请创建：
-  cat > ${path} <<'JSON'
-  {
-    "discord": { "botUserId": "<your-bot-user-id>" },
-    "claudeCode": { "workingDir": "/path/to/working/dir" }
-  }
-  JSON
+agent-nexus 配置模板已创建：${path}
+请编辑其中的 botUserId、allowedUserIds 和 workingDir，然后确认权限：
   chmod 600 ${path}
 `;
 
 const TOKEN_HINT = (path: string) => `\
-DISCORD_BOT_TOKEN 缺失或权限不对：${path}
-secrets 目录已自动创建。请创建 token 文件（权限必须 0600）：
+DISCORD_BOT_TOKEN 文件已创建：${path}
+请写入 token（权限必须 0600）：
   echo -n '<your-token>' > ${path}
   chmod 600 ${path}
+`;
+
+const DEFAULT_CONFIG_TEMPLATE = `\
+{
+  "discord": {
+    "botUserId": "",
+    "allowedUserIds": []
+  },
+  "claudeCode": {
+    "workingDir": "",
+    "bin": "claude",
+    "allowedTools": ["Read", "Grep", "Glob", "Edit", "Write"]
+  },
+  "log": {
+    "level": "info"
+  }
+}
 `;
 
 export async function ensureConfigDirs(): Promise<void> {
@@ -81,11 +92,46 @@ export async function ensureConfigDirs(): Promise<void> {
   await chmod(secrets, 0o700);
 }
 
-export async function loadConfig(): Promise<AgentNexusConfig> {
+async function createFileIfMissing(
+  path: string,
+  content: string,
+  mode: number,
+): Promise<boolean> {
   try {
-    await ensureConfigDirs();
+    await writeFile(path, content, { mode, flag: 'wx' });
+    await chmod(path, mode);
+    return true;
   } catch (err) {
-    throw new ConfigError(`初始化配置目录失败：${(err as Error).message}`);
+    if ((err as NodeJS.ErrnoException).code === 'EEXIST') {
+      return false;
+    }
+    throw err;
+  }
+}
+
+export async function ensureConfigScaffold(): Promise<{
+  configCreated: boolean;
+  tokenCreated: boolean;
+}> {
+  await ensureConfigDirs();
+  const configCreated = await createFileIfMissing(
+    configPath(),
+    DEFAULT_CONFIG_TEMPLATE,
+    0o600,
+  );
+  const tokenCreated = await createFileIfMissing(discordTokenPath(), '', 0o600);
+  return { configCreated, tokenCreated };
+}
+
+export async function loadConfig(): Promise<AgentNexusConfig> {
+  let scaffold;
+  try {
+    scaffold = await ensureConfigScaffold();
+  } catch (err) {
+    throw new ConfigError(`初始化配置文件失败：${(err as Error).message}`);
+  }
+  if (scaffold.configCreated) {
+    throw new ConfigError(CONFIG_HINT(configPath()));
   }
 
   const path = configPath();
@@ -149,10 +195,14 @@ export async function loadConfig(): Promise<AgentNexusConfig> {
 }
 
 export async function loadDiscordToken(): Promise<string> {
+  let scaffold;
   try {
-    await ensureConfigDirs();
+    scaffold = await ensureConfigScaffold();
   } catch (err) {
-    throw new SecretsPermissionError(`初始化 secrets 目录失败：${(err as Error).message}`);
+    throw new SecretsPermissionError(`初始化 secrets 文件失败：${(err as Error).message}`);
+  }
+  if (scaffold.tokenCreated) {
+    throw new SecretsPermissionError(TOKEN_HINT(discordTokenPath()));
   }
 
   const path = discordTokenPath();

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,4 +1,4 @@
-import { readFile, stat } from 'node:fs/promises';
+import { chmod, mkdir, readFile, stat } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -56,9 +56,7 @@ export function defaultDiscordStatePath(): string {
 
 const CONFIG_HINT = (path: string) => `\
 agent-nexus 配置缺失：${path}
-请创建：
-  mkdir -p ${join(configRoot(), 'secrets')}
-  chmod 700 ${configRoot()} ${join(configRoot(), 'secrets')}
+配置目录已自动创建。请创建：
   cat > ${path} <<'JSON'
   {
     "discord": { "botUserId": "<your-bot-user-id>" },
@@ -70,12 +68,26 @@ agent-nexus 配置缺失：${path}
 
 const TOKEN_HINT = (path: string) => `\
 DISCORD_BOT_TOKEN 缺失或权限不对：${path}
-请创建（权限必须 0600）：
+secrets 目录已自动创建。请创建 token 文件（权限必须 0600）：
   echo -n '<your-token>' > ${path}
   chmod 600 ${path}
 `;
 
+export async function ensureConfigDirs(): Promise<void> {
+  const root = configRoot();
+  const secrets = join(root, 'secrets');
+  await mkdir(secrets, { recursive: true, mode: 0o700 });
+  await chmod(root, 0o700);
+  await chmod(secrets, 0o700);
+}
+
 export async function loadConfig(): Promise<AgentNexusConfig> {
+  try {
+    await ensureConfigDirs();
+  } catch (err) {
+    throw new ConfigError(`初始化配置目录失败：${(err as Error).message}`);
+  }
+
   const path = configPath();
   let raw: string;
   try {
@@ -137,6 +149,12 @@ export async function loadConfig(): Promise<AgentNexusConfig> {
 }
 
 export async function loadDiscordToken(): Promise<string> {
+  try {
+    await ensureConfigDirs();
+  } catch (err) {
+    throw new SecretsPermissionError(`初始化 secrets 目录失败：${(err as Error).message}`);
+  }
+
   const path = discordTokenPath();
   let st;
   try {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,19 @@ importers:
 
   packages/cli:
     dependencies:
+      discord.js:
+        specifier: ^14.16.0
+        version: 14.26.3
+      execa:
+        specifier: ^9.5.0
+        version: 9.6.1
+      pino:
+        specifier: ^9.5.0
+        version: 9.14.0
+      pino-pretty:
+        specifier: ^11.3.0
+        version: 11.3.0
+    devDependencies:
       '@agent-nexus/agent-claudecode':
         specifier: workspace:*
         version: link:../agent/claudecode
@@ -47,6 +60,9 @@ importers:
       '@agent-nexus/protocol':
         specifier: workspace:*
         version: link:../protocol
+      esbuild:
+        specifier: ^0.27.7
+        version: 0.27.7
 
   packages/daemon:
     dependencies:


### PR DESCRIPTION
## Summary

当前 CLI 虽然有 `bin` 字段，但只能在 monorepo 内用 `node packages/cli/dist/index.js` 或源码 dev 模式跑；单独 npm 安装会碰到内部 `workspace:*` 包不可解析的问题。同时，首次运行不应要求用户先手动创建 `~/.agent-nexus/`、`config.json` 或 token 文件。

本 PR：
- 将 `@agent-nexus/cli` 改为可发布 npm 包，提供 `agent-nexus` 二进制入口
- 用 esbuild bundle 内部 `@agent-nexus/*` workspace 代码，运行时只保留第三方 npm 依赖
- 新增 `pnpm pack:cli`，并让 `pnpm build` 生成可安装 bin bundle
- 首次运行自动创建 `~/.agent-nexus/`、`~/.agent-nexus/secrets/`、`config.json` 模板和空 `DISCORD_BOT_TOKEN` 文件，权限分别收紧到 0700 / 0600
- CI 新增 tarball 安装 smoke test，验证 bin shim 能启动到配置校验并创建配置脚手架
- 同步 README 与 `docs/dev/process/release.md` 的打包/验证流程

## Why

MVP 运行入口应是一个可安装的 npm 二进制包，而不是要求用户 clone 仓库后直接跑 `node packages/cli/dist/index.js`。内部 package 仍保持 monorepo 边界，但发布产物需要把它们收敛进 CLI 包，避免要求同时发布多个私有 workspace 包。

ADR: [`docs/dev/adr/0004-language-runtime.md`](docs/dev/adr/0004-language-runtime.md)（TypeScript / Node + pnpm workspaces；MVP 走 npm 全局安装路径分发）
Spec: N/A，本 PR 不改变 protocol / platform / agent 外部契约；配置脚手架自动创建属于 CLI 本地启动体验修正，遵循 [`docs/dev/spec/security/secrets.md`](docs/dev/spec/security/secrets.md) 的 file secrets 权限约束

## Test plan

- [x] Tests: `packages/cli/src/config.test.ts` 覆盖首次运行自动创建 config root / secrets 目录、`config.json` 模板、空 token 文件及权限
- [x] Tests: CI smoke test 新增 `pnpm pack:cli` + tarball install + `agent-nexus` bin 启动到配置模板创建提示 + 目录/文件权限断言
- [x] `corepack pnpm build` — 通过，`packages/cli/dist/index.js` bundle 生成并保留 shebang/0755
- [x] `corepack pnpm test` — 13 files / 228 tests passed
- [x] `corepack pnpm pack:cli` — 通过，tarball 只包含 `dist/index.js`、`package.json`、`LICENSE`
- [x] `npm install --prefix "$tmp/install" packages/cli/agent-nexus-cli-*.tgz && HOME="$tmp/home" "$tmp/install/node_modules/.bin/agent-nexus"` — 安装成功，bin 创建配置脚手架并进入应用配置校验
- [x] `git diff --check` — 通过

## Review notes

- Independent agent review: 本地 Claude review，无 blocker；指出 README `typecheck` 说明失真，已修复；建议收紧 bin-only 包的 `types`/冗余 dist 文件，已改为只发布 `dist/index.js`
- Deep review: N/A；未改协议、安全模型、权限边界或跨模块接口契约

## Out of scope

- 不执行 `npm publish`
- 不决定正式版本号、tag 策略、npm channel 或发布公告模板
- 不改变 Discord / Claude Code runtime 行为