### PR TITLE
feat(cli): parse named platform agent config

### DIFF
--- a/packages/cli/src/agent.test.ts
+++ b/packages/cli/src/agent.test.ts
@@ -1,7 +1,7 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest';
-import type { AgentRuntime } from '@agent-nexus/protocol';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Logger } from '@agent-nexus/daemon';
-import type { AgentNexusConfig } from './config.js';
+import type { AgentRuntime } from '@agent-nexus/protocol';
+import type { AgentConfig, AgentNexusConfig } from './config.js';
 
 const claudeRuntime = { name: () => 'claudecode' } as AgentRuntime;
 const codexRuntime = { name: () => 'codex' } as AgentRuntime;
@@ -21,26 +21,43 @@ vi.mock('@agent-nexus/agent-codex', () => ({
   runCompatibilityProbe: runCodexProbeMock,
 }));
 
-import { createSelectedAgent } from './agent.js';
+import { createAgentRuntime, createSelectedAgent } from './agent.js';
 
 const logger = {
   warn: vi.fn(),
   error: vi.fn(),
 } as unknown as Logger;
 
-function baseConfig(): Omit<AgentNexusConfig, 'agent' | 'claudeCode' | 'codex'> {
+function baseConfig(agentName: string, agents: AgentConfig[]): AgentNexusConfig {
   return {
-    discord: {
-      botUserId: 'bot',
-      allowedUserIds: ['U1'],
-      statePath: '/state/discord.json',
-    },
+    platforms: [
+      {
+        name: 'discord-main',
+        type: 'discord',
+        botUserId: 'bot',
+        tokenRef: 'DISCORD_BOT_TOKEN',
+        statePath: '/state/discord.json',
+        publicChannelMode: 'thread',
+        auth: {
+          allowlist: {
+            userIds: ['U1'],
+            roleIds: [],
+            allowedGuildIds: ['G1'],
+            allowedChannelIds: [],
+            allowDM: true,
+            requireMentionOrSlash: true,
+          },
+        },
+        bindings: [{ agentName, channelIds: ['C1'] }],
+      },
+    ],
+    agents,
     ui: { toolMessages: 'append' },
     log: { level: 'info' },
   };
 }
 
-describe('createSelectedAgent', () => {
+describe('createAgentRuntime', () => {
   beforeEach(() => {
     createClaudeCodeRuntimeMock.mockClear();
     runClaudeProbeMock.mockClear();
@@ -50,10 +67,10 @@ describe('createSelectedAgent', () => {
   });
 
   it('claudecode backend 跑 Claude probe 并注入 Claude runtime，保持默认 session config', async () => {
-    const selected = await createSelectedAgent(
+    const selected = await createAgentRuntime(
       {
-        ...baseConfig(),
-        agent: { backend: 'claudecode' },
+        name: 'claude-prod',
+        backend: 'claudecode',
         claudeCode: {
           bin: 'claude',
           workingDir: '/work',
@@ -96,12 +113,8 @@ describe('createSelectedAgent', () => {
       loadRules: false,
     } as const;
 
-    const selected = await createSelectedAgent(
-      {
-        ...baseConfig(),
-        agent: { backend: 'codex' },
-        codex,
-      },
+    const selected = await createAgentRuntime(
+      { name: 'codex-dev', backend: 'codex', codex },
       logger,
     );
 
@@ -119,5 +132,49 @@ describe('createSelectedAgent', () => {
       toolWhitelist: [],
       timeoutMs: 300_000,
     });
+  });
+});
+
+describe('createSelectedAgent', () => {
+  it('P9 启动路径从唯一 binding 选择目标 agent', async () => {
+    const selected = await createSelectedAgent(
+      baseConfig('codex-dev', [
+        {
+          name: 'codex-dev',
+          backend: 'codex',
+          codex: {
+            bin: 'codex',
+            workingDir: '/codex',
+            sandbox: 'read-only',
+            addDirs: [],
+            loadUserConfig: false,
+            loadRules: false,
+          },
+        },
+      ]),
+      logger,
+    );
+
+    expect(selected.agent).toBe(codexRuntime);
+  });
+
+  it('P9 启动路径遇到多个 binding 时拒绝，避免假装完成 P10 路由', async () => {
+    const config = baseConfig('codex-dev', [
+      {
+        name: 'codex-dev',
+        backend: 'codex',
+        codex: {
+          bin: 'codex',
+          workingDir: '/codex',
+          sandbox: 'read-only',
+          addDirs: [],
+          loadUserConfig: false,
+          loadRules: false,
+        },
+      },
+    ]);
+    config.platforms[0].bindings.push({ agentName: 'codex-dev', channelIds: ['C2'] });
+
+    await expect(createSelectedAgent(config, logger)).rejects.toThrow(/P10/);
   });
 });

--- a/packages/cli/src/agent.ts
+++ b/packages/cli/src/agent.ts
@@ -8,7 +8,7 @@ import {
 } from '@agent-nexus/agent-codex';
 import type { Logger } from '@agent-nexus/daemon';
 import type { AgentRuntime, SessionConfig } from '@agent-nexus/protocol';
-import type { AgentNexusConfig } from './config.js';
+import { ConfigError, type AgentConfig, type AgentNexusConfig } from './config.js';
 
 const DEFAULT_SESSION_TIMEOUT_MS = 300_000;
 
@@ -20,14 +20,12 @@ export interface SelectedAgent {
   >;
 }
 
-export async function createSelectedAgent(
-  config: AgentNexusConfig,
+export async function createAgentRuntime(
+  agentConfig: AgentConfig,
   logger: Logger,
 ): Promise<SelectedAgent> {
-  if (config.agent.backend === 'codex') {
-    const codex = config.codex;
-    if (!codex) throw new Error('agent.backend=codex 需要 codex 配置');
-
+  if (agentConfig.backend === 'codex') {
+    const codex = agentConfig.codex;
     await runCodexCompatibilityProbe({
       config: codex,
       logger,
@@ -43,11 +41,7 @@ export async function createSelectedAgent(
     };
   }
 
-  const claudeCode = config.claudeCode;
-  if (!claudeCode) {
-    throw new Error('agent.backend=claudecode 需要 claudeCode 配置');
-  }
-
+  const claudeCode = agentConfig.claudeCode;
   await runClaudeCodeCompatibilityProbe({
     claudeBin: claudeCode.bin,
     logger,
@@ -82,4 +76,31 @@ export async function createSelectedAgent(
       timeoutMs: DEFAULT_SESSION_TIMEOUT_MS,
     },
   };
+}
+
+export async function createSelectedAgent(
+  config: AgentNexusConfig,
+  logger: Logger,
+): Promise<SelectedAgent> {
+  if (config.platforms.length !== 1) {
+    throw new ConfigError('P9 CLI 启动暂只支持一个 platform；P10 会接入多 platform 路由');
+  }
+  const platform = config.platforms[0];
+  if (!platform) {
+    throw new ConfigError('P9 CLI 启动需要一个 platform');
+  }
+  if (platform.bindings.length !== 1) {
+    throw new ConfigError('P9 CLI 启动暂只支持一个 binding；P10 会接入多 agent 路由');
+  }
+  const binding = platform.bindings[0];
+  if (!binding) {
+    throw new ConfigError('P9 CLI 启动需要一个 binding');
+  }
+  const agentConfig = config.agents.find(
+    (agent) => agent.name === binding.agentName,
+  );
+  if (!agentConfig) {
+    throw new ConfigError(`binding 引用了不存在的 agent：${binding.agentName}`);
+  }
+  return createAgentRuntime(agentConfig, logger);
 }

--- a/packages/cli/src/config.test.ts
+++ b/packages/cli/src/config.test.ts
@@ -22,13 +22,54 @@ import {
   SecretsPermissionError,
   loadConfig,
   loadDiscordToken,
+  loadSecret,
 } from './config.js';
 
-// 最小合法 discord 段——allowedUserIds 必填，下游测试统一用同一个 fixture。
-const VALID_DISCORD = {
-  botUserId: '12345',
-  allowedUserIds: ['U1'],
+const VALID_AUTH = {
+  allowlist: {
+    userIds: ['U1'],
+    allowedGuildIds: ['G1'],
+  },
 };
+
+const VALID_PLATFORM = {
+  name: 'discord-main',
+  type: 'discord',
+  botUserId: '12345',
+  tokenRef: 'DISCORD_BOT_TOKEN',
+  auth: VALID_AUTH,
+  bindings: [{ agentName: 'codex-dev', channelIds: ['C1'] }],
+};
+
+const VALID_CODEX_AGENT = {
+  name: 'codex-dev',
+  backend: 'codex',
+  codex: {
+    workingDir: '/codex',
+    sandbox: 'workspace-write',
+    addDirs: ['/extra'],
+    loadUserConfig: true,
+    loadRules: true,
+  },
+};
+
+const VALID_CLAUDE_AGENT = {
+  name: 'claude-prod',
+  backend: 'claudecode',
+  claudeCode: {
+    workingDir: '/claude',
+    allowedTools: ['Read', 'Bash'],
+    permissionLevel: 'default',
+  },
+};
+
+function validConfig(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    platforms: [VALID_PLATFORM],
+    agents: [VALID_CODEX_AGENT, VALID_CLAUDE_AGENT],
+    ...overrides,
+  };
+}
 
 describe('config loader', () => {
   let tmp: string;
@@ -43,11 +84,11 @@ describe('config loader', () => {
     await rm(tmp, { recursive: true, force: true });
   });
 
-  it('loadConfig 首次运行自动创建 config 模板和 token 文件', async () => {
+  it('loadConfig 首次运行自动创建新结构 config 模板和 tokenRef 对应 secret 文件', async () => {
     await rm(join(tmp, '.agent-nexus'), { recursive: true, force: true });
 
-    await expect(loadConfig()).rejects.toBeInstanceOf(ConfigError);
-    await expect(loadConfig()).rejects.toThrow(/config\.json/);
+    await expect(loadConfig()).rejects.toThrow(ConfigError);
+    await expect(loadConfig()).rejects.toThrow(/config\.json|workingDir/);
 
     const root = await stat(join(tmp, '.agent-nexus'));
     const secrets = await stat(join(tmp, '.agent-nexus', 'secrets'));
@@ -63,323 +104,266 @@ describe('config loader', () => {
     expect(secrets.mode & 0o777).toBe(0o700);
     expect(config.mode & 0o777).toBe(0o600);
     expect(token.mode & 0o777).toBe(0o600);
-    expect(configText).toMatch(/allowedUserIds/);
-    expect(configText).toMatch(/"agent"/);
-    expect(configText).toMatch(/"backend": "claudecode"/);
-    expect(configText).toMatch(/"codex"/);
-    expect(configText).toMatch(/workingDir/);
-    expect(configText).toMatch(/permissionLevel/);
-    expect(configText).toMatch(/_permissionLevelComment/);
-    expect(configText).toMatch(/_levelComment/);
-    expect(configText).toMatch(/toolMessages/);
-    expect(configText).toMatch(/_toolMessagesComment/);
+    expect(configText).toMatch(/"platforms"/);
+    expect(configText).toMatch(/"agents"/);
+    expect(configText).toMatch(/"tokenRef": "DISCORD_BOT_TOKEN"/);
+    expect(configText).toMatch(/"bindings"/);
+    expect(configText).toMatch(/"channelIds"/);
+    expect(configText).toMatch(/"auth"/);
+    expect(configText).toMatch(/"allowlist"/);
+    expect(configText).not.toMatch(/"agent"\s*:/);
+    expect(configText).not.toMatch(/"discord"\s*:/);
   });
 
-  it('loadConfig 缺 discord.botUserId → ConfigError（含字段名）', async () => {
+  it('loadConfig 解析 platforms[] / agents[] 新结构并应用 owner parser 默认值', async () => {
     await writeFile(
       join(tmp, '.agent-nexus', 'config.json'),
-      JSON.stringify({ claudeCode: { workingDir: '/x' } }),
-    );
-    await expect(loadConfig()).rejects.toBeInstanceOf(ConfigError);
-    await expect(loadConfig()).rejects.toThrow(/botUserId/);
-  });
-
-  it('loadConfig 缺 claudeCode.workingDir → ConfigError（含字段名）', async () => {
-    await writeFile(
-      join(tmp, '.agent-nexus', 'config.json'),
-      JSON.stringify({ discord: VALID_DISCORD }),
-    );
-    await expect(loadConfig()).rejects.toBeInstanceOf(ConfigError);
-    await expect(loadConfig()).rejects.toThrow(/workingDir/);
-  });
-
-  it('loadConfig 默认值兜底（bin / allowedTools / log.level）：Bash 默认禁用', async () => {
-    // spec/security/tool-boundary.md：Bash 必须默认禁用，启用须显式列入 allowedTools。
-    await writeFile(
-      join(tmp, '.agent-nexus', 'config.json'),
-      JSON.stringify({
-        discord: VALID_DISCORD,
-        claudeCode: { workingDir: '/x' },
-      }),
-    );
-    const cfg = await loadConfig();
-    expect(cfg.agent.backend).toBe('claudecode');
-    expect(cfg.claudeCode.bin).toBe('claude');
-    expect(cfg.claudeCode.permissionLevel).toBe('default');
-    expect(cfg.claudeCode.allowedTools).not.toContain('Bash');
-    // spec 默认集 Read/Grep/Glob/Edit/Write
-    expect(cfg.claudeCode.allowedTools).toEqual(
-      expect.arrayContaining(['Read', 'Grep', 'Glob', 'Edit', 'Write']),
-    );
-    expect(cfg.ui.toolMessages).toBe('append');
-    expect(cfg.log.level).toBe('info');
-  });
-
-  it('loadConfig 自动补齐缺失的默认字段到 config 文件', async () => {
-    const path = join(tmp, '.agent-nexus', 'config.json');
-    await writeFile(
-      path,
-      JSON.stringify({
-        discord: VALID_DISCORD,
-        claudeCode: { workingDir: '/x' },
-      }),
+      JSON.stringify(validConfig({ ui: { toolMessages: 'compact' }, log: { level: 'debug' } })),
     );
 
     const cfg = await loadConfig();
-    const normalized = JSON.parse(await readFile(path, 'utf8')) as Record<
-      string,
-      unknown
-    >;
 
-    expect(cfg.claudeCode.bin).toBe('claude');
-    expect(normalized).toMatchObject({
-      agent: {
-        _backendComment: 'allowed: claudecode, codex',
-        backend: 'claudecode',
-      },
-      claudeCode: {
-        workingDir: '/x',
-        bin: 'claude',
-        _permissionLevelComment:
-          'allowed: default, acceptEdits, auto, bypassPermissions, dontAsk, plan',
-        permissionLevel: 'default',
-        allowedTools: ['Read', 'Grep', 'Glob', 'Edit', 'Write'],
-      },
-      codex: {
-        workingDir: '',
-        bin: 'codex',
-        _sandboxComment: 'allowed: read-only, workspace-write',
-        sandbox: 'read-only',
-        addDirs: [],
-        loadUserConfig: false,
-        loadRules: false,
-      },
-      log: {
-        _levelComment: 'allowed: trace, debug, info, warn, error, fatal',
-        level: 'info',
-      },
-      ui: {
-        _toolMessagesComment: 'allowed: append, compact',
-        toolMessages: 'append',
-      },
-    });
-    expect((await stat(path)).mode & 0o777).toBe(0o600);
-  });
-
-  it('loadConfig 校验失败前也会补齐缺失的占位字段', async () => {
-    const path = join(tmp, '.agent-nexus', 'config.json');
-    await writeFile(
-      path,
-      JSON.stringify({
-        claudeCode: { workingDir: '/x' },
-      }),
-    );
-
-    await expect(loadConfig()).rejects.toThrow(/botUserId/);
-    const normalized = JSON.parse(await readFile(path, 'utf8')) as Record<
-      string,
-      unknown
-    >;
-    expect(normalized).toMatchObject({
-      agent: {
-        _backendComment: 'allowed: claudecode, codex',
-        backend: 'claudecode',
-      },
-      discord: {
-        botUserId: '',
-        allowedUserIds: [],
-      },
-      codex: {
-        workingDir: '',
-        bin: 'codex',
-        _sandboxComment: 'allowed: read-only, workspace-write',
-        sandbox: 'read-only',
-        addDirs: [],
-        loadUserConfig: false,
-        loadRules: false,
-      },
-      claudeCode: {
-        workingDir: '/x',
-        bin: 'claude',
-        _permissionLevelComment:
-          'allowed: default, acceptEdits, auto, bypassPermissions, dontAsk, plan',
-        permissionLevel: 'default',
-        allowedTools: ['Read', 'Grep', 'Glob', 'Edit', 'Write'],
-      },
-      log: {
-        _levelComment: 'allowed: trace, debug, info, warn, error, fatal',
-        level: 'info',
-      },
-      ui: {
-        _toolMessagesComment: 'allowed: append, compact',
-        toolMessages: 'append',
-      },
-    });
-  });
-
-  it.each(['append', 'compact'] as const)('loadConfig 用户显式 toolMessages=%s → 保留', async (toolMessages) => {
-    await writeFile(
-      join(tmp, '.agent-nexus', 'config.json'),
-      JSON.stringify({
-        discord: VALID_DISCORD,
-        claudeCode: { workingDir: '/x' },
-        ui: { toolMessages },
-      }),
-    );
-    const cfg = await loadConfig();
-    expect(cfg.ui.toolMessages).toBe(toolMessages);
-  });
-
-  it('loadConfig ui.toolMessages 非允许值 → ConfigError', async () => {
-    await writeFile(
-      join(tmp, '.agent-nexus', 'config.json'),
-      JSON.stringify({
-        discord: VALID_DISCORD,
-        claudeCode: { workingDir: '/x' },
-        ui: { toolMessages: 'hidden' },
-      }),
-    );
-    await expect(loadConfig()).rejects.toBeInstanceOf(ConfigError);
-    await expect(loadConfig()).rejects.toThrow(/ui\.toolMessages/);
-  });
-
-  it.each([
-    'acceptEdits',
-    'auto',
-    'bypassPermissions',
-    'default',
-    'dontAsk',
-    'plan',
-  ] as const)('loadConfig 用户显式 permissionLevel=%s → 保留', async (permissionLevel) => {
-    await writeFile(
-      join(tmp, '.agent-nexus', 'config.json'),
-      JSON.stringify({
-        discord: VALID_DISCORD,
-        claudeCode: { workingDir: '/x', permissionLevel },
-      }),
-    );
-    const cfg = await loadConfig();
-    expect(cfg.claudeCode.permissionLevel).toBe(permissionLevel);
-  });
-
-  it('loadConfig 用户显式列出 Bash → 保留', async () => {
-    await writeFile(
-      join(tmp, '.agent-nexus', 'config.json'),
-      JSON.stringify({
-        discord: VALID_DISCORD,
-        claudeCode: { workingDir: '/x', allowedTools: ['Read', 'Bash'] },
-      }),
-    );
-    const cfg = await loadConfig();
-    expect(cfg.claudeCode.allowedTools).toEqual(['Read', 'Bash']);
-  });
-
-  it('loadConfig 缺 discord.allowedUserIds → ConfigError（fail-closed）', async () => {
-    // PR #50 把 discord 解析下沉到 platform-discord，但 allowedUserIds 必填判定
-    // 仍属 cli loader 路由层的可观察契约（错误经包装回 ConfigError 抛出）。
-    await writeFile(
-      join(tmp, '.agent-nexus', 'config.json'),
-      JSON.stringify({
-        discord: { botUserId: '12345' },
-        claudeCode: { workingDir: '/x' },
-      }),
-    );
-    await expect(loadConfig()).rejects.toBeInstanceOf(ConfigError);
-    await expect(loadConfig()).rejects.toThrow(/allowedUserIds/);
-  });
-
-  it('loadConfig agent.backend=codex → 只要求 codex 配置并保留 Claude 配置块可选', async () => {
-    await writeFile(
-      join(tmp, '.agent-nexus', 'config.json'),
-      JSON.stringify({
-        agent: { backend: 'codex' },
-        discord: VALID_DISCORD,
-        codex: {
-          workingDir: '/codex',
-          model: 'gpt-5-codex',
-          sandbox: 'workspace-write',
-          addDirs: ['/extra'],
-          loadUserConfig: true,
-          loadRules: true,
+    expect(cfg.platforms).toHaveLength(1);
+    expect(cfg.platforms[0]).toMatchObject({
+      name: 'discord-main',
+      type: 'discord',
+      tokenRef: 'DISCORD_BOT_TOKEN',
+      botUserId: '12345',
+      publicChannelMode: 'thread',
+      auth: {
+        allowlist: {
+          userIds: ['U1'],
+          roleIds: [],
+          allowedGuildIds: ['G1'],
+          allowedChannelIds: [],
+          allowDM: true,
+          requireMentionOrSlash: true,
         },
-      }),
-    );
-    const cfg = await loadConfig();
-    expect(cfg.agent.backend).toBe('codex');
-    expect(cfg.codex).toMatchObject({
-      bin: 'codex',
-      workingDir: '/codex',
-      model: 'gpt-5-codex',
-      sandbox: 'workspace-write',
-      addDirs: ['/extra'],
-      loadUserConfig: true,
-      loadRules: true,
+      },
+      bindings: [{ agentName: 'codex-dev', channelIds: ['C1'] }],
     });
-    expect(cfg).not.toHaveProperty('claudeCode');
+    expect(cfg.platforms[0].statePath).toBe(
+      join(tmp, '.agent-nexus', 'state', 'discord-discord-main.json'),
+    );
+    expect(cfg.agents).toHaveLength(2);
+    expect(cfg.agents[0]).toMatchObject({
+      name: 'codex-dev',
+      backend: 'codex',
+      codex: { bin: 'codex', workingDir: '/codex' },
+    });
+    expect(cfg.agents[1]).toMatchObject({
+      name: 'claude-prod',
+      backend: 'claudecode',
+      claudeCode: { bin: 'claude', workingDir: '/claude' },
+    });
+    expect(cfg.ui.toolMessages).toBe('compact');
+    expect(cfg.log.level).toBe('debug');
   });
 
-  it('loadConfig agent.backend=codex 且缺 codex.workingDir → ConfigError', async () => {
+  it('legacy 顶层字段被清晰拒绝，不做自动迁移', async () => {
     await writeFile(
       join(tmp, '.agent-nexus', 'config.json'),
       JSON.stringify({
         agent: { backend: 'codex' },
-        discord: VALID_DISCORD,
-        codex: {},
+        discord: { botUserId: '12345', allowedUserIds: ['U1'] },
+        codex: { workingDir: '/codex' },
       }),
     );
-    await expect(loadConfig()).rejects.toBeInstanceOf(ConfigError);
-    await expect(loadConfig()).rejects.toThrow(/codex\.workingDir/);
+
+    await expect(loadConfig()).rejects.toThrow(/legacy|platforms\[\]|agents\[\]/);
   });
 
-  it('loadConfig agent.backend 非允许值 → ConfigError', async () => {
+  it('platforms[] / agents[] 缺失或空数组 → ConfigError（含字段路径）', async () => {
+    await writeFile(join(tmp, '.agent-nexus', 'config.json'), JSON.stringify({ agents: [] }));
+    await expect(loadConfig()).rejects.toThrow(/platforms/);
+
     await writeFile(
       join(tmp, '.agent-nexus', 'config.json'),
-      JSON.stringify({
-        agent: { backend: 'other' },
-        discord: VALID_DISCORD,
-        claudeCode: { workingDir: '/x' },
-      }),
+      JSON.stringify({ platforms: [VALID_PLATFORM], agents: [] }),
     );
-    await expect(loadConfig()).rejects.toBeInstanceOf(ConfigError);
-    await expect(loadConfig()).rejects.toThrow(/agent\.backend/);
+    await expect(loadConfig()).rejects.toThrow(/agents/);
   });
 
-  it('loadConfig discord.statePath 缺省 → 路由传递默认 ~/.agent-nexus/state/discord.json', async () => {
+  it('重复 platform name / agent name → ConfigError（列出重复 name）', async () => {
     await writeFile(
       join(tmp, '.agent-nexus', 'config.json'),
-      JSON.stringify({
-        discord: VALID_DISCORD,
-        claudeCode: { workingDir: '/x' },
-      }),
+      JSON.stringify(
+        validConfig({
+          platforms: [VALID_PLATFORM, { ...VALID_PLATFORM, botUserId: '67890' }],
+        }),
+      ),
     );
-    const cfg = await loadConfig();
-    expect(cfg.discord.statePath).toBe(
-      join(tmp, '.agent-nexus', 'state', 'discord.json'),
+    await expect(loadConfig()).rejects.toThrow(/platforms\[\]\.name.*discord-main/);
+
+    await writeFile(
+      join(tmp, '.agent-nexus', 'config.json'),
+      JSON.stringify(
+        validConfig({
+          agents: [VALID_CODEX_AGENT, { ...VALID_CLAUDE_AGENT, name: 'codex-dev' }],
+        }),
+      ),
+    );
+    await expect(loadConfig()).rejects.toThrow(/agents\[\]\.name.*codex-dev/);
+  });
+
+  it('P9 在 session 隔离完成前拒绝多个同 type platform 实例', async () => {
+    await writeFile(
+      join(tmp, '.agent-nexus', 'config.json'),
+      JSON.stringify(
+        validConfig({
+          platforms: [
+            VALID_PLATFORM,
+            { ...VALID_PLATFORM, name: 'discord-alt', botUserId: '67890' },
+          ],
+        }),
+      ),
+    );
+
+    await expect(loadConfig()).rejects.toThrow(/platforms\[\]\.type.*P10|session/);
+  });
+
+  it('未知 platform type / backend → ConfigError', async () => {
+    await writeFile(
+      join(tmp, '.agent-nexus', 'config.json'),
+      JSON.stringify(
+        validConfig({
+          platforms: [{ ...VALID_PLATFORM, type: 'slack' }],
+        }),
+      ),
+    );
+    await expect(loadConfig()).rejects.toThrow(/platforms\[0\]\.type/);
+
+    await writeFile(
+      join(tmp, '.agent-nexus', 'config.json'),
+      JSON.stringify(
+        validConfig({
+          agents: [{ ...VALID_CODEX_AGENT, backend: 'other' }],
+        }),
+      ),
+    );
+    await expect(loadConfig()).rejects.toThrow(/agents\[0\]\.backend/);
+  });
+
+  it('未知顶层字段和 agent 顶层字段 fail-closed', async () => {
+    await writeFile(
+      join(tmp, '.agent-nexus', 'config.json'),
+      JSON.stringify(validConfig({ routes: [] })),
+    );
+    await expect(loadConfig()).rejects.toThrow(/config\.json\.routes/);
+
+    await writeFile(
+      join(tmp, '.agent-nexus', 'config.json'),
+      JSON.stringify(
+        validConfig({
+          agents: [{ ...VALID_CODEX_AGENT, default: true }],
+        }),
+      ),
+    );
+    await expect(loadConfig()).rejects.toThrow(/agents\[0\]\.default/);
+  });
+
+  it('binding 引用不存在 agent → ConfigError（含 binding 字段路径）', async () => {
+    await writeFile(
+      join(tmp, '.agent-nexus', 'config.json'),
+      JSON.stringify(
+        validConfig({
+          platforms: [
+            {
+              ...VALID_PLATFORM,
+              bindings: [{ agentName: 'missing-agent', channelIds: ['C1'] }],
+            },
+          ],
+        }),
+      ),
+    );
+
+    await expect(loadConfig()).rejects.toThrow(/platforms\[0\]\.bindings\[0\]\.agentName/);
+  });
+
+  it('platform auth 和 Discord binding owner parser 错误经 ConfigError 包装并保留字段路径', async () => {
+    await writeFile(
+      join(tmp, '.agent-nexus', 'config.json'),
+      JSON.stringify(
+        validConfig({
+          platforms: [
+            {
+              ...VALID_PLATFORM,
+              auth: { allowlist: { userIds: [], allowedGuildIds: [] } },
+            },
+          ],
+        }),
+      ),
+    );
+    await expect(loadConfig()).rejects.toThrow(
+      /platforms\[0\]\.auth\.allowlist.*至少/,
+    );
+
+    await writeFile(
+      join(tmp, '.agent-nexus', 'config.json'),
+      JSON.stringify(
+        validConfig({
+          platforms: [
+            {
+              ...VALID_PLATFORM,
+              bindings: [{ agentName: 'codex-dev', channelIds: [] }],
+            },
+          ],
+        }),
+      ),
+    );
+    await expect(loadConfig()).rejects.toThrow(
+      /platforms\[0\]\.bindings\[0\]\.channelIds/,
     );
   });
 
-  it('loadDiscordToken 缺 token 文件 → SecretsPermissionError', async () => {
-    await expect(loadDiscordToken()).rejects.toBeInstanceOf(
+  it('tokenRef 非 secret ref 名称 → ConfigError（parse 期覆盖所有 platform）', async () => {
+    await writeFile(
+      join(tmp, '.agent-nexus', 'config.json'),
+      JSON.stringify(
+        validConfig({
+          platforms: [{ ...VALID_PLATFORM, tokenRef: '../DISCORD_BOT_TOKEN' }],
+        }),
+      ),
+    );
+
+    await expect(loadConfig()).rejects.toThrow(/platforms\[0\]\.tokenRef/);
+  });
+
+  it('agent backend 私有字段缺失或 inactive backend 块存在 → ConfigError', async () => {
+    await writeFile(
+      join(tmp, '.agent-nexus', 'config.json'),
+      JSON.stringify(validConfig({ agents: [{ name: 'codex-dev', backend: 'codex' }] })),
+    );
+    await expect(loadConfig()).rejects.toThrow(/agents\[0\]\.codex/);
+
+    await writeFile(
+      join(tmp, '.agent-nexus', 'config.json'),
+      JSON.stringify(
+        validConfig({
+          agents: [
+            {
+              ...VALID_CODEX_AGENT,
+              claudeCode: { workingDir: '/stale' },
+            },
+          ],
+        }),
+      ),
+    );
+    await expect(loadConfig()).rejects.toThrow(/agents\[0\]\.claudeCode/);
+  });
+
+  it('loadSecret 按 tokenRef 读取 ~/.agent-nexus/secrets/<name>，权限和值都 fail-closed', async () => {
+    await expect(loadSecret('DISCORD_BOT_TOKEN')).rejects.toBeInstanceOf(
       SecretsPermissionError,
     );
-    const token = await stat(
-      join(tmp, '.agent-nexus', 'secrets', 'DISCORD_BOT_TOKEN'),
-    );
-    expect(token.mode & 0o777).toBe(0o600);
-  });
 
-  it('loadDiscordToken 权限非 0600 → SecretsPermissionError', async () => {
-    const path = join(tmp, '.agent-nexus', 'secrets', 'DISCORD_BOT_TOKEN');
-    await writeFile(path, 'token-abc');
-    await chmod(path, 0o644);
-    await expect(loadDiscordToken()).rejects.toThrow(/0600/);
-  });
-
-  it('loadDiscordToken 0600 + 非空 → 返回 trim 后的 token', async () => {
     const path = join(tmp, '.agent-nexus', 'secrets', 'DISCORD_BOT_TOKEN');
     await writeFile(path, '  token-abc\n');
+    await chmod(path, 0o644);
+    await expect(loadSecret('DISCORD_BOT_TOKEN')).rejects.toThrow(/0600/);
+
     await chmod(path, 0o600);
-    const t = await loadDiscordToken();
-    expect(t).toBe('token-abc');
+    await expect(loadSecret('DISCORD_BOT_TOKEN')).resolves.toBe('token-abc');
+    await expect(loadDiscordToken()).resolves.toBe('token-abc');
   });
 });

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -2,8 +2,8 @@ import { chmod, mkdir, readFile, stat, writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import {
-  parseDiscordConfig,
-  type DiscordConfig,
+  parseDiscordPlatformConfig,
+  type DiscordPlatformConfig,
   DiscordConfigError,
 } from '@agent-nexus/platform-discord';
 import {
@@ -18,38 +18,47 @@ import {
 } from '@agent-nexus/agent-codex';
 import {
   parseDaemonConfig,
+  parsePlatformAuthConfig,
   type DaemonConfig,
+  type PlatformAuthConfig,
   DaemonConfigError,
 } from '@agent-nexus/daemon';
 
-export type { DiscordConfig, ClaudeCodeConfig, CodexConfig };
+export type {
+  ClaudeCodeConfig,
+  CodexConfig,
+  DiscordPlatformConfig,
+  PlatformAuthConfig,
+};
 
 export type AgentBackend = 'claudecode' | 'codex';
 
 type LogLevel = 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'fatal';
 
-interface BaseAgentNexusConfig {
-  discord: DiscordConfig;
-  agent: {
-    backend: AgentBackend;
-  };
+export type PlatformConfig = DiscordPlatformConfig & {
+  auth: PlatformAuthConfig;
+};
+
+export type AgentConfig =
+  | {
+      name: string;
+      backend: 'claudecode';
+      claudeCode: ClaudeCodeConfig;
+    }
+  | {
+      name: string;
+      backend: 'codex';
+      codex: CodexConfig;
+    };
+
+export interface AgentNexusConfig {
+  platforms: PlatformConfig[];
+  agents: AgentConfig[];
   ui: DaemonConfig;
   log: {
     level: LogLevel;
   };
 }
-
-export type AgentNexusConfig =
-  | (BaseAgentNexusConfig & {
-      agent: { backend: 'claudecode' };
-      claudeCode: ClaudeCodeConfig;
-      codex?: CodexConfig;
-    })
-  | (BaseAgentNexusConfig & {
-      agent: { backend: 'codex' };
-      codex: CodexConfig;
-      claudeCode?: ClaudeCodeConfig;
-    });
 
 export class ConfigError extends Error {
   constructor(message: string) {
@@ -66,8 +75,9 @@ export class SecretsPermissionError extends Error {
 }
 
 const DEFAULT_LOG_LEVEL = 'info' as const;
-const DEFAULT_BACKEND = 'claudecode' as const;
 const BACKENDS = ['claudecode', 'codex'] as const;
+const PLATFORM_TYPES = ['discord'] as const;
+const LEGACY_TOP_LEVEL_KEYS = ['discord', 'agent', 'claudeCode', 'codex'] as const;
 
 export function configRoot(): string {
   return join(homedir(), '.agent-nexus');
@@ -77,22 +87,26 @@ export function configPath(): string {
   return join(configRoot(), 'config.json');
 }
 
-export function discordTokenPath(): string {
-  return join(configRoot(), 'secrets', 'DISCORD_BOT_TOKEN');
+export function secretPath(name: string): string {
+  return join(configRoot(), 'secrets', name);
 }
 
-export function defaultDiscordStatePath(): string {
-  return join(configRoot(), 'state', 'discord.json');
+export function discordTokenPath(): string {
+  return secretPath('DISCORD_BOT_TOKEN');
+}
+
+export function defaultDiscordStatePath(name: string): string {
+  return join(configRoot(), 'state', `discord-${encodeURIComponent(name)}.json`);
 }
 
 const CONFIG_HINT = (path: string) => `\
 agent-nexus 配置模板已创建：${path}
-请编辑其中的 botUserId、allowedUserIds 和 workingDir，然后确认权限：
+请编辑其中的 platforms[].botUserId、platforms[].auth.allowlist、platforms[].bindings[].channelIds 和 agents[].workingDir，然后确认权限：
   chmod 600 ${path}
 `;
 
 const TOKEN_HINT = (path: string) => `\
-DISCORD_BOT_TOKEN 文件已创建：${path}
+secret 文件已创建或缺失：${path}
 请写入 token（权限必须 0600）：
   echo -n '<your-token>' > ${path}
   chmod 600 ${path}
@@ -100,30 +114,57 @@ DISCORD_BOT_TOKEN 文件已创建：${path}
 
 const DEFAULT_CONFIG_TEMPLATE = `\
 {
-  "agent": {
-    "_backendComment": "allowed: claudecode, codex",
-    "backend": "claudecode"
-  },
-  "discord": {
-    "botUserId": "",
-    "allowedUserIds": []
-  },
-  "claudeCode": {
-    "workingDir": "",
-    "bin": "claude",
-    "_permissionLevelComment": "allowed: default, acceptEdits, auto, bypassPermissions, dontAsk, plan",
-    "permissionLevel": "default",
-    "allowedTools": ["Read", "Grep", "Glob", "Edit", "Write"]
-  },
-  "codex": {
-    "workingDir": "",
-    "bin": "codex",
-    "_sandboxComment": "allowed: read-only, workspace-write",
-    "sandbox": "read-only",
-    "addDirs": [],
-    "loadUserConfig": false,
-    "loadRules": false
-  },
+  "platforms": [
+    {
+      "name": "discord-main",
+      "type": "discord",
+      "botUserId": "",
+      "tokenRef": "DISCORD_BOT_TOKEN",
+      "publicChannelMode": "thread",
+      "auth": {
+        "allowlist": {
+          "userIds": [],
+          "roleIds": [],
+          "allowedGuildIds": [],
+          "allowedChannelIds": [],
+          "allowDM": true,
+          "requireMentionOrSlash": true
+        }
+      },
+      "bindings": [
+        {
+          "agentName": "codex-dev",
+          "channelIds": []
+        }
+      ]
+    }
+  ],
+  "agents": [
+    {
+      "name": "codex-dev",
+      "backend": "codex",
+      "codex": {
+        "workingDir": "",
+        "bin": "codex",
+        "_sandboxComment": "allowed: read-only, workspace-write",
+        "sandbox": "read-only",
+        "addDirs": [],
+        "loadUserConfig": false,
+        "loadRules": false
+      }
+    },
+    {
+      "name": "claude-prod",
+      "backend": "claudecode",
+      "claudeCode": {
+        "workingDir": "",
+        "bin": "claude",
+        "_permissionLevelComment": "allowed: default, acceptEdits, auto, bypassPermissions, dontAsk, plan",
+        "permissionLevel": "default",
+        "allowedTools": ["Read", "Grep", "Glob", "Edit", "Write"]
+      }
+    }
+  ],
   "log": {
     "_levelComment": "allowed: trace, debug, info, warn, error, fatal",
     "level": "info"
@@ -139,44 +180,38 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === 'object' && !Array.isArray(value);
 }
 
-function cloneJsonObject(value: unknown): unknown {
-  return JSON.parse(JSON.stringify(value)) as unknown;
+function requireNonEmptyString(
+  raw: Record<string, unknown>,
+  key: string,
+  path: string,
+): string {
+  const value = raw[key];
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new ConfigError(`${path}.${key} 必须是非空字符串`);
+  }
+  return value;
 }
 
-function applyMissingFields(
-  target: Record<string, unknown>,
-  defaults: Record<string, unknown>,
-): boolean {
-  let changed = false;
-  for (const [key, defaultValue] of Object.entries(defaults)) {
-    if (!(key in target)) {
-      target[key] = cloneJsonObject(defaultValue);
-      changed = true;
-      continue;
-    }
-    if (isRecord(target[key]) && isRecord(defaultValue)) {
-      changed = applyMissingFields(target[key], defaultValue) || changed;
+function duplicateNames(items: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const dup = new Set<string>();
+  for (const name of items) {
+    if (seen.has(name)) dup.add(name);
+    seen.add(name);
+  }
+  return [...dup];
+}
+
+function assertNoUnknownKeys(
+  raw: Record<string, unknown>,
+  allowed: readonly string[],
+  path: string,
+): void {
+  for (const key of Object.keys(raw)) {
+    if (!allowed.includes(key)) {
+      throw new ConfigError(`未知字段 ${path}.${key}`);
     }
   }
-  return changed;
-}
-
-async function writeNormalizedConfigIfNeeded(
-  path: string,
-  obj: Record<string, unknown>,
-): Promise<void> {
-  const defaults = JSON.parse(DEFAULT_CONFIG_TEMPLATE) as Record<string, unknown>;
-  if (!applyMissingFields(obj, defaults)) return;
-  await writeFile(path, `${JSON.stringify(obj, null, 2)}\n`, { mode: 0o600 });
-  await chmod(path, 0o600);
-}
-
-export async function ensureConfigDirs(): Promise<void> {
-  const root = configRoot();
-  const secrets = join(root, 'secrets');
-  await mkdir(secrets, { recursive: true, mode: 0o700 });
-  await chmod(root, 0o700);
-  await chmod(secrets, 0o700);
 }
 
 async function createFileIfMissing(
@@ -196,6 +231,14 @@ async function createFileIfMissing(
   }
 }
 
+export async function ensureConfigDirs(): Promise<void> {
+  const root = configRoot();
+  const secrets = join(root, 'secrets');
+  await mkdir(secrets, { recursive: true, mode: 0o700 });
+  await chmod(root, 0o700);
+  await chmod(secrets, 0o700);
+}
+
 export async function ensureConfigScaffold(): Promise<{
   configCreated: boolean;
   tokenCreated: boolean;
@@ -208,6 +251,158 @@ export async function ensureConfigScaffold(): Promise<{
   );
   const tokenCreated = await createFileIfMissing(discordTokenPath(), '', 0o600);
   return { configCreated, tokenCreated };
+}
+
+function assertArray(raw: Record<string, unknown>, key: string, path: string): unknown[] {
+  const value = raw[key];
+  if (!Array.isArray(value)) {
+    throw new ConfigError(`${path}.${key} 必须是非空数组`);
+  }
+  if (value.length === 0) {
+    throw new ConfigError(`${path}.${key} 不能是空数组`);
+  }
+  return value;
+}
+
+function rejectLegacyTopLevel(path: string, obj: Record<string, unknown>): void {
+  const legacyKeys = LEGACY_TOP_LEVEL_KEYS.filter((key) => key in obj);
+  if (legacyKeys.length === 0) return;
+  throw new ConfigError(
+    `${path} 是 legacy 配置形态（顶层 ${legacyKeys.join(', ')}）。` +
+      '请迁移为 platforms[] / agents[]：platforms[].name/type/auth/bindings/tokenRef，' +
+      'agents[].name/backend/(claudeCode|codex)。loader 不做自动迁移。',
+  );
+}
+
+function parseAgent(raw: unknown, index: number): AgentConfig {
+  const path = `agents[${index}]`;
+  if (!isRecord(raw)) {
+    throw new ConfigError(`字段 ${path} 必须是对象`);
+  }
+  assertNoUnknownKeys(raw, ['name', 'backend', 'claudeCode', 'codex'], path);
+  const name = requireNonEmptyString(raw, 'name', path);
+  const backendRaw = raw['backend'];
+  if (!BACKENDS.includes(backendRaw as AgentBackend)) {
+    throw new ConfigError(
+      `字段 ${path}.backend 必须是 ${BACKENDS.map((v) => `"${v}"`).join(' / ')}`,
+    );
+  }
+  const backend = backendRaw as AgentBackend;
+
+  if (backend === 'codex') {
+    if ('claudeCode' in raw) {
+      throw new ConfigError(`字段 ${path}.claudeCode 不允许出现在 backend="codex" 的 agent 中`);
+    }
+    if (!('codex' in raw)) {
+      throw new ConfigError(`缺字段 ${path}.codex`);
+    }
+    try {
+      return { name, backend, codex: parseCodexConfig(raw['codex']) };
+    } catch (err) {
+      if (err instanceof CodexConfigError) {
+        throw new ConfigError(`${path}.codex ${err.message}`);
+      }
+      throw err;
+    }
+  }
+
+  if ('codex' in raw) {
+    throw new ConfigError(`字段 ${path}.codex 不允许出现在 backend="claudecode" 的 agent 中`);
+  }
+  if (!('claudeCode' in raw)) {
+    throw new ConfigError(`缺字段 ${path}.claudeCode`);
+  }
+  try {
+    return { name, backend, claudeCode: parseClaudeCodeConfig(raw['claudeCode']) };
+  } catch (err) {
+    if (err instanceof ClaudeCodeConfigError) {
+      throw new ConfigError(`${path}.claudeCode ${err.message}`);
+    }
+    throw err;
+  }
+}
+
+function parsePlatform(raw: unknown, index: number): PlatformConfig {
+  const path = `platforms[${index}]`;
+  if (!isRecord(raw)) {
+    throw new ConfigError(`字段 ${path} 必须是对象`);
+  }
+  const typeRaw = raw['type'];
+  if (!PLATFORM_TYPES.includes(typeRaw as 'discord')) {
+    throw new ConfigError(
+      `字段 ${path}.type 必须是 ${PLATFORM_TYPES.map((v) => `"${v}"`).join(' / ')}`,
+    );
+  }
+  const name = requireNonEmptyString(raw, 'name', path);
+
+  let auth: PlatformAuthConfig;
+  try {
+    auth = parsePlatformAuthConfig(raw['auth'], { path: `${path}.auth` });
+  } catch (err) {
+    if (err instanceof DaemonConfigError) {
+      throw new ConfigError(`${configPath()} ${err.message}`);
+    }
+    throw err;
+  }
+
+  try {
+    const platform = parseDiscordPlatformConfig(raw, {
+      path,
+      defaultStatePath: defaultDiscordStatePath(name),
+    });
+    return { ...platform, auth };
+  } catch (err) {
+    if (err instanceof DiscordConfigError) {
+      throw new ConfigError(`${configPath()} ${err.message}`);
+    }
+    throw err;
+  }
+}
+
+function assertSinglePlatformTypeUntilP10(platforms: PlatformConfig[]): void {
+  const seen = new Set<string>();
+  for (const platform of platforms) {
+    if (seen.has(platform.type)) {
+      throw new ConfigError(
+        'platforms[].type 暂不允许配置多个同 type platform；' +
+          'P10 完成 platformName session 隔离后再放开。',
+      );
+    }
+    seen.add(platform.type);
+  }
+}
+
+function assertBindingReferences(
+  platforms: PlatformConfig[],
+  agents: AgentConfig[],
+): void {
+  const agentNames = new Set(agents.map((agent) => agent.name));
+  for (const [platformIndex, platform] of platforms.entries()) {
+    for (const [bindingIndex, binding] of platform.bindings.entries()) {
+      if (!agentNames.has(binding.agentName)) {
+        throw new ConfigError(
+          `字段 platforms[${platformIndex}].bindings[${bindingIndex}].agentName ` +
+            `引用了不存在的 agent "${binding.agentName}"`,
+        );
+      }
+    }
+  }
+}
+
+function parseLog(raw: unknown): { level: LogLevel } {
+  const log = isRecord(raw) ? raw : {};
+  const levelRaw = log['level'];
+  if (
+    levelRaw !== undefined &&
+    !['trace', 'debug', 'info', 'warn', 'error', 'fatal'].includes(
+      levelRaw as LogLevel,
+    )
+  ) {
+    throw new ConfigError(
+      '字段 log.level 必须是 "trace" / "debug" / "info" / "warn" / "error" / "fatal"',
+    );
+  }
+  return { level: (levelRaw as LogLevel | undefined) ?? DEFAULT_LOG_LEVEL };
 }
 
 export async function loadConfig(): Promise<AgentNexusConfig> {
@@ -239,43 +434,38 @@ export async function loadConfig(): Promise<AgentNexusConfig> {
     throw new ConfigError(`${path} 不是合法 JSON：${(err as Error).message}`);
   }
 
-  if (!parsed || typeof parsed !== 'object') {
+  if (!isRecord(parsed)) {
     throw new ConfigError(`${path} 顶层必须是对象`);
   }
-  const obj = parsed as Record<string, unknown>;
-  try {
-    await writeNormalizedConfigIfNeeded(path, obj);
-  } catch (err) {
-    throw new ConfigError(`补齐 ${path} 缺失字段失败：${(err as Error).message}`);
+  rejectLegacyTopLevel(path, parsed);
+  assertNoUnknownKeys(parsed, ['platforms', 'agents', 'log', 'ui'], path);
+
+  const platformsRaw = assertArray(parsed, 'platforms', path);
+  const agentsRaw = assertArray(parsed, 'agents', path);
+
+  const agents = agentsRaw.map((agent, index) => parseAgent(agent, index));
+  const duplicateAgentNames = duplicateNames(agents.map((agent) => agent.name));
+  if (duplicateAgentNames.length > 0) {
+    throw new ConfigError(`agents[].name 重复：${duplicateAgentNames.join(', ')}`);
   }
 
-  const agentRaw = (obj['agent'] as Record<string, unknown> | undefined) ?? {};
-  const backendRaw = agentRaw['backend'];
-  if (
-    backendRaw !== undefined &&
-    !BACKENDS.includes(backendRaw as AgentBackend)
-  ) {
+  const platforms = platformsRaw.map((platform, index) =>
+    parsePlatform(platform, index),
+  );
+  const duplicatePlatformNames = duplicateNames(
+    platforms.map((platform) => platform.name),
+  );
+  if (duplicatePlatformNames.length > 0) {
     throw new ConfigError(
-      `${path} 字段 agent.backend 必须是 ${BACKENDS.map((v) => `"${v}"`).join(' / ')}`,
+      `platforms[].name 重复：${duplicatePlatformNames.join(', ')}`,
     );
   }
-  const backend = (backendRaw as AgentBackend | undefined) ?? DEFAULT_BACKEND;
-
-  let discord: DiscordConfig;
-  try {
-    discord = parseDiscordConfig(obj['discord'], {
-      defaultStatePath: defaultDiscordStatePath(),
-    });
-  } catch (err) {
-    if (err instanceof DiscordConfigError) {
-      throw new ConfigError(`${path} ${err.message}`);
-    }
-    throw err;
-  }
+  assertSinglePlatformTypeUntilP10(platforms);
+  assertBindingReferences(platforms, agents);
 
   let ui: DaemonConfig;
   try {
-    ui = parseDaemonConfig(obj['ui']);
+    ui = parseDaemonConfig(parsed['ui']);
   } catch (err) {
     if (err instanceof DaemonConfigError) {
       throw new ConfigError(`${path} ${err.message}`);
@@ -283,68 +473,33 @@ export async function loadConfig(): Promise<AgentNexusConfig> {
     throw err;
   }
 
-  const log = (obj['log'] as Record<string, unknown> | undefined) ?? {};
-  const levelRaw = log['level'];
-  const level: LogLevel =
-    typeof levelRaw === 'string' &&
-    ['trace', 'debug', 'info', 'warn', 'error', 'fatal'].includes(levelRaw)
-      ? (levelRaw as LogLevel)
-      : DEFAULT_LOG_LEVEL;
-
-  const base = {
-    discord,
-    agent: { backend },
-    ui,
-    log: { level },
-  };
-
-  if (backend === 'codex') {
-    let codex: CodexConfig;
-    try {
-      codex = parseCodexConfig(obj['codex']);
-    } catch (err) {
-      if (err instanceof CodexConfigError) {
-        throw new ConfigError(`${path} ${err.message}`);
-      }
-      throw err;
-    }
-
-    return {
-      ...base,
-      agent: { backend },
-      codex,
-    };
-  }
-
-  let claudeCode: ClaudeCodeConfig;
-  try {
-    claudeCode = parseClaudeCodeConfig(obj['claudeCode']);
-  } catch (err) {
-    if (err instanceof ClaudeCodeConfigError) {
-      throw new ConfigError(`${path} ${err.message}`);
-    }
-    throw err;
-  }
-
   return {
-    ...base,
-    agent: { backend },
-    claudeCode,
+    platforms,
+    agents,
+    ui,
+    log: parseLog(parsed['log']),
   };
 }
 
-export async function loadDiscordToken(): Promise<string> {
+function assertValidSecretName(name: string): void {
+  if (!/^[A-Za-z0-9_][A-Za-z0-9_.-]*$/.test(name)) {
+    throw new SecretsPermissionError(`secret ref "${name}" 不是合法名称`);
+  }
+}
+
+export async function loadSecret(name: string): Promise<string> {
+  assertValidSecretName(name);
   let scaffold;
   try {
     scaffold = await ensureConfigScaffold();
   } catch (err) {
     throw new SecretsPermissionError(`初始化 secrets 文件失败：${(err as Error).message}`);
   }
-  if (scaffold.tokenCreated) {
-    throw new SecretsPermissionError(TOKEN_HINT(discordTokenPath()));
+  if (scaffold.tokenCreated && name === 'DISCORD_BOT_TOKEN') {
+    throw new SecretsPermissionError(TOKEN_HINT(secretPath(name)));
   }
 
-  const path = discordTokenPath();
+  const path = secretPath(name);
   let st;
   try {
     st = await stat(path);
@@ -362,10 +517,13 @@ export async function loadDiscordToken(): Promise<string> {
     );
   }
 
-  const raw = await readFile(path, 'utf8');
-  const token = raw.trim();
+  const token = (await readFile(path, 'utf8')).trim();
   if (token.length === 0) {
     throw new SecretsPermissionError(`${path} 为空`);
   }
   return token;
+}
+
+export async function loadDiscordToken(): Promise<string> {
+  return loadSecret('DISCORD_BOT_TOKEN');
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -8,7 +8,7 @@ import {
   ConfigError,
   SecretsPermissionError,
   loadConfig,
-  loadDiscordToken,
+  loadSecret,
 } from './config.js';
 
 async function main(): Promise<void> {
@@ -16,7 +16,11 @@ async function main(): Promise<void> {
   let token: string;
   try {
     config = await loadConfig();
-    token = await loadDiscordToken();
+    const [firstPlatform] = config.platforms;
+    if (!firstPlatform) {
+      throw new ConfigError('platforms[] 不能是空数组');
+    }
+    token = await loadSecret(firstPlatform.tokenRef);
   } catch (err) {
     if (err instanceof ConfigError || err instanceof SecretsPermissionError) {
       process.stderr.write(`\n${err.message}\n`);
@@ -26,18 +30,43 @@ async function main(): Promise<void> {
   }
 
   const logger = createLogger({ level: config.log.level });
+  const [platformConfig] = config.platforms;
+  if (!platformConfig) {
+    throw new ConfigError('platforms[] 不能是空数组');
+  }
   logger.info(
-    { source: 'file', secret: 'DISCORD_BOT_TOKEN' },
+    { source: 'file', secret: platformConfig.tokenRef },
     'secret_loaded',
+  );
+  logger.warn(
+    {
+      platformName: platformConfig.name,
+      bindingChannelIds: platformConfig.bindings.map((binding) => binding.channelIds),
+      authFieldsParsedOnly: [
+        'roleIds',
+        'allowedGuildIds',
+        'allowedChannelIds',
+        'allowDM',
+        'requireMentionOrSlash',
+      ],
+      publicChannelMode: platformConfig.publicChannelMode,
+      enforcedInP9: ['auth.allowlist.userIds'],
+      plannedPhase: 'P10',
+    },
+    'p9_platform_constraints_not_enforced_until_router',
   );
 
   let selectedAgent: SelectedAgent;
   try {
     selectedAgent = await createSelectedAgent(config, logger);
   } catch (err) {
+    if (err instanceof ConfigError) {
+      process.stderr.write(`\n${err.message}\n`);
+      process.exit(1);
+    }
     logger.error(
       {
-        agentBackend: config.agent.backend,
+        agentNames: config.agents.map((agent) => agent.name),
         errorKind: 'agent',
         code: 'compat_probe_failed',
         cause: err instanceof Error ? err.message : String(err),
@@ -50,14 +79,14 @@ async function main(): Promise<void> {
 
   // state 目录与 secrets 目录同级，权限 0700 与 secrets 一致
   // → spec/platform-adapter.md §"运行时状态持久化"
-  await mkdir(dirname(config.discord.statePath), { recursive: true, mode: 0o700 });
+  await mkdir(dirname(platformConfig.statePath), { recursive: true, mode: 0o700 });
 
   const platform = createDiscordPlatform({
     token,
-    botUserId: config.discord.botUserId,
-    statePath: config.discord.statePath,
-    allowedUserIds: config.discord.allowedUserIds,
-    testGuildId: config.discord.testGuildId,
+    botUserId: platformConfig.botUserId,
+    statePath: platformConfig.statePath,
+    allowedUserIds: platformConfig.auth.allowlist.userIds,
+    testGuildId: platformConfig.testGuildId,
     logger,
   });
 

--- a/packages/daemon/src/config.test.ts
+++ b/packages/daemon/src/config.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { DaemonConfigError, parseDaemonConfig } from './config.js';
+import {
+  DaemonConfigError,
+  parseDaemonConfig,
+  parsePlatformAuthConfig,
+} from './config.js';
 
 describe('daemon config', () => {
   it('缺省 toolMessages → append', () => {
@@ -18,5 +22,89 @@ describe('daemon config', () => {
     expect(() => parseDaemonConfig({ toolMessages: 'hidden' })).toThrow(
       /ui\.toolMessages/,
     );
+  });
+});
+
+describe('platform auth config', () => {
+  const validAuth = {
+    allowlist: {
+      userIds: ['U1'],
+      roleIds: [],
+      allowedGuildIds: ['G1'],
+      allowedChannelIds: ['C1'],
+      allowDM: false,
+      requireMentionOrSlash: true,
+    },
+  };
+
+  it('解析 platforms[].auth.allowlist 并保留显式字段', () => {
+    expect(
+      parsePlatformAuthConfig(validAuth, { path: 'platforms[0].auth' }),
+    ).toEqual(validAuth);
+  });
+
+  it('allowDM / requireMentionOrSlash 缺省为 true，role/channel 列表缺省为空', () => {
+    expect(
+      parsePlatformAuthConfig(
+        {
+          allowlist: {
+            userIds: ['U1'],
+            allowedGuildIds: ['G1'],
+          },
+        },
+        { path: 'platforms[0].auth' },
+      ),
+    ).toEqual({
+      allowlist: {
+        userIds: ['U1'],
+        roleIds: [],
+        allowedGuildIds: ['G1'],
+        allowedChannelIds: [],
+        allowDM: true,
+        requireMentionOrSlash: true,
+      },
+    });
+  });
+
+  it('ID 列表允许缺省或空数组，但至少一个 ID 列表要非空', () => {
+    expect(
+      parsePlatformAuthConfig(
+        { allowlist: { userIds: [], roleIds: ['R1'], allowedGuildIds: ['G1'] } },
+        { path: 'platforms[0].auth' },
+      ).allowlist,
+    ).toMatchObject({
+      userIds: [],
+      roleIds: ['R1'],
+      allowedGuildIds: ['G1'],
+    });
+
+    expect(() =>
+      parsePlatformAuthConfig(
+        {
+          allowlist: {
+            userIds: [],
+            roleIds: [],
+            allowedGuildIds: [],
+            allowedChannelIds: [],
+          },
+        },
+        { path: 'platforms[0].auth' },
+      ),
+    ).toThrow(/platforms\[0\]\.auth\.allowlist.*至少/);
+  });
+
+  it('未知 allowlist 字段 fail-closed', () => {
+    expect(() =>
+      parsePlatformAuthConfig(
+        {
+          allowlist: {
+            userIds: ['U1'],
+            allowedGuildIds: ['G1'],
+            shared_channel_mode: true,
+          },
+        },
+        { path: 'platforms[0].auth' },
+      ),
+    ).toThrow(/shared_channel_mode/);
   });
 });

--- a/packages/daemon/src/config.ts
+++ b/packages/daemon/src/config.ts
@@ -5,11 +5,136 @@ export interface DaemonConfig {
   toolMessages: ToolMessageMode;
 }
 
+export interface AllowlistConfig {
+  userIds: string[];
+  roleIds: string[];
+  allowedGuildIds: string[];
+  allowedChannelIds: string[];
+  allowDM: boolean;
+  requireMentionOrSlash: boolean;
+}
+
+export interface PlatformAuthConfig {
+  allowlist: AllowlistConfig;
+}
+
 export class DaemonConfigError extends Error {
   constructor(message: string) {
     super(message);
     this.name = 'DaemonConfigError';
   }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function assertNoUnknownKeys(
+  raw: Record<string, unknown>,
+  allowed: readonly string[],
+  path: string,
+): void {
+  for (const key of Object.keys(raw)) {
+    if (!allowed.includes(key)) {
+      throw new DaemonConfigError(`未知字段 ${path}.${key}`);
+    }
+  }
+}
+
+function parseStringArray(
+  raw: Record<string, unknown>,
+  key: string,
+  path: string,
+): string[] {
+  const value = raw[key];
+  if (value === undefined) {
+    return [];
+  }
+  if (!Array.isArray(value)) {
+    throw new DaemonConfigError(`字段 ${path}.${key} 必须是字符串数组`);
+  }
+  for (const item of value) {
+    if (typeof item !== 'string' || item.length === 0) {
+      throw new DaemonConfigError(`字段 ${path}.${key} 必须是非空字符串数组`);
+    }
+  }
+  return [...value];
+}
+
+function parseBoolean(
+  raw: Record<string, unknown>,
+  key: string,
+  path: string,
+  defaultValue: boolean,
+): boolean {
+  const value = raw[key];
+  if (value === undefined) return defaultValue;
+  if (typeof value !== 'boolean') {
+    throw new DaemonConfigError(`字段 ${path}.${key} 必须是布尔值`);
+  }
+  return value;
+}
+
+export function parsePlatformAuthConfig(
+  raw: unknown,
+  ctx: { path: string } = { path: 'auth' },
+): PlatformAuthConfig {
+  if (!isRecord(raw)) {
+    throw new DaemonConfigError(`字段 ${ctx.path} 必须是对象`);
+  }
+  assertNoUnknownKeys(raw, ['allowlist'], ctx.path);
+
+  const allowlistPath = `${ctx.path}.allowlist`;
+  if (!isRecord(raw['allowlist'])) {
+    throw new DaemonConfigError(`字段 ${allowlistPath} 必须是对象`);
+  }
+  const allowlist = raw['allowlist'];
+  assertNoUnknownKeys(
+    allowlist,
+    [
+      'userIds',
+      'roleIds',
+      'allowedGuildIds',
+      'allowedChannelIds',
+      'allowDM',
+      'requireMentionOrSlash',
+    ],
+    allowlistPath,
+  );
+
+  const parsed: AllowlistConfig = {
+    userIds: parseStringArray(allowlist, 'userIds', allowlistPath),
+    roleIds: parseStringArray(allowlist, 'roleIds', allowlistPath),
+    allowedGuildIds: parseStringArray(
+      allowlist,
+      'allowedGuildIds',
+      allowlistPath,
+    ),
+    allowedChannelIds: parseStringArray(
+      allowlist,
+      'allowedChannelIds',
+      allowlistPath,
+    ),
+    allowDM: parseBoolean(allowlist, 'allowDM', allowlistPath, true),
+    requireMentionOrSlash: parseBoolean(
+      allowlist,
+      'requireMentionOrSlash',
+      allowlistPath,
+      true,
+    ),
+  };
+  if (
+    parsed.userIds.length === 0 &&
+    parsed.roleIds.length === 0 &&
+    parsed.allowedGuildIds.length === 0 &&
+    parsed.allowedChannelIds.length === 0
+  ) {
+    throw new DaemonConfigError(
+      `字段 ${allowlistPath} 至少需要一个非空 ID 列表`,
+    );
+  }
+
+  return { allowlist: parsed };
 }
 
 export function parseDaemonConfig(raw: unknown): DaemonConfig {

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -2,8 +2,11 @@ export { createLogger, type Logger, type CreateLoggerOptions } from './logger.js
 export { Engine, type EngineDeps } from './engine.js';
 export {
   parseDaemonConfig,
+  parsePlatformAuthConfig,
   DaemonConfigError,
+  type AllowlistConfig,
   type DaemonConfig,
+  type PlatformAuthConfig,
   type ToolMessageMode,
 } from './config.js';
 export { SessionStore, type SessionEntry } from './session-store.js';

--- a/packages/platform/discord/src/config.test.ts
+++ b/packages/platform/discord/src/config.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { parseDiscordConfig, DiscordConfigError } from './config.js';
+import {
+  parseDiscordConfig,
+  parseDiscordPlatformConfig,
+  DiscordConfigError,
+} from './config.js';
 
 const DEFAULT_STATE_PATH = '/default/state/discord.json';
 const ctx = { defaultStatePath: DEFAULT_STATE_PATH };
@@ -130,5 +134,86 @@ describe('parseDiscordConfig', () => {
     expect(result.allowedUserIds).toEqual(['U1']);
     expect(result.statePath).toBe(DEFAULT_STATE_PATH);
     expect(result.testGuildId).toBeUndefined();
+  });
+});
+
+describe('parseDiscordPlatformConfig', () => {
+  const validPlatform = {
+    name: 'discord-main',
+    type: 'discord',
+    botUserId: '12345',
+    tokenRef: 'DISCORD_BOT_TOKEN',
+    auth: { allowlist: { userIds: ['U1'], allowedGuildIds: ['G1'] } },
+    bindings: [{ agentName: 'codex-dev', channelIds: ['C1'] }],
+  };
+
+  it('解析 Discord platform owner 字段和 channel binding', () => {
+    const result = parseDiscordPlatformConfig(validPlatform, {
+      path: 'platforms[0]',
+      defaultStatePath: DEFAULT_STATE_PATH,
+    });
+
+    expect(result).toEqual({
+      name: 'discord-main',
+      type: 'discord',
+      botUserId: '12345',
+      tokenRef: 'DISCORD_BOT_TOKEN',
+      statePath: DEFAULT_STATE_PATH,
+      publicChannelMode: 'thread',
+      bindings: [{ agentName: 'codex-dev', channelIds: ['C1'] }],
+    });
+  });
+
+  it('binding.channelIds 缺失、空数组、非字符串元素都拒绝并带字段路径', () => {
+    expect(() =>
+      parseDiscordPlatformConfig(
+        { ...validPlatform, bindings: [{ agentName: 'codex-dev' }] },
+        { path: 'platforms[0]', defaultStatePath: DEFAULT_STATE_PATH },
+      ),
+    ).toThrow(/platforms\[0\]\.bindings\[0\]\.channelIds/);
+
+    expect(() =>
+      parseDiscordPlatformConfig(
+        { ...validPlatform, bindings: [{ agentName: 'codex-dev', channelIds: [] }] },
+        { path: 'platforms[0]', defaultStatePath: DEFAULT_STATE_PATH },
+      ),
+    ).toThrow(/platforms\[0\]\.bindings\[0\]\.channelIds/);
+
+    expect(() =>
+      parseDiscordPlatformConfig(
+        { ...validPlatform, bindings: [{ agentName: 'codex-dev', channelIds: ['C1', 42] }] },
+        { path: 'platforms[0]', defaultStatePath: DEFAULT_STATE_PATH },
+      ),
+    ).toThrow(/platforms\[0\]\.bindings\[0\]\.channelIds/);
+  });
+
+  it('binding 未知条件字段 fail-closed', () => {
+    expect(() =>
+      parseDiscordPlatformConfig(
+        {
+          ...validPlatform,
+          bindings: [{ agentName: 'codex-dev', channelIds: ['C1'], guildIds: ['G1'] }],
+        },
+        { path: 'platforms[0]', defaultStatePath: DEFAULT_STATE_PATH },
+      ),
+    ).toThrow(/platforms\[0\]\.bindings\[0\]\.guildIds/);
+  });
+
+  it('未知 platform 字段 fail-closed，避免把 token 明文混进配置', () => {
+    expect(() =>
+      parseDiscordPlatformConfig(
+        { ...validPlatform, token: 'secret-value' },
+        { path: 'platforms[0]', defaultStatePath: DEFAULT_STATE_PATH },
+      ),
+    ).toThrow(/platforms\[0\]\.token/);
+  });
+
+  it('tokenRef 必须是 secret ref 名称，不能包含路径分隔符', () => {
+    expect(() =>
+      parseDiscordPlatformConfig(
+        { ...validPlatform, tokenRef: '../DISCORD_BOT_TOKEN' },
+        { path: 'platforms[0]', defaultStatePath: DEFAULT_STATE_PATH },
+      ),
+    ).toThrow(/platforms\[0\]\.tokenRef/);
   });
 });

--- a/packages/platform/discord/src/config.ts
+++ b/packages/platform/discord/src/config.ts
@@ -16,11 +16,166 @@ export interface DiscordConfig {
   testGuildId?: string;
 }
 
+export type DiscordPublicChannelMode = 'disabled' | 'thread' | 'public';
+
+export interface DiscordBindingConfig {
+  agentName: string;
+  channelIds: string[];
+}
+
+export interface DiscordPlatformConfig {
+  name: string;
+  type: 'discord';
+  botUserId: string;
+  tokenRef: string;
+  bindings: DiscordBindingConfig[];
+  statePath: string;
+  testGuildId?: string;
+  publicChannelMode: DiscordPublicChannelMode;
+}
+
 export class DiscordConfigError extends Error {
   constructor(message: string) {
     super(message);
     this.name = 'DiscordConfigError';
   }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function assertNoUnknownKeys(
+  raw: Record<string, unknown>,
+  allowed: readonly string[],
+  path: string,
+): void {
+  for (const key of Object.keys(raw)) {
+    if (!allowed.includes(key)) {
+      throw new DiscordConfigError(`未知字段 ${path}.${key}`);
+    }
+  }
+}
+
+function requireString(raw: Record<string, unknown>, key: string, path: string): string {
+  const value = raw[key];
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new DiscordConfigError(`缺字段 ${path}.${key}（非空字符串）`);
+  }
+  return value;
+}
+
+function optionalString(
+  raw: Record<string, unknown>,
+  key: string,
+  path: string,
+): string | undefined {
+  const value = raw[key];
+  if (value === undefined) return undefined;
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new DiscordConfigError(`字段 ${path}.${key} 必须是非空字符串`);
+  }
+  return value;
+}
+
+function assertValidSecretRef(value: string, path: string): void {
+  if (!/^[A-Za-z0-9_][A-Za-z0-9_.-]*$/.test(value)) {
+    throw new DiscordConfigError(`字段 ${path} 必须是 secret ref 名称，不能包含路径分隔符`);
+  }
+}
+
+function parseBinding(raw: unknown, path: string): DiscordBindingConfig {
+  if (!isRecord(raw)) {
+    throw new DiscordConfigError(`字段 ${path} 必须是对象`);
+  }
+  assertNoUnknownKeys(raw, ['agentName', 'channelIds'], path);
+
+  const agentName = requireString(raw, 'agentName', path);
+  const channelIdsRaw = raw['channelIds'];
+  if (!Array.isArray(channelIdsRaw)) {
+    throw new DiscordConfigError(`字段 ${path}.channelIds 必须是非空字符串数组`);
+  }
+  if (channelIdsRaw.length === 0) {
+    throw new DiscordConfigError(`字段 ${path}.channelIds 不能是空数组`);
+  }
+  for (const channelId of channelIdsRaw) {
+    if (typeof channelId !== 'string' || channelId.length === 0) {
+      throw new DiscordConfigError(`字段 ${path}.channelIds 必须是非空字符串数组`);
+    }
+  }
+
+  return { agentName, channelIds: [...channelIdsRaw] };
+}
+
+export function parseDiscordPlatformConfig(
+  raw: unknown,
+  ctx: { path: string; defaultStatePath: string },
+): DiscordPlatformConfig {
+  if (!isRecord(raw)) {
+    throw new DiscordConfigError(`字段 ${ctx.path} 必须是对象`);
+  }
+  assertNoUnknownKeys(
+    raw,
+    [
+      'name',
+      'type',
+      'botUserId',
+      'tokenRef',
+      'bindings',
+      'auth',
+      'statePath',
+      'testGuildId',
+      'publicChannelMode',
+    ],
+    ctx.path,
+  );
+
+  const name = requireString(raw, 'name', ctx.path);
+  const type = requireString(raw, 'type', ctx.path);
+  if (type !== 'discord') {
+    throw new DiscordConfigError(`字段 ${ctx.path}.type 必须是 "discord"`);
+  }
+  const botUserId = requireString(raw, 'botUserId', ctx.path);
+  const tokenRef = requireString(raw, 'tokenRef', ctx.path);
+  assertValidSecretRef(tokenRef, `${ctx.path}.tokenRef`);
+
+  const bindingsRaw = raw['bindings'];
+  if (!Array.isArray(bindingsRaw)) {
+    throw new DiscordConfigError(`字段 ${ctx.path}.bindings 必须是非空数组`);
+  }
+  if (bindingsRaw.length === 0) {
+    throw new DiscordConfigError(`字段 ${ctx.path}.bindings 不能是空数组`);
+  }
+  const bindings = bindingsRaw.map((binding, index) =>
+    parseBinding(binding, `${ctx.path}.bindings[${index}]`),
+  );
+
+  const statePath = optionalString(raw, 'statePath', ctx.path) ?? ctx.defaultStatePath;
+  const testGuildId = optionalString(raw, 'testGuildId', ctx.path);
+  const publicChannelModeRaw = raw['publicChannelMode'];
+  if (
+    publicChannelModeRaw !== undefined &&
+    !['disabled', 'thread', 'public'].includes(
+      publicChannelModeRaw as DiscordPublicChannelMode,
+    )
+  ) {
+    throw new DiscordConfigError(
+      `字段 ${ctx.path}.publicChannelMode 必须是 "disabled" / "thread" / "public"`,
+    );
+  }
+  const publicChannelMode =
+    (publicChannelModeRaw as DiscordPublicChannelMode | undefined) ?? 'thread';
+
+  return {
+    name,
+    type: 'discord',
+    botUserId,
+    tokenRef,
+    bindings,
+    statePath,
+    ...(testGuildId === undefined ? {} : { testGuildId }),
+    publicChannelMode,
+  };
 }
 
 export function parseDiscordConfig(

--- a/packages/platform/discord/src/index.ts
+++ b/packages/platform/discord/src/index.ts
@@ -1,4 +1,12 @@
-export { parseDiscordConfig, type DiscordConfig, DiscordConfigError } from './config.js';
+export {
+  parseDiscordConfig,
+  parseDiscordPlatformConfig,
+  DiscordConfigError,
+  type DiscordBindingConfig,
+  type DiscordConfig,
+  type DiscordPlatformConfig,
+  type DiscordPublicChannelMode,
+} from './config.js';
 
 // TODO MVP 跳过：
 // - DM 消息（intents 没开 DirectMessages）


### PR DESCRIPTION
## Summary

Implements P9 of the multi-platform/multi-agent config epic:
- switches the CLI loader to top-level `platforms[]` / `agents[]`
- rejects legacy top-level `discord` / `agent` / `claudeCode` / `codex` configs with migration guidance
- validates duplicate names, backend/type enums, inactive backend blocks, binding references, Discord `channelIds`, auth allowlist shape, and `tokenRef` names
- keeps current runtime startup limited to one platform and one binding until P10 routing/session isolation, with an explicit warning for parsed platform constraints that are not enforced until P10

## ADR / spec

- ADR/spec: `docs/dev/spec/config-routing.md` from P8 PR #111
- Auth owner rules: `docs/dev/spec/security/auth.md`
- Secret owner rules: `docs/dev/spec/security/secrets.md`

## Tests

- Red confirmed before implementation: new P9 tests initially failed against the legacy loader.
- `corepack pnpm test packages/daemon/src/config.test.ts packages/platform/discord/src/config.test.ts packages/cli/src/config.test.ts packages/cli/src/agent.test.ts`
- `corepack pnpm test`
- `corepack pnpm typecheck`
- `corepack pnpm build`
- `git diff --check`

## Review

Adversarial review log: `/home/node/.goal/codex-agent/reviews/p9-adversarial-20260523-230628`

Round 1 found one blocker and two important issues; all were fixed. Round 2 verdict: `接近最优，建议停止`.

Backlog-only nits from review:
- an unreachable defensive `platformConfig` check could be simplified later
- the P9 warning for parsed-but-not-enforced platform constraints has no direct assertion yet