### PR TITLE
feat(agent-codex): implement Codex exec runtime

### DIFF
--- a/docs/dev/spec/agent-runtime.md
+++ b/docs/dev/spec/agent-runtime.md
@@ -317,7 +317,7 @@ Agent runtime 实现必须有：
 1. 固定 CC 输出 transcript（JSONL fixture）→ 产出符合 spec 的 AgentEvent 流
 2. `sendInput` → 看到 `session_started` / `text_delta` / `turn_finished` 的合理序列
 3. `interrupt` → 产出 `turn_finished { reason: "user_interrupt" }`
-4. 超时 → 产出 `turn_finished { reason: "error" }` + `error` 事件
+4. 超时 → 产出 `turn_finished { reason: "wallclock_timeout" }` + `error` 事件
 5. 子进程崩溃 fixture → 产出 `error` + `session_stopped`
 6. `usage` 事件的 token 数可被 daemon 成功记账
 7. tool_result 多变体 + 边界 fixture：content 为 string / 空串 / null / 缺字段 / 块数组 / 空数组 / 非 block 数组 / 未识别块 / plain object 各形态 → 产出 kind 正确的 ToolResultContent（按判别优先级），未识别块原样留在 `blocks` 内

--- a/packages/agent/codex/src/index.test.ts
+++ b/packages/agent/codex/src/index.test.ts
@@ -1,9 +1,159 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { PassThrough } from 'node:stream';
+import { execa } from 'execa';
+import type {
+  AgentEvent,
+  AgentSession,
+  SessionConfig,
+  SessionKey,
+} from '@agent-nexus/protocol';
 import { createCodexRuntime } from './index.js';
+import type { CodexConfig } from './config.js';
+
+vi.mock('execa', () => ({
+  execa: vi.fn(),
+}));
+
+const mockedExeca = vi.mocked(execa);
+
+const fakeLogger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+  trace: vi.fn(),
+  fatal: vi.fn(),
+} as unknown as import('@agent-nexus/daemon').Logger;
+
+const codexConfig: CodexConfig = {
+  bin: 'codex',
+  workingDir: '/workspace/project',
+  sandbox: 'read-only',
+  addDirs: [],
+  loadUserConfig: false,
+  loadRules: false,
+};
+
+const sessionKey: SessionKey = {
+  platform: 'discord',
+  channelId: 'C1',
+  initiatorUserId: 'U1',
+};
+
+const sessionConfig: SessionConfig = {
+  sessionId: 'sess-1',
+  workingDir: '/workspace/project',
+  toolWhitelist: [],
+  timeoutMs: 300_000,
+};
+
+function nextTick(): Promise<void> {
+  return new Promise((resolve) => queueMicrotask(resolve));
+}
+
+function fixture(name: string): string {
+  return readFileSync(
+    new URL(`../testdata/jsonl/${name}.jsonl`, import.meta.url),
+    'utf8',
+  );
+}
+
+function makeExecSubproc(): {
+  stdout: PassThrough;
+  stderr: PassThrough;
+  kill: ReturnType<typeof vi.fn>;
+  emitLine: (line: string) => void;
+  emitFixture: (body: string) => void;
+  resolve: () => void;
+  reject: (err: Error) => void;
+  then: Promise<void>['then'];
+  catch: Promise<void>['catch'];
+  finally: Promise<void>['finally'];
+  pid: number;
+} {
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+  let resolveFn: () => void = () => {};
+  let rejectFn: (err: Error) => void = () => {};
+  const settled = new Promise<void>((resolve, reject) => {
+    resolveFn = resolve;
+    rejectFn = reject;
+  });
+  settled.catch(() => {});
+  const kill = vi.fn((signal?: NodeJS.Signals | number) => {
+    if (signal === 'SIGINT') return true;
+    if (signal === 'SIGTERM' || signal === 'SIGKILL') {
+      stdout.end();
+      rejectFn(
+        Object.assign(new Error(`killed ${String(signal)}`), {
+          signal: typeof signal === 'string' ? signal : 'SIGTERM',
+        }),
+      );
+    }
+    return true;
+  });
+
+  return {
+    stdout,
+    stderr,
+    kill,
+    pid: 1234,
+    emitLine(line: string): void {
+      stdout.write(`${line}\n`);
+    },
+    emitFixture(body: string): void {
+      for (const line of body.split('\n')) {
+        if (line.trim().length > 0) stdout.write(`${line}\n`);
+      }
+    },
+    resolve(): void {
+      stdout.end();
+      setImmediate(resolveFn);
+    },
+    reject(err: Error): void {
+      stdout.end();
+      setImmediate(() => rejectFn(err));
+    },
+    then: settled.then.bind(settled),
+    catch: settled.catch.bind(settled),
+    finally: settled.finally.bind(settled),
+  };
+}
+
+function makeRuntime() {
+  return createCodexRuntime({
+    config: codexConfig,
+    logger: fakeLogger,
+    syntheticTurnFinishedDeliveryMs: 10,
+    gracefulInterruptMs: 20,
+    sigtermGraceMs: 30,
+  });
+}
+
+function collectEvents(
+  runtime: ReturnType<typeof createCodexRuntime>,
+  session: AgentSession,
+): AgentEvent[] {
+  const events: AgentEvent[] = [];
+  runtime.onEvent(session, (event) => {
+    events.push(event);
+  });
+  return events;
+}
 
 describe('createCodexRuntime', () => {
+  beforeEach(() => {
+    mockedExeca.mockReset();
+    vi.useRealTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('返回 codex runtime name 与已验证 capability', () => {
-    const runtime = createCodexRuntime();
+    const runtime = makeRuntime();
 
     expect(runtime.name()).toBe('codex');
     expect(runtime.capabilities()).toEqual({
@@ -14,5 +164,487 @@ describe('createCodexRuntime', () => {
       supportsStdinInterrupt: false,
       supportsNativeToolWhitelist: false,
     });
+  });
+
+  it('首轮用 codex exec --json 并把 baseline JSONL 映射成 AgentEvent', async () => {
+    const child = makeExecSubproc();
+    mockedExeca.mockReturnValueOnce(child as unknown as ReturnType<typeof execa>);
+    const runtime = makeRuntime();
+    const session = runtime.startSession(sessionKey, sessionConfig);
+    const events = collectEvents(runtime, session);
+
+    const turn = runtime.sendInput(session, {
+      type: 'user_message',
+      text: 'hello',
+      traceId: 'trace-1',
+    });
+    await nextTick();
+
+    expect(mockedExeca).toHaveBeenCalledWith(
+      'codex',
+      [
+        '--sandbox',
+        'read-only',
+        '--ask-for-approval',
+        'never',
+        '--cd',
+        '/workspace/project',
+        'exec',
+        '--json',
+        '--skip-git-repo-check',
+        '--ignore-user-config',
+        '--ignore-rules',
+        'hello',
+      ],
+      { buffer: false },
+    );
+
+    child.emitFixture(fixture('baseline-text'));
+    child.resolve();
+    await turn;
+
+    expect(session.agentSessionId).toBe('thread-baseline');
+    expect(session.state).toBe('Idle');
+    expect(events.map((event) => event.type)).toEqual([
+      'session_started',
+      'text_final',
+      'usage',
+      'turn_finished',
+    ]);
+    const started = events[0];
+    if (started?.type !== 'session_started') throw new Error('expected started');
+    expect(started.payload).toMatchObject({
+      agentSessionId: 'thread-baseline',
+      pid: 1234,
+      workingDir: '/workspace/project',
+      capabilities: { supportsStreaming: false },
+    });
+    const text = events[1];
+    if (text?.type !== 'text_final') throw new Error('expected text');
+    expect(text.payload.text).toBe('P4_OK');
+    const usage = events[2];
+    if (usage?.type !== 'usage') throw new Error('expected usage');
+    expect(usage.payload).toMatchObject({
+      model: 'unknown',
+      inputTokens: 10,
+      outputTokens: 2,
+      cacheReadTokens: 4,
+      cacheWriteTokens: 0,
+      costUsd: null,
+      turnSequence: 1,
+      toolCallsThisTurn: 0,
+      completeness: 'partial',
+    });
+    const finished = events[3];
+    if (finished?.type !== 'turn_finished') throw new Error('expected finished');
+    expect(finished.payload).toEqual({ reason: 'stop', turnSequence: 1 });
+  });
+
+  it('第二轮用 exec resume thread_id 且同一 thread 不重复 session_started', async () => {
+    const firstChild = makeExecSubproc();
+    const secondChild = makeExecSubproc();
+    mockedExeca
+      .mockReturnValueOnce(firstChild as unknown as ReturnType<typeof execa>)
+      .mockReturnValueOnce(secondChild as unknown as ReturnType<typeof execa>);
+    const runtime = makeRuntime();
+    const session = runtime.startSession(sessionKey, sessionConfig);
+    const events = collectEvents(runtime, session);
+
+    const first = runtime.sendInput(session, {
+      type: 'user_message',
+      text: 'first',
+      traceId: 'trace-1',
+    });
+    await nextTick();
+    firstChild.emitFixture(fixture('baseline-text'));
+    firstChild.resolve();
+    await first;
+
+    const second = runtime.sendInput(session, {
+      type: 'user_message',
+      text: 'second',
+      traceId: 'trace-2',
+    });
+    await nextTick();
+    expect(mockedExeca.mock.calls[1]![1]).toEqual([
+      '--sandbox',
+      'read-only',
+      '--ask-for-approval',
+      'never',
+      '--cd',
+      '/workspace/project',
+      'exec',
+      'resume',
+      '--json',
+      '--skip-git-repo-check',
+      '--ignore-user-config',
+      '--ignore-rules',
+      'thread-baseline',
+      'second',
+    ]);
+    secondChild.emitFixture(fixture('resume-text'));
+    secondChild.resolve();
+    await second;
+
+    expect(session.agentSessionId).toBe('thread-baseline');
+    expect(events.filter((event) => event.type === 'session_started')).toHaveLength(1);
+    expect(events.filter((event) => event.type === 'text_final')).toHaveLength(2);
+    expect(events.filter((event) => event.type === 'turn_finished')).toHaveLength(2);
+  });
+
+  it('resumeFromAgentSessionId 作为首轮 thread，返回不一致时 fail closed', async () => {
+    const child = makeExecSubproc();
+    mockedExeca.mockReturnValueOnce(child as unknown as ReturnType<typeof execa>);
+    const runtime = makeRuntime();
+    const session = runtime.startSession(sessionKey, {
+      ...sessionConfig,
+      resumeFromAgentSessionId: 'expected-thread',
+    });
+    const events = collectEvents(runtime, session);
+
+    const turn = runtime.sendInput(session, {
+      type: 'user_message',
+      text: 'resume',
+      traceId: 'trace-mismatch',
+    });
+    await nextTick();
+    expect(mockedExeca.mock.calls[0]![1]).toEqual([
+      '--sandbox',
+      'read-only',
+      '--ask-for-approval',
+      'never',
+      '--cd',
+      '/workspace/project',
+      'exec',
+      'resume',
+      '--json',
+      '--skip-git-repo-check',
+      '--ignore-user-config',
+      '--ignore-rules',
+      'expected-thread',
+      'resume',
+    ]);
+    child.emitLine(
+      JSON.stringify({ type: 'thread.started', thread_id: 'different-thread' }),
+    );
+    child.reject(new Error('codex exit'));
+    await turn;
+
+    expect(session.state).toBe('Errored');
+    expect(events.map((event) => event.type)).toEqual([
+      'error',
+      'turn_finished',
+      'session_stopped',
+    ]);
+    const err = events[0];
+    if (err?.type !== 'error') throw new Error('expected error');
+    expect(err.payload).toMatchObject({
+      errorKind: 'agent',
+      code: 'codex_thread_mismatch',
+    });
+  });
+
+  it('command_execution 映射为工具 start/result/finished 顺序', async () => {
+    const child = makeExecSubproc();
+    mockedExeca.mockReturnValueOnce(child as unknown as ReturnType<typeof execa>);
+    const runtime = makeRuntime();
+    const session = runtime.startSession(sessionKey, sessionConfig);
+    const events = collectEvents(runtime, session);
+
+    const turn = runtime.sendInput(session, {
+      type: 'user_message',
+      text: 'tool',
+      traceId: 'trace-tool',
+    });
+    await nextTick();
+    child.emitFixture(fixture('command-execution'));
+    child.resolve();
+    await turn;
+
+    expect(events.map((event) => event.type)).toEqual([
+      'session_started',
+      'tool_call_started',
+      'tool_result',
+      'tool_call_finished',
+      'text_final',
+      'usage',
+      'turn_finished',
+    ]);
+    const started = events[1];
+    if (started?.type !== 'tool_call_started') {
+      throw new Error('expected tool_call_started');
+    }
+    expect(started.payload).toEqual({
+      callId: 'item_0',
+      toolName: 'command_execution',
+      inputSummary: "/bin/zsh -lc 'printf TOOL_OK'",
+    });
+    const result = events[2];
+    if (result?.type !== 'tool_result') throw new Error('expected result');
+    expect(result.payload).toEqual({
+      callId: 'item_0',
+      resultSequence: 0,
+      content: { kind: 'text', text: 'TOOL_OK' },
+      isError: false,
+    });
+    const finished = events[3];
+    if (finished?.type !== 'tool_call_finished') throw new Error('expected finished');
+    expect(finished.payload.status).toBe('ok');
+  });
+
+  it('error 加 turn.failed 映射为诊断 error 和 terminal error', async () => {
+    const child = makeExecSubproc();
+    mockedExeca.mockReturnValueOnce(child as unknown as ReturnType<typeof execa>);
+    const runtime = makeRuntime();
+    const session = runtime.startSession(sessionKey, sessionConfig);
+    const events = collectEvents(runtime, session);
+
+    const turn = runtime.sendInput(session, {
+      type: 'user_message',
+      text: 'fail',
+      traceId: 'trace-fail',
+    });
+    await nextTick();
+    child.emitFixture(fixture('turn-failed'));
+    child.reject(Object.assign(new Error('codex exit 1'), { exitCode: 1 }));
+    await turn;
+
+    expect(events.map((event) => event.type)).toEqual([
+      'session_started',
+      'error',
+      'error',
+      'turn_finished',
+    ]);
+    const terminal = events.at(-1);
+    if (terminal?.type !== 'turn_finished') throw new Error('expected terminal');
+    expect(terminal.payload).toEqual({ reason: 'error', turnSequence: 1 });
+    expect(session.state).toBe('Idle');
+  });
+
+  it('未知 JSONL event 只打 debug 日志且不阻断 turn', async () => {
+    const child = makeExecSubproc();
+    mockedExeca.mockReturnValueOnce(child as unknown as ReturnType<typeof execa>);
+    const runtime = makeRuntime();
+    const session = runtime.startSession(sessionKey, sessionConfig);
+    const events = collectEvents(runtime, session);
+
+    const turn = runtime.sendInput(session, {
+      type: 'user_message',
+      text: 'unknown',
+      traceId: 'trace-unknown',
+    });
+    await nextTick();
+    child.emitFixture(fixture('unknown-events'));
+    child.resolve();
+    await turn;
+
+    expect(events.map((event) => event.type)).toEqual([
+      'session_started',
+      'usage',
+      'turn_finished',
+    ]);
+    expect(fakeLogger.debug).toHaveBeenCalledWith(
+      expect.objectContaining({ eventType: 'mystery.event' }),
+      'codex_unknown_event',
+    );
+    expect(fakeLogger.debug).toHaveBeenCalledWith(
+      expect.objectContaining({ itemType: 'mystery_item' }),
+      'codex_unknown_item',
+    );
+  });
+
+  it('interrupt 终止当前子进程并只合成一次 user_interrupt terminal', async () => {
+    vi.useFakeTimers();
+    const child = makeExecSubproc();
+    child.kill.mockImplementation(() => true);
+    mockedExeca.mockReturnValueOnce(child as unknown as ReturnType<typeof execa>);
+    const runtime = makeRuntime();
+    const session = runtime.startSession(sessionKey, sessionConfig);
+    const events = collectEvents(runtime, session);
+
+    const turn = runtime.sendInput(session, {
+      type: 'user_message',
+      text: 'long',
+      traceId: 'trace-int',
+    });
+    await nextTick();
+    child.emitLine(
+      JSON.stringify({ type: 'thread.started', thread_id: 'thread-int' }),
+    );
+    child.emitLine(
+      JSON.stringify({
+        type: 'item.started',
+        item: {
+          id: 'item_0',
+          type: 'command_execution',
+          command: "/bin/zsh -lc 'sleep 60'",
+          aggregated_output: '',
+          exit_code: null,
+          status: 'in_progress',
+        },
+      }),
+    );
+
+    runtime.interrupt(session);
+    expect(child.kill).toHaveBeenCalledWith('SIGINT');
+    await vi.advanceTimersByTimeAsync(10);
+    await turn;
+    child.emitFixture(fixture('late-terminal-after-interrupt'));
+    await vi.advanceTimersByTimeAsync(20);
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+    await vi.advanceTimersByTimeAsync(30);
+    expect(child.kill).toHaveBeenCalledWith('SIGKILL');
+
+    const terminals = events.filter((event) => event.type === 'turn_finished');
+    expect(terminals).toHaveLength(1);
+    const terminal = terminals[0];
+    if (terminal?.type !== 'turn_finished') throw new Error('expected terminal');
+    expect(terminal.payload).toEqual({
+      reason: 'user_interrupt',
+      turnSequence: 1,
+      source: 'runtime-synthesized',
+    });
+    const toolFinished = events.find(
+      (event) => event.type === 'tool_call_finished',
+    );
+    if (toolFinished?.type !== 'tool_call_finished') {
+      throw new Error('expected tool_call_finished');
+    }
+    expect(toolFinished.payload.status).toBe('cancelled');
+  });
+
+  it('interrupt 后下一轮等待旧进程清理完成再 resume', async () => {
+    vi.useFakeTimers();
+    const firstChild = makeExecSubproc();
+    firstChild.kill.mockImplementation(() => true);
+    const secondChild = makeExecSubproc();
+    mockedExeca
+      .mockReturnValueOnce(firstChild as unknown as ReturnType<typeof execa>)
+      .mockReturnValueOnce(secondChild as unknown as ReturnType<typeof execa>);
+    const runtime = makeRuntime();
+    const session = runtime.startSession(sessionKey, sessionConfig);
+    const events = collectEvents(runtime, session);
+
+    const first = runtime.sendInput(session, {
+      type: 'user_message',
+      text: 'long',
+      traceId: 'trace-int-1',
+    });
+    await nextTick();
+    firstChild.emitLine(
+      JSON.stringify({ type: 'thread.started', thread_id: 'thread-int' }),
+    );
+    runtime.interrupt(session);
+    await vi.advanceTimersByTimeAsync(10);
+    await first;
+
+    const second = runtime.sendInput(session, {
+      type: 'user_message',
+      text: 'next',
+      traceId: 'trace-int-2',
+    });
+    await nextTick();
+    expect(mockedExeca).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(20);
+    expect(firstChild.kill).toHaveBeenCalledWith('SIGTERM');
+    await vi.advanceTimersByTimeAsync(30);
+    expect(firstChild.kill).toHaveBeenCalledWith('SIGKILL');
+    await nextTick();
+    expect(mockedExeca).toHaveBeenCalledTimes(2);
+    expect(mockedExeca.mock.calls[1]![1]).toEqual(
+      expect.arrayContaining(['exec', 'resume', 'thread-int', 'next']),
+    );
+
+    secondChild.emitLine(
+      JSON.stringify({ type: 'thread.started', thread_id: 'thread-int' }),
+    );
+    secondChild.emitLine(
+      JSON.stringify({
+        type: 'item.completed',
+        item: { id: 'item_0', type: 'agent_message', text: 'after' },
+      }),
+    );
+    secondChild.emitLine(
+      JSON.stringify({
+        type: 'turn.completed',
+        usage: { input_tokens: 1, cached_input_tokens: 0, output_tokens: 1 },
+      }),
+    );
+    secondChild.resolve();
+    await second;
+
+    expect(events.filter((event) => event.type === 'turn_finished')).toHaveLength(2);
+    expect(events.filter((event) => event.type === 'text_final')).toHaveLength(1);
+  });
+
+  it('timeout 合成 wallclock_timeout 并保留 session 可恢复', async () => {
+    vi.useFakeTimers();
+    const firstChild = makeExecSubproc();
+    firstChild.kill.mockImplementation(() => true);
+    const secondChild = makeExecSubproc();
+    mockedExeca
+      .mockReturnValueOnce(firstChild as unknown as ReturnType<typeof execa>)
+      .mockReturnValueOnce(secondChild as unknown as ReturnType<typeof execa>);
+    const runtime = makeRuntime();
+    const session = runtime.startSession(sessionKey, {
+      ...sessionConfig,
+      timeoutMs: 100,
+    });
+    const events = collectEvents(runtime, session);
+
+    const turn = runtime.sendInput(session, {
+      type: 'user_message',
+      text: 'slow',
+      traceId: 'trace-timeout',
+    });
+    await nextTick();
+    await vi.advanceTimersByTimeAsync(100);
+    await turn;
+
+    expect(firstChild.kill).toHaveBeenCalledWith('SIGINT');
+    expect(events.map((event) => event.type)).toEqual([
+      'turn_finished',
+      'error',
+    ]);
+    const terminal = events[0];
+    if (terminal?.type !== 'turn_finished') throw new Error('expected terminal');
+    expect(terminal.payload).toMatchObject({
+      reason: 'wallclock_timeout',
+      source: 'runtime-synthesized',
+    });
+    const err = events[1];
+    if (err?.type !== 'error') throw new Error('expected error');
+    expect(err.payload).toMatchObject({
+      errorKind: 'agent',
+      code: 'codex_wallclock_timeout',
+    });
+
+    const second = runtime.sendInput(session, {
+      type: 'user_message',
+      text: 'after-timeout',
+      traceId: 'trace-after-timeout',
+    });
+    await nextTick();
+    expect(mockedExeca).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(20);
+    expect(firstChild.kill).toHaveBeenCalledWith('SIGTERM');
+    await vi.advanceTimersByTimeAsync(30);
+    expect(firstChild.kill).toHaveBeenCalledWith('SIGKILL');
+    await nextTick();
+    expect(session.state).toBe('Busy');
+    expect(mockedExeca).toHaveBeenCalledTimes(2);
+    secondChild.emitLine(
+      JSON.stringify({ type: 'thread.started', thread_id: 'thread-after-timeout' }),
+    );
+    secondChild.emitLine(
+      JSON.stringify({
+        type: 'turn.completed',
+        usage: { input_tokens: 1, cached_input_tokens: 0, output_tokens: 0 },
+      }),
+    );
+    secondChild.resolve();
+    await second;
+    expect(session.state).toBe('Idle');
   });
 });

--- a/packages/agent/codex/src/index.ts
+++ b/packages/agent/codex/src/index.ts
@@ -17,13 +17,23 @@ export {
 
 import type {
   AgentCapabilitySet,
+  AgentEvent,
   AgentEventHandler,
   AgentInput,
   AgentRuntime,
   AgentSession,
   SessionConfig,
   SessionKey,
+  ToolCallStatus,
+  TurnEndReason,
+  UsageRecord,
 } from '@agent-nexus/protocol';
+import { EventEmitter } from 'node:events';
+import { createInterface } from 'node:readline';
+import { execa } from 'execa';
+import type { Logger } from '@agent-nexus/daemon';
+import type { CodexConfig } from './config.js';
+import { buildCodexExecArgs, buildCodexResumeArgs } from './probe.js';
 
 const capabilities: AgentCapabilitySet = {
   supportsThinking: false,
@@ -34,11 +44,574 @@ const capabilities: AgentCapabilitySet = {
   supportsNativeToolWhitelist: false,
 };
 
-function notImplemented(method: string): Error {
-  return new Error(`Codex runtime ${method} is not implemented until P4`);
+type ChildProcess = ReturnType<typeof execa> & {
+  stdout?: NodeJS.ReadableStream | null;
+  stderr?: NodeJS.ReadableStream | null;
+  pid?: number;
+  kill(signal?: NodeJS.Signals | number): boolean;
+};
+
+interface ToolCallState {
+  toolName: string;
+  resultSequence: number;
+  finished: boolean;
 }
 
-export function createCodexRuntime(): AgentRuntime {
+interface TurnState {
+  traceId: string;
+  turnSequence: number;
+  startedAtMs: number;
+  toolCalls: Map<string, ToolCallState>;
+  sawThreadStarted: boolean;
+  terminalEmitted: boolean;
+  resolve: () => void;
+  timeout?: NodeJS.Timeout;
+}
+
+interface RuntimeState {
+  emitter: EventEmitter;
+  sessionConfig: SessionConfig;
+  proc?: ChildProcess;
+  queue: Promise<void>;
+  queuedTurns: number;
+  nextSequence: number;
+  nextTurnSequence: number;
+  currentTurn?: TurnState;
+  cleanupBarrier?: Promise<void>;
+  cleanupBarrierResolve?: () => void;
+  cleanupTimers: NodeJS.Timeout[];
+  sessionStarted: boolean;
+  stopped: boolean;
+  errored: boolean;
+}
+
+export interface CodexRuntimeOptions {
+  config: CodexConfig;
+  logger: Logger;
+  syntheticTurnFinishedDeliveryMs?: number;
+  gracefulInterruptMs?: number;
+  sigtermGraceMs?: number;
+}
+
+const stateMap = new WeakMap<AgentSession, RuntimeState>();
+
+function makeEvent(
+  state: RuntimeState,
+  type: AgentEvent['type'],
+  traceId: string,
+  payload: AgentEvent['payload'],
+): AgentEvent {
+  return {
+    type,
+    traceId,
+    timestamp: new Date(),
+    sequence: state.nextSequence++,
+    payload,
+  } as AgentEvent;
+}
+
+function emitEvent(
+  state: RuntimeState,
+  type: AgentEvent['type'],
+  traceId: string,
+  payload: AgentEvent['payload'],
+): void {
+  state.emitter.emit('event', makeEvent(state, type, traceId, payload));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function safeString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function truncate(value: string, max = 240): string {
+  return value.length > max ? `${value.slice(0, max)}...` : value;
+}
+
+function numeric(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0;
+}
+
+function clearTurnTimer(turn: TurnState): void {
+  if (turn.timeout) clearTimeout(turn.timeout);
+  turn.timeout = undefined;
+}
+
+function clearCleanupTimers(state: RuntimeState): void {
+  for (const timer of state.cleanupTimers) clearTimeout(timer);
+  state.cleanupTimers = [];
+}
+
+function finishOpenToolCalls(
+  state: RuntimeState,
+  turn: TurnState,
+  statusOverride?: ToolCallStatus,
+): void {
+  for (const [callId, tool] of turn.toolCalls) {
+    if (tool.finished) continue;
+    tool.finished = true;
+    emitEvent(state, 'tool_call_finished', turn.traceId, {
+      callId,
+      toolName: tool.toolName,
+      status: statusOverride ?? 'error',
+    });
+  }
+}
+
+function finishTurn(
+  state: RuntimeState,
+  reason: TurnEndReason,
+  source?: 'runtime-synthesized',
+): void {
+  const turn = state.currentTurn;
+  if (!turn || turn.terminalEmitted) return;
+  turn.terminalEmitted = true;
+  clearTurnTimer(turn);
+  finishOpenToolCalls(
+    state,
+    turn,
+    reason === 'user_interrupt' ? 'cancelled' : 'error',
+  );
+  emitEvent(state, 'turn_finished', turn.traceId, {
+    reason,
+    turnSequence: turn.turnSequence,
+    ...(source ? { source } : {}),
+  });
+  turn.resolve();
+}
+
+function cleanupAfterTurn(session: AgentSession, state: RuntimeState): void {
+  const turn = state.currentTurn;
+  if (turn) clearTurnTimer(turn);
+  clearCleanupTimers(state);
+  state.currentTurn = undefined;
+  state.proc = undefined;
+  state.cleanupBarrierResolve?.();
+  state.cleanupBarrier = undefined;
+  state.cleanupBarrierResolve = undefined;
+  session.pid = undefined;
+  if (!state.stopped && !state.errored) session.state = 'Idle';
+}
+
+function usageRecordFromCodex(
+  runtimeConfig: CodexConfig,
+  turn: TurnState,
+  usage: unknown,
+): UsageRecord {
+  const raw = isRecord(usage) ? usage : {};
+  return {
+    model: runtimeConfig.model ?? 'unknown',
+    inputTokens: numeric(raw['input_tokens']),
+    outputTokens: numeric(raw['output_tokens']),
+    cacheReadTokens: numeric(raw['cached_input_tokens']),
+    cacheWriteTokens: 0,
+    costUsd: null,
+    turnSequence: turn.turnSequence,
+    toolCallsThisTurn: turn.toolCalls.size,
+    wallClockMs: Date.now() - turn.startedAtMs,
+    completeness: 'partial',
+  };
+}
+
+export function createCodexRuntime(opts: CodexRuntimeOptions): AgentRuntime {
+  const { config: runtimeConfig, logger } = opts;
+  const syntheticDeliveryMs = opts.syntheticTurnFinishedDeliveryMs ?? 250;
+  const gracefulInterruptMs = opts.gracefulInterruptMs ?? 5_000;
+  const sigtermGraceMs = opts.sigtermGraceMs ?? 5_000;
+
+  function getState(session: AgentSession): RuntimeState {
+    const state = stateMap.get(session);
+    if (!state) throw new Error('unknown session');
+    return state;
+  }
+
+  function emitErrorTurn(
+    state: RuntimeState,
+    traceId: string,
+    code: string,
+    message: string,
+  ): void {
+    emitEvent(state, 'error', traceId, { errorKind: 'agent', code, message });
+    emitEvent(state, 'turn_finished', traceId, {
+      reason: 'error',
+      turnSequence: state.nextTurnSequence++,
+    });
+  }
+
+  function stopWithError(
+    session: AgentSession,
+    state: RuntimeState,
+    traceId: string,
+    code: string,
+    message: string,
+  ): void {
+    state.errored = true;
+    session.state = 'Errored';
+    state.proc?.kill('SIGTERM');
+    emitEvent(state, 'error', traceId, { errorKind: 'agent', code, message });
+    if (state.currentTurn && !state.currentTurn.terminalEmitted) {
+      finishTurn(state, 'error');
+    }
+    emitEvent(state, 'session_stopped', traceId, { reason: 'error' });
+    cleanupAfterTurn(session, state);
+  }
+
+  function beginCleanupTimers(
+    session: AgentSession,
+    state: RuntimeState,
+    proc: ChildProcess,
+  ): void {
+    if (!state.cleanupBarrier) {
+      state.cleanupBarrier = new Promise<void>((resolve) => {
+        state.cleanupBarrierResolve = resolve;
+      });
+    }
+    clearCleanupTimers(state);
+    state.cleanupTimers.push(
+      setTimeout(() => {
+        proc.kill('SIGTERM');
+      }, gracefulInterruptMs),
+      setTimeout(() => {
+        proc.kill('SIGKILL');
+        cleanupAfterTurn(session, state);
+      }, gracefulInterruptMs + sigtermGraceMs),
+    );
+  }
+
+  function handleThreadStarted(
+    session: AgentSession,
+    state: RuntimeState,
+    threadId: unknown,
+  ): void {
+    const turn = state.currentTurn;
+    const traceId = turn?.traceId ?? 'system';
+    if (typeof threadId !== 'string' || threadId.length === 0) {
+      stopWithError(
+        session,
+        state,
+        traceId,
+        'codex_thread_missing',
+        'Codex thread.started event did not include thread_id',
+      );
+      return;
+    }
+    const expected = session.agentSessionId;
+    if (expected && expected !== threadId) {
+      stopWithError(
+        session,
+        state,
+        traceId,
+        'codex_thread_mismatch',
+        'Codex resumed thread_id did not match the expected session id',
+      );
+      return;
+    }
+    session.agentSessionId = threadId;
+    if (turn) turn.sawThreadStarted = true;
+    if (state.sessionStarted) return;
+    state.sessionStarted = true;
+    emitEvent(state, 'session_started', traceId, {
+      agentSessionId: threadId,
+      pid: session.pid,
+      workingDir: runtimeConfig.workingDir,
+      capabilities,
+    });
+  }
+
+  function handleCommandStarted(state: RuntimeState, item: Record<string, unknown>): void {
+    const turn = state.currentTurn;
+    if (!turn || turn.terminalEmitted) return;
+    const id = safeString(item['id']);
+    if (!id) return;
+    turn.toolCalls.set(id, {
+      toolName: 'command_execution',
+      resultSequence: 0,
+      finished: false,
+    });
+    emitEvent(state, 'tool_call_started', turn.traceId, {
+      callId: id,
+      toolName: 'command_execution',
+      inputSummary: truncate(safeString(item['command']) ?? ''),
+    });
+  }
+
+  function handleCommandCompleted(
+    state: RuntimeState,
+    item: Record<string, unknown>,
+  ): void {
+    const turn = state.currentTurn;
+    if (!turn || turn.terminalEmitted) return;
+    const id = safeString(item['id']);
+    if (!id) return;
+    let tool = turn.toolCalls.get(id);
+    if (!tool) {
+      tool = {
+        toolName: 'command_execution',
+        resultSequence: 0,
+        finished: false,
+      };
+      turn.toolCalls.set(id, tool);
+    }
+    const status =
+      item['status'] === 'completed' && item['exit_code'] === 0 ? 'ok' : 'error';
+    const output = typeof item['aggregated_output'] === 'string'
+      ? item['aggregated_output']
+      : '';
+    emitEvent(state, 'tool_result', turn.traceId, {
+      callId: id,
+      resultSequence: tool.resultSequence++,
+      content: { kind: 'text', text: output },
+      isError: status === 'error',
+    });
+    tool.finished = true;
+    emitEvent(state, 'tool_call_finished', turn.traceId, {
+      callId: id,
+      toolName: tool.toolName,
+      status,
+      ...(status === 'error'
+        ? {
+            errorSummary: `exit_code=${String(item['exit_code'])} status=${String(item['status'])}`,
+          }
+        : {}),
+    });
+  }
+
+  function handleItem(
+    state: RuntimeState,
+    item: unknown,
+  ): void {
+    const turn = state.currentTurn;
+    if (!turn || turn.terminalEmitted || !isRecord(item)) return;
+    const itemType = item['type'];
+    if (itemType === 'agent_message') {
+      const text = item['text'];
+      if (typeof text === 'string') {
+        emitEvent(state, 'text_final', turn.traceId, { text });
+      }
+    } else if (itemType === 'command_execution') {
+      handleCommandCompleted(state, item);
+    } else {
+      logger.debug(
+        {
+          itemId: typeof item['id'] === 'string' ? item['id'] : undefined,
+          itemType,
+        },
+        'codex_unknown_item',
+      );
+    }
+  }
+
+  function handleCodexEvent(
+    session: AgentSession,
+    state: RuntimeState,
+    event: Record<string, unknown>,
+  ): void {
+    const turn = state.currentTurn;
+    const type = event['type'];
+    if (type === 'thread.started') {
+      handleThreadStarted(session, state, event['thread_id']);
+    } else if (type === 'turn.started') {
+      return;
+    } else if (type === 'item.started') {
+      const item = event['item'];
+      if (turn && !turn.terminalEmitted && isRecord(item)) {
+        if (item['type'] === 'command_execution') {
+          handleCommandStarted(state, item);
+        } else {
+          logger.debug(
+            {
+              itemId: typeof item['id'] === 'string' ? item['id'] : undefined,
+              itemType: item['type'],
+            },
+            'codex_unknown_item',
+          );
+        }
+      }
+    } else if (type === 'item.completed') {
+      handleItem(state, event['item']);
+    } else if (type === 'turn.completed') {
+      if (!turn || turn.terminalEmitted) return;
+      if (!turn.sawThreadStarted) {
+        stopWithError(
+          session,
+          state,
+          turn.traceId,
+          'codex_thread_missing',
+          'Codex turn completed before thread.started bound the session id',
+        );
+        return;
+      }
+      emitEvent(
+        state,
+        'usage',
+        turn.traceId,
+        usageRecordFromCodex(runtimeConfig, turn, event['usage']),
+      );
+      finishTurn(state, 'stop');
+      cleanupAfterTurn(session, state);
+    } else if (type === 'error') {
+      if (!turn || turn.terminalEmitted) return;
+      emitEvent(state, 'error', turn.traceId, {
+        errorKind: 'agent',
+        code: 'codex_error',
+        message: safeString(event['message']) ?? 'Codex CLI emitted an error',
+      });
+    } else if (type === 'turn.failed') {
+      if (!turn || turn.terminalEmitted) return;
+      const err = isRecord(event['error']) ? event['error'] : {};
+      emitEvent(state, 'error', turn.traceId, {
+        errorKind: 'agent',
+        code: 'codex_turn_failed',
+        message: safeString(err['message']) ?? 'Codex CLI turn failed',
+      });
+      finishTurn(state, 'error');
+      cleanupAfterTurn(session, state);
+    } else {
+      logger.debug({ eventType: type }, 'codex_unknown_event');
+    }
+  }
+
+  async function readStdoutLoop(
+    session: AgentSession,
+    state: RuntimeState,
+    proc: ChildProcess,
+  ): Promise<void> {
+    const rl = createInterface({ input: proc.stdout!, crlfDelay: Infinity });
+    for await (const line of rl) {
+      if (!line.trim()) continue;
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(line);
+      } catch {
+        logger.debug({ line: truncate(line) }, 'codex_non_json_line');
+        continue;
+      }
+      if (!isRecord(parsed)) continue;
+      handleCodexEvent(session, state, parsed);
+    }
+  }
+
+  async function runTurn(
+    session: AgentSession,
+    state: RuntimeState,
+    input: AgentInput,
+  ): Promise<void> {
+    if (state.cleanupBarrier) await state.cleanupBarrier;
+    if (state.stopped || state.errored) {
+      emitErrorTurn(
+        state,
+        input.traceId,
+        'session_stopped',
+        'sendInput called after session cleanup failed',
+      );
+      return;
+    }
+    const traceId = input.traceId;
+    const prompt = input.text ?? '';
+    const threadId = session.agentSessionId ?? state.sessionConfig.resumeFromAgentSessionId;
+    const args = threadId
+      ? buildCodexResumeArgs(runtimeConfig, threadId, prompt)
+      : buildCodexExecArgs(runtimeConfig, prompt);
+
+    await new Promise<void>((resolve) => {
+      const turn: TurnState = {
+        traceId,
+        turnSequence: state.nextTurnSequence++,
+        startedAtMs: Date.now(),
+        toolCalls: new Map(),
+        sawThreadStarted: false,
+        terminalEmitted: false,
+        resolve,
+      };
+      state.currentTurn = turn;
+      session.state = 'Busy';
+
+      let proc: ChildProcess;
+      try {
+        proc = execa(runtimeConfig.bin, args, { buffer: false }) as ChildProcess;
+      } catch (err) {
+        emitEvent(state, 'error', traceId, {
+          errorKind: 'agent',
+          code: 'codex_spawn_failed',
+          message: err instanceof Error ? err.message : String(err),
+        });
+        finishTurn(state, 'error');
+        cleanupAfterTurn(session, state);
+        return;
+      }
+
+      if (!proc.stdout) {
+        emitEvent(state, 'error', traceId, {
+          errorKind: 'agent',
+          code: 'codex_stdout_missing',
+          message: 'Codex subprocess stdout is missing',
+        });
+        proc.kill('SIGTERM');
+        finishTurn(state, 'error');
+        cleanupAfterTurn(session, state);
+        return;
+      }
+
+      state.proc = proc;
+      session.pid = proc.pid;
+      turn.timeout = setTimeout(() => {
+        proc.kill('SIGINT');
+        finishTurn(state, 'wallclock_timeout', 'runtime-synthesized');
+        emitEvent(state, 'error', traceId, {
+          errorKind: 'agent',
+          code: 'codex_wallclock_timeout',
+          message: 'Codex turn exceeded wallclock timeout',
+        });
+        beginCleanupTimers(session, state, proc);
+      }, state.sessionConfig.timeoutMs);
+
+      readStdoutLoop(session, state, proc).catch((err: unknown) => {
+        if (!state.stopped && !state.errored && !turn.terminalEmitted) {
+          stopWithError(
+            session,
+            state,
+            traceId,
+            'codex_stdout_error',
+            err instanceof Error ? err.message : String(err),
+          );
+        }
+      });
+
+      void Promise.resolve(proc).then(
+        () => {
+          if (!state.stopped && !state.errored && state.currentTurn === turn) {
+            if (!turn.terminalEmitted) {
+              emitEvent(state, 'error', traceId, {
+                errorKind: 'agent',
+                code: 'codex_process_exited_without_terminal',
+                message: 'Codex process exited without a terminal JSONL event',
+              });
+              finishTurn(state, 'error');
+            }
+            cleanupAfterTurn(session, state);
+          }
+        },
+        (err: unknown) => {
+          if (!state.stopped && !state.errored && state.currentTurn === turn) {
+            if (!turn.terminalEmitted) {
+              emitEvent(state, 'error', traceId, {
+                errorKind: 'agent',
+                code: 'codex_subproc_error',
+                message: err instanceof Error ? err.message : String(err),
+              });
+              finishTurn(state, 'error');
+              emitEvent(state, 'session_stopped', traceId, { reason: 'error' });
+            }
+            cleanupAfterTurn(session, state);
+          }
+        },
+      );
+    });
+  }
+
   return {
     name(): string {
       return 'codex';
@@ -48,28 +621,111 @@ export function createCodexRuntime(): AgentRuntime {
       return capabilities;
     },
 
-    startSession(_key: SessionKey, _config: SessionConfig): AgentSession {
-      throw notImplemented('startSession');
+    startSession(key: SessionKey, sessionConfig: SessionConfig): AgentSession {
+      const session: AgentSession = {
+        key,
+        backend: 'codex',
+        state: 'Idle',
+        startedAt: new Date(),
+        agentSessionId: sessionConfig.resumeFromAgentSessionId,
+      };
+      stateMap.set(session, {
+        emitter: new EventEmitter(),
+        sessionConfig,
+        queue: Promise.resolve(),
+        queuedTurns: 0,
+        nextSequence: 0,
+        nextTurnSequence: 1,
+        cleanupTimers: [],
+        sessionStarted: false,
+        stopped: false,
+        errored: false,
+      });
+      return session;
     },
 
-    stopSession(_session: AgentSession): void {
-      throw notImplemented('stopSession');
+    stopSession(session: AgentSession): void {
+      const state = getState(session);
+      state.stopped = true;
+      session.state = 'Stopped';
+      state.proc?.kill('SIGTERM');
+      clearCleanupTimers(state);
+      if (state.currentTurn && !state.currentTurn.terminalEmitted) {
+        finishTurn(state, 'error');
+      }
+      emitEvent(state, 'session_stopped', state.currentTurn?.traceId ?? 'system', {
+        reason: 'user_stop',
+      });
+      cleanupAfterTurn(session, state);
     },
 
-    isAlive(_session: AgentSession): boolean {
-      return false;
+    isAlive(session: AgentSession): boolean {
+      const state = stateMap.get(session);
+      return session.state !== 'Stopped' && state?.errored !== true;
     },
 
-    async sendInput(_session: AgentSession, _input: AgentInput): Promise<void> {
-      throw notImplemented('sendInput');
+    async sendInput(session: AgentSession, input: AgentInput): Promise<void> {
+      const state = getState(session);
+      if (session.state === 'Stopped' || state.errored) {
+        emitErrorTurn(
+          state,
+          input.traceId,
+          'session_stopped',
+          'sendInput called on stopped session',
+        );
+        return;
+      }
+      if (state.currentTurn && state.queuedTurns >= 1) {
+        emitErrorTurn(
+          state,
+          input.traceId,
+          'concurrent_send_input',
+          'sendInput queue is full',
+        );
+        return;
+      }
+      state.queuedTurns++;
+      const work = state.queue.then(async () => {
+        state.queuedTurns--;
+        await runTurn(session, state, input);
+      });
+      state.queue = work.catch(() => {});
+      await work;
     },
 
-    onEvent(_session: AgentSession, _handler: AgentEventHandler): void {
-      throw notImplemented('onEvent');
+    onEvent(session: AgentSession, handler: AgentEventHandler): void {
+      const state = getState(session);
+      state.emitter.on('event', (event: AgentEvent) => {
+        try {
+          const ret = handler(event);
+          if (ret && typeof (ret as Promise<void>).then === 'function') {
+            (ret as Promise<void>).catch((err) => {
+              logger.error({ err }, 'agent_event_handler_rejected');
+            });
+          }
+        } catch (err) {
+          logger.error({ err }, 'agent_event_handler_threw');
+        }
+      });
     },
 
-    interrupt(_session: AgentSession): void {
-      throw notImplemented('interrupt');
+    interrupt(session: AgentSession): void {
+      const state = getState(session);
+      const turn = state.currentTurn;
+      const proc = state.proc;
+      if (!proc || !turn || turn.terminalEmitted) {
+        logger.debug({ sessionKey: session.key }, 'codex_interrupt_no_inflight');
+        return;
+      }
+      const signaled = proc.kill('SIGINT');
+      if (!signaled) return;
+      setTimeout(() => {
+        if (!state.currentTurn || state.currentTurn !== turn || turn.terminalEmitted) {
+          return;
+        }
+        finishTurn(state, 'user_interrupt', 'runtime-synthesized');
+        beginCleanupTimers(session, state, proc);
+      }, syntheticDeliveryMs);
     },
   };
 }

--- a/packages/agent/codex/src/probe.test.ts
+++ b/packages/agent/codex/src/probe.test.ts
@@ -1,4 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 import type { Logger } from '@agent-nexus/daemon';
 import {
   buildCodexExecArgs,
@@ -88,7 +91,27 @@ describe('Codex command construction', () => {
 });
 
 describe('Codex compatibility probe', () => {
-  it('校验 version 与 exec help 的必需静态能力', async () => {
+  const execPingStdout = [
+    '{"type":"thread.started","thread_id":"thread-probe"}',
+    '{"type":"turn.started"}',
+    '{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"CODEX_PROBE_OK"}}',
+    '{"type":"turn.completed","usage":{"input_tokens":1,"cached_input_tokens":0,"output_tokens":1}}',
+  ].join('\n');
+  const resumeStdout = [
+    '{"type":"thread.started","thread_id":"thread-probe"}',
+    '{"type":"turn.started"}',
+    '{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"CODEX_PROBE_RESUME_OK"}}',
+    '{"type":"turn.completed","usage":{"input_tokens":2,"cached_input_tokens":1,"output_tokens":1}}',
+  ].join('\n');
+  const toolStdout = [
+    '{"type":"thread.started","thread_id":"thread-tool"}',
+    '{"type":"turn.started"}',
+    '{"type":"item.started","item":{"id":"item_0","type":"command_execution","command":"/bin/zsh -lc \\"printf CODEX_TOOL_OK\\"","aggregated_output":"","exit_code":null,"status":"in_progress"}}',
+    '{"type":"item.completed","item":{"id":"item_0","type":"command_execution","command":"/bin/zsh -lc \\"printf CODEX_TOOL_OK\\"","aggregated_output":"CODEX_TOOL_OK","exit_code":0,"status":"completed"}}',
+    '{"type":"turn.completed","usage":{"input_tokens":3,"cached_input_tokens":1,"output_tokens":1}}',
+  ].join('\n');
+
+  it('校验 version、help、exec/resume JSONL 与 tool 事件 schema', async () => {
     execaMock
       .mockResolvedValueOnce({ stdout: 'codex-cli 0.133.0' })
       .mockResolvedValueOnce({
@@ -96,7 +119,10 @@ describe('Codex compatibility probe', () => {
       })
       .mockResolvedValueOnce({
         stdout: 'Usage: codex exec\nresume --json --ignore-user-config --ignore-rules',
-      });
+      })
+      .mockResolvedValueOnce({ stdout: execPingStdout })
+      .mockResolvedValueOnce({ stdout: resumeStdout })
+      .mockResolvedValueOnce({ stdout: toolStdout });
 
     await expect(
       runCompatibilityProbe({
@@ -107,6 +133,11 @@ describe('Codex compatibility probe', () => {
     expect(execaMock).toHaveBeenNthCalledWith(1, 'codex', ['--version']);
     expect(execaMock).toHaveBeenNthCalledWith(2, 'codex', ['--help']);
     expect(execaMock).toHaveBeenNthCalledWith(3, 'codex', ['exec', '--help']);
+    const execArgs = execaMock.mock.calls[3]![1] as string[];
+    const resumeArgs = execaMock.mock.calls[4]![1] as string[];
+    expect(execArgs).toContain('--json');
+    expect(execArgs).not.toContain('--dangerously-bypass-approvals-and-sandbox');
+    expect(resumeArgs).toEqual(expect.arrayContaining(['exec', 'resume', 'thread-probe']));
   });
 
   it('version 输出为空时 fail closed', async () => {
@@ -133,5 +164,65 @@ describe('Codex compatibility probe', () => {
     await expect(
       runCompatibilityProbe({ config: baseConfig, logger: logger() }),
     ).rejects.toThrow('missing --json in codex help');
+  });
+
+  it('exec JSONL 缺少 thread.started 时 fail closed', async () => {
+    execaMock
+      .mockResolvedValueOnce({ stdout: 'codex-cli 0.133.0' })
+      .mockResolvedValueOnce({
+        stdout: 'Usage: codex\nexec\n--sandbox --ask-for-approval --cd --add-dir',
+      })
+      .mockResolvedValueOnce({
+        stdout: 'Usage: codex exec\nresume --json --ignore-user-config --ignore-rules',
+      })
+      .mockResolvedValueOnce({
+        stdout: '{"type":"turn.started"}\n{"type":"turn.completed","usage":{"input_tokens":1}}',
+      });
+
+    await expect(
+      runCompatibilityProbe({ config: baseConfig, logger: logger() }),
+    ).rejects.toThrow('missing thread.started in exec probe');
+  });
+
+  it('workspace-write sandbox 通过 Codex 写哨兵文件验证工作目录可写', async () => {
+    const workingDir = await mkdtemp(join(tmpdir(), 'codex-probe-'));
+    try {
+      execaMock
+        .mockResolvedValueOnce({ stdout: 'codex-cli 0.133.0' })
+        .mockResolvedValueOnce({
+          stdout: 'Usage: codex\nexec\n--sandbox --ask-for-approval --cd --add-dir',
+        })
+        .mockResolvedValueOnce({
+          stdout: 'Usage: codex exec\nresume --json --ignore-user-config --ignore-rules',
+        })
+        .mockResolvedValueOnce({ stdout: execPingStdout })
+        .mockResolvedValueOnce({ stdout: resumeStdout })
+        .mockResolvedValueOnce({ stdout: toolStdout })
+        .mockImplementationOnce(async (_bin: string, args: string[]) => {
+          const prompt = args.at(-1) ?? '';
+          const sentinelName = prompt.split(' > ')[1];
+          if (!sentinelName) throw new Error('missing sentinel name');
+          await writeFile(join(workingDir, sentinelName), 'CODEX_WORKSPACE_WRITE_OK');
+          return {
+            stdout: [
+              '{"type":"thread.started","thread_id":"thread-write"}',
+              '{"type":"turn.started"}',
+              '{"type":"item.started","item":{"id":"item_0","type":"command_execution","command":"printf CODEX_WORKSPACE_WRITE_OK","aggregated_output":"","exit_code":null,"status":"in_progress"}}',
+              '{"type":"item.completed","item":{"id":"item_0","type":"command_execution","command":"printf CODEX_WORKSPACE_WRITE_OK","aggregated_output":"","exit_code":0,"status":"completed"}}',
+              '{"type":"turn.completed","usage":{"input_tokens":1,"cached_input_tokens":0,"output_tokens":0}}',
+            ].join('\n'),
+          };
+        });
+
+      await expect(
+        runCompatibilityProbe({
+          config: { ...baseConfig, sandbox: 'workspace-write', workingDir },
+          logger: logger(),
+        }),
+      ).resolves.toBeUndefined();
+      expect(execaMock).toHaveBeenCalledTimes(7);
+    } finally {
+      await rm(workingDir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/agent/codex/src/probe.ts
+++ b/packages/agent/codex/src/probe.ts
@@ -1,4 +1,6 @@
 import { execa } from 'execa';
+import { readFile, rm } from 'node:fs/promises';
+import { join } from 'node:path';
 import type { Logger } from '@agent-nexus/daemon';
 import type { CodexConfig } from './config.js';
 
@@ -15,6 +17,15 @@ export class CodexCompatibilityProbeError extends Error {
 export interface CodexCompatibilityProbeOptions {
   config: CodexConfig;
   logger: Logger;
+}
+
+interface JsonlProbeFacts {
+  threadId?: string;
+  sawTurnStarted: boolean;
+  sawAgentMessage: boolean;
+  sawTurnCompletedUsage: boolean;
+  sawCommandStarted: boolean;
+  sawCommandCompleted: boolean;
 }
 
 function addGlobalArgs(args: string[], config: CodexConfig): void {
@@ -82,12 +93,97 @@ function requireOneHelpToken(help: string, tokens: string[], label: string): voi
   }
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function parseJsonl(stdout: string): Record<string, unknown>[] {
+  const events: Record<string, unknown>[] = [];
+  for (const line of stdout.split('\n')) {
+    if (line.trim().length === 0) continue;
+    const parsed = JSON.parse(line) as unknown;
+    if (!isRecord(parsed)) {
+      throw new Error('non-object JSONL event in codex probe');
+    }
+    events.push(parsed);
+  }
+  return events;
+}
+
+function collectFacts(stdout: string): JsonlProbeFacts {
+  const facts: JsonlProbeFacts = {
+    sawTurnStarted: false,
+    sawAgentMessage: false,
+    sawTurnCompletedUsage: false,
+    sawCommandStarted: false,
+    sawCommandCompleted: false,
+  };
+  for (const event of parseJsonl(stdout)) {
+    const type = event['type'];
+    if (type === 'thread.started' && typeof event['thread_id'] === 'string') {
+      facts.threadId = event['thread_id'];
+    } else if (type === 'turn.started') {
+      facts.sawTurnStarted = true;
+    } else if (type === 'turn.completed' && isRecord(event['usage'])) {
+      facts.sawTurnCompletedUsage = true;
+    } else if (type === 'item.started' && isRecord(event['item'])) {
+      facts.sawCommandStarted =
+        facts.sawCommandStarted || event['item']['type'] === 'command_execution';
+    } else if (type === 'item.completed' && isRecord(event['item'])) {
+      facts.sawAgentMessage =
+        facts.sawAgentMessage || event['item']['type'] === 'agent_message';
+      facts.sawCommandCompleted =
+        facts.sawCommandCompleted || event['item']['type'] === 'command_execution';
+    }
+  }
+  return facts;
+}
+
+function requireBaseTurnFacts(facts: JsonlProbeFacts, label: string): void {
+  if (!facts.threadId) throw new Error(`missing thread.started in ${label} probe`);
+  if (!facts.sawTurnStarted) throw new Error(`missing turn.started in ${label} probe`);
+  if (!facts.sawAgentMessage) {
+    throw new Error(`missing agent_message in ${label} probe`);
+  }
+  if (!facts.sawTurnCompletedUsage) {
+    throw new Error(`missing turn.completed usage in ${label} probe`);
+  }
+}
+
+function assertNoDangerousArgs(args: string[]): void {
+  if (args.includes('--dangerously-bypass-approvals-and-sandbox')) {
+    throw new Error('dangerous bypass flag must not be used by codex backend');
+  }
+}
+
+async function verifyWorkspaceWrite(config: CodexConfig): Promise<void> {
+  const sentinelName = `.codex-agent-probe-${process.pid}-${Date.now()}.txt`;
+  const sentinelPath = join(config.workingDir, sentinelName);
+  const args = buildCodexExecArgs(
+    config,
+    `Use the shell to run exactly: printf CODEX_WORKSPACE_WRITE_OK > ${sentinelName}`,
+  );
+  assertNoDangerousArgs(args);
+  try {
+    const probe = await execa(config.bin, args);
+    const facts = collectFacts((probe.stdout ?? '').toString());
+    if (!facts.sawCommandStarted || !facts.sawCommandCompleted) {
+      throw new Error('workspace-write probe did not emit command_execution events');
+    }
+    const content = await readFile(sentinelPath, 'utf8');
+    if (content !== 'CODEX_WORKSPACE_WRITE_OK') {
+      throw new Error('workspace-write probe wrote unexpected sentinel content');
+    }
+  } finally {
+    await rm(sentinelPath, { force: true });
+  }
+}
+
 export async function runCompatibilityProbe(
   opts: CodexCompatibilityProbeOptions,
 ): Promise<void> {
   const { config, logger } = opts;
   try {
-    // P3 only gates the static CLI surface. P4 must add behavioral exec/resume probes.
     const version = await execa(config.bin, ['--version']);
     const versionText = (version.stdout ?? '').toString().trim();
     if (!versionText) {
@@ -113,6 +209,42 @@ export async function runCompatibilityProbe(
     }
     if (config.model) {
       requireOneHelpToken(combinedHelp, ['--model', '-m'], '--model/-m');
+    }
+
+    const execArgs = buildCodexExecArgs(config, 'Reply exactly: CODEX_PROBE_OK');
+    assertNoDangerousArgs(execArgs);
+    const execProbe = await execa(config.bin, execArgs);
+    const execFacts = collectFacts((execProbe.stdout ?? '').toString());
+    requireBaseTurnFacts(execFacts, 'exec');
+
+    const resumeArgs = buildCodexResumeArgs(
+      config,
+      execFacts.threadId!,
+      'Reply exactly: CODEX_PROBE_RESUME_OK',
+    );
+    assertNoDangerousArgs(resumeArgs);
+    const resumeProbe = await execa(config.bin, resumeArgs);
+    const resumeFacts = collectFacts((resumeProbe.stdout ?? '').toString());
+    requireBaseTurnFacts(resumeFacts, 'resume');
+    if (resumeFacts.threadId !== execFacts.threadId) {
+      throw new Error('resume probe returned a different thread_id');
+    }
+
+    const toolArgs = buildCodexExecArgs(
+      config,
+      'Use the shell to run: printf CODEX_TOOL_OK',
+    );
+    assertNoDangerousArgs(toolArgs);
+    const toolProbe = await execa(config.bin, toolArgs);
+    const toolFacts = collectFacts((toolProbe.stdout ?? '').toString());
+    if (!toolFacts.sawCommandStarted) {
+      throw new Error('missing command_execution item.started in tool probe');
+    }
+    if (!toolFacts.sawCommandCompleted) {
+      throw new Error('missing command_execution item.completed in tool probe');
+    }
+    if (config.sandbox === 'workspace-write') {
+      await verifyWorkspaceWrite(config);
     }
   } catch (err) {
     throw new CodexCompatibilityProbeError(

--- a/packages/agent/codex/testdata/jsonl/baseline-text.jsonl
+++ b/packages/agent/codex/testdata/jsonl/baseline-text.jsonl
@@ -1,0 +1,4 @@
+{"type":"thread.started","thread_id":"thread-baseline"}
+{"type":"turn.started"}
+{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"P4_OK"}}
+{"type":"turn.completed","usage":{"input_tokens":10,"cached_input_tokens":4,"output_tokens":2,"reasoning_output_tokens":0}}

--- a/packages/agent/codex/testdata/jsonl/command-execution.jsonl
+++ b/packages/agent/codex/testdata/jsonl/command-execution.jsonl
@@ -1,0 +1,6 @@
+{"type":"thread.started","thread_id":"thread-tool"}
+{"type":"turn.started"}
+{"type":"item.started","item":{"id":"item_0","type":"command_execution","command":"/bin/zsh -lc 'printf TOOL_OK'","aggregated_output":"","exit_code":null,"status":"in_progress"}}
+{"type":"item.completed","item":{"id":"item_0","type":"command_execution","command":"/bin/zsh -lc 'printf TOOL_OK'","aggregated_output":"TOOL_OK","exit_code":0,"status":"completed"}}
+{"type":"item.completed","item":{"id":"item_1","type":"agent_message","text":"TOOL_OK"}}
+{"type":"turn.completed","usage":{"input_tokens":20,"cached_input_tokens":5,"output_tokens":4,"reasoning_output_tokens":0}}

--- a/packages/agent/codex/testdata/jsonl/late-terminal-after-interrupt.jsonl
+++ b/packages/agent/codex/testdata/jsonl/late-terminal-after-interrupt.jsonl
@@ -1,0 +1,1 @@
+{"type":"turn.completed","usage":{"input_tokens":100,"cached_input_tokens":0,"output_tokens":0,"reasoning_output_tokens":0}}

--- a/packages/agent/codex/testdata/jsonl/resume-text.jsonl
+++ b/packages/agent/codex/testdata/jsonl/resume-text.jsonl
@@ -1,0 +1,4 @@
+{"type":"thread.started","thread_id":"thread-baseline"}
+{"type":"turn.started"}
+{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"P4_RESUMED"}}
+{"type":"turn.completed","usage":{"input_tokens":12,"cached_input_tokens":8,"output_tokens":3,"reasoning_output_tokens":0}}

--- a/packages/agent/codex/testdata/jsonl/turn-failed.jsonl
+++ b/packages/agent/codex/testdata/jsonl/turn-failed.jsonl
@@ -1,0 +1,4 @@
+{"type":"thread.started","thread_id":"thread-failed"}
+{"type":"turn.started"}
+{"type":"error","message":"temporary reconnecting"}
+{"type":"turn.failed","error":{"message":"401 Unauthorized: Missing bearer or basic authentication"}}

--- a/packages/agent/codex/testdata/jsonl/unknown-events.jsonl
+++ b/packages/agent/codex/testdata/jsonl/unknown-events.jsonl
@@ -1,0 +1,5 @@
+{"type":"thread.started","thread_id":"thread-unknown"}
+{"type":"turn.started"}
+{"type":"mystery.event","safe":"summary"}
+{"type":"item.completed","item":{"id":"item_x","type":"mystery_item","value":1}}
+{"type":"turn.completed","usage":{"input_tokens":1,"cached_input_tokens":0,"output_tokens":0,"reasoning_output_tokens":0}}


### PR DESCRIPTION
## Summary

- Implement Codex runtime turn execution with one `codex exec --json` subprocess per turn and `codex exec resume` after `thread_id` is bound.
- Map Codex JSONL into `AgentEvent`: session_started, text_final, tool events, usage, turn_finished, error, plus synthesized interrupt and wallclock timeout terminals.
- Extend compatibility probe beyond help text to validate exec/resume JSONL, command_execution events, and workspace-write sentinel writes.
- Add Codex JSONL fixtures and align `agent-runtime.md` timeout contract text with `wallclock_timeout`.

## Required answers

1. ADR used: `docs/dev/adr/0014-codex-cli-backend.md`.
2. Spec followed: `docs/dev/spec/agent-backends/codex-cli.md` and `docs/dev/spec/agent-runtime.md`.
3. Tests and validation: added Codex runtime/probe contract tests plus JSONL fixtures. Ran `corepack pnpm --filter @agent-nexus/agent-codex test`, `corepack pnpm --filter @agent-nexus/agent-codex typecheck`, `corepack pnpm test`, `corepack pnpm typecheck`, and `git diff --check`.

## Review

- Independent adversarial review log: `/home/node/.goal/codex-agent/reviews/p4-adversarial-1779564133`.
- Round 1 found 3 important and 6 nit/low issues.
- Fixed I1/I2/I3, N1, N5, and N7; left N2/N4/N6 as explicitly non-blocking nits with rationale.
- Round 3 marked the final doc fix resolved, no new issues, final judgement: `接近最优`.

## Notes

This PR does not wire CLI backend selection; that remains P5.