### PR TITLE
feat(daemon): route platform bindings to named agents

### DIFF
--- a/docs/dev/spec/config-routing.md
+++ b/docs/dev/spec/config-routing.md
@@ -256,17 +256,16 @@ platform adapter 实例。
 
 ## Session 隔离
 
-`SessionKey.platform` 当前只有平台类型字符串（如 `"discord"`）。多 platform 实例后，同一类型的不同 bot 可能拥有相同 channel/user ID，必须纳入 platform instance identity。
+Adapter 产出的 `PlatformSessionKey.platform` 只有平台类型字符串（如 `"discord"`）。多 platform 实例后，同一类型的不同 bot 可能拥有相同 channel/user ID，daemon 必须在 route decision 后注入 platform instance identity。
 
-P10 起 `SessionKey` 或等价 routing/session context 必须包含 `platformName`。序列化 session key 至少区分：
+P10 起 daemon/agent 侧完整 `SessionKey` 必须包含 `platformName`。序列化 session key 区分：
 
 ```text
 platformName + platformType + channelId + initiatorUserId
 ```
 
-在该迁移完成前，CLI 必须拒绝同时启动两个同 type platform 实例，错误消息说明当前 session 隔离尚未完成。
-P10 改动必须同步覆盖 session-store、idempotency 与 persistence 的 key 序列化测试；不得让新 4 段 key 与旧
-3 段 key 在同一 store 中混用。
+P10 迁移完成后，CLI 可以同时启动多个同 type platform 实例；session store、idempotency 与 persistence
+不得使用旧 3 段 key。
 
 ## Legacy 配置迁移
 
@@ -319,7 +318,7 @@ P9 实现必须覆盖：
 5. Discord binding `match.discord.channelIds` 非空字符串数组校验。
 6. legacy config 被清晰拒绝。
 7. routing 0 命中、1 命中、多命中三分支；未授权用户走 `auth_denied` 而不是 `route_not_found`。
-8. 两个同 type platform 实例在 session 隔离迁移前被清晰拒绝。
+8. 两个同 type platform 实例在 session 隔离迁移完成后可被解析；statePath 由 platform name 派生，互不复用。
 9. secret 示例与日志不包含 token 明文。
 
 P10 实现必须覆盖：

--- a/docs/dev/spec/infra/persistence.md
+++ b/docs/dev/spec/infra/persistence.md
@@ -48,7 +48,7 @@ contracts:
 | 列 | 类型 | 约束 |
 |---|---|---|
 | `session_id` | TEXT PRIMARY KEY | ulid / uuidv7；单调递增 |
-| `session_key` | TEXT NOT NULL | `<platform>:<channelId>:<userId>` |
+| `session_key` | TEXT NOT NULL | `<platformName>:<platform>:<channelId>:<userId>` |
 | `generation` | INTEGER NOT NULL | 同 session_key 下的代数，从 1 起 |
 | `state` | TEXT NOT NULL | `Created|Active|Idle|Archived|Errored|Interrupted` |
 | `created_at` | TEXT NOT NULL | RFC3339 |

--- a/docs/dev/spec/message-protocol.md
+++ b/docs/dev/spec/message-protocol.md
@@ -33,7 +33,7 @@ NormalizedEvent {
     // 标识
     eventId: string                          // 平台事件 ID（全局唯一，含时间序）
     platform: string                         // "discord"
-    sessionKey: SessionKey
+    sessionKey: PlatformSessionKey
     messageId: string?                       // 消息类事件必填
     traceId: string                          // adapter 生成或从上下文继承
 
@@ -76,21 +76,27 @@ enum EventType {
 
 ## SessionKey
 
-入站事件归一化的会话路由 key。
+Platform adapter 产出的入站事件只包含平台类型、频道和发起者；配置实例名由 daemon routing 层在
+`RouteContext.platformName` 中注入。daemon/agent 侧使用的完整 `SessionKey` 必须包含 `platformName`。
 
 ```text
-SessionKey {
+PlatformSessionKey {
     platform: string                // IM 平台标识，例 "discord"
     channelId: string               // 会话容器 ID（Discord channel ID 或 thread ID）
     initiatorUserId: string         // 发起者 ID
 }
+
+SessionKey {
+    platformName: string            // 配置实例名，例 "discord-main"
+    platform: string
+    channelId: string
+    initiatorUserId: string
+}
 ```
 
-序列化（日志、持久化）：`<platform>:<channelId>:<initiatorUserId>`。
-
-多 platform instance 路由引入后，session partition 必须额外区分配置实例名
-`platformName`；迁移语义见 [`config-routing.md`](config-routing.md) §Session 隔离。在迁移落地前，
-不得同时启动两个同 type platform 实例。
+完整 `SessionKey` 序列化（日志、持久化、session/idempotency key）：
+`<platformName>:<platform>:<channelId>:<initiatorUserId>`。`PlatformSessionKey` 只能用于 adapter
+入站归一化，不得作为 daemon session/idempotency 存储 key。
 
 **SessionKey 不唯一跨时间**——同一 SessionKey 可以随时间对应多个已归档 + 一个活跃的 session 实例。会话本体的持久化主键是 `sessionId`，不是 SessionKey。SessionKey 与 sessionId 的关系、生命周期、Discord thread 映射等组合语义见 [`../architecture/session-model.md`](../architecture/session-model.md)。
 

--- a/docs/dev/spec/platform-adapter.md
+++ b/docs/dev/spec/platform-adapter.md
@@ -87,7 +87,7 @@ platform instance 的稳定实例名由 [`config-routing.md`](config-routing.md)
 |---|---|---|
 | `eventId` | 是 | 平台事件 ID（Discord interaction id / message id） |
 | `platform` | 是 | `"discord"` |
-| `sessionKey` | 是 | `(platform, channelId, userId)` 构造 |
+| `sessionKey` | 是 | adapter 层 `PlatformSessionKey(platform, channelId, userId)`；daemon routing 层再注入 `platformName` |
 | `messageId` | 视事件 | 消息类事件必填（Discord message snowflake） |
 | `type` | 是 | `message | command | reaction | ...` |
 | `text` | 视事件 | 消息正文（已去除 bot mention） |

--- a/packages/agent/claudecode/src/index.test.ts
+++ b/packages/agent/claudecode/src/index.test.ts
@@ -26,6 +26,7 @@ const fakeLogger = {
 } as unknown as import('@agent-nexus/daemon').Logger;
 
 const sessionKey: SessionKey = {
+  platformName: 'discord-main',
   platform: 'discord',
   channelId: 'C1',
   initiatorUserId: 'U1',

--- a/packages/agent/codex/src/index.test.ts
+++ b/packages/agent/codex/src/index.test.ts
@@ -36,6 +36,7 @@ const codexConfig: CodexConfig = {
 };
 
 const sessionKey: SessionKey = {
+  platformName: 'discord-main',
   platform: 'discord',
   channelId: 'C1',
   initiatorUserId: 'U1',

--- a/packages/cli/src/agent.test.ts
+++ b/packages/cli/src/agent.test.ts
@@ -21,7 +21,7 @@ vi.mock('@agent-nexus/agent-codex', () => ({
   runCompatibilityProbe: runCodexProbeMock,
 }));
 
-import { createAgentRuntime, createSelectedAgent } from './agent.js';
+import { createAgentRegistry, createAgentRuntime } from './agent.js';
 
 const logger = {
   warn: vi.fn(),
@@ -142,9 +142,9 @@ describe('createAgentRuntime', () => {
   });
 });
 
-describe('createSelectedAgent', () => {
-  it('P9 启动路径从唯一 binding 选择目标 agent', async () => {
-    const selected = await createSelectedAgent(
+describe('createAgentRegistry', () => {
+  it('为每个命名 agent 创建 runtime，binding 选择交给 daemon router', async () => {
+    const registry = await createAgentRegistry(
       baseConfig('codex-dev', [
         {
           name: 'codex-dev',
@@ -158,14 +158,32 @@ describe('createSelectedAgent', () => {
             loadRules: false,
           },
         },
+        {
+          name: 'claude-prod',
+          backend: 'claudecode',
+          claudeCode: {
+            bin: 'claude',
+            workingDir: '/claude',
+            allowedTools: ['Read'],
+            permissionLevel: 'default',
+          },
+        },
       ]),
       logger,
     );
 
-    expect(selected.agent).toBe(codexRuntime);
+    expect(registry).toHaveLength(2);
+    expect(registry[0]).toMatchObject({
+      agentName: 'codex-dev',
+      agent: codexRuntime,
+    });
+    expect(registry[1]).toMatchObject({
+      agentName: 'claude-prod',
+      agent: claudeRuntime,
+    });
   });
 
-  it('P9 启动路径遇到多个 binding 时拒绝，避免假装完成 P10 路由', async () => {
+  it('多个 binding 不再阻止 agent registry 创建', async () => {
     const config = baseConfig('codex-dev', [
       {
         name: 'codex-dev',
@@ -187,6 +205,6 @@ describe('createSelectedAgent', () => {
       match: { discord: { channelIds: ['C2'] } },
     });
 
-    await expect(createSelectedAgent(config, logger)).rejects.toThrow(/P10/);
+    await expect(createAgentRegistry(config, logger)).resolves.toHaveLength(1);
   });
 });

--- a/packages/cli/src/agent.ts
+++ b/packages/cli/src/agent.ts
@@ -8,7 +8,8 @@ import {
 } from '@agent-nexus/agent-codex';
 import type { Logger } from '@agent-nexus/daemon';
 import type { AgentRuntime, SessionConfig } from '@agent-nexus/protocol';
-import { ConfigError, type AgentConfig, type AgentNexusConfig } from './config.js';
+import type { EngineAgent } from '@agent-nexus/daemon';
+import type { AgentConfig, AgentNexusConfig } from './config.js';
 
 const DEFAULT_SESSION_TIMEOUT_MS = 300_000;
 
@@ -78,29 +79,18 @@ export async function createAgentRuntime(
   };
 }
 
-export async function createSelectedAgent(
+export async function createAgentRegistry(
   config: AgentNexusConfig,
   logger: Logger,
-): Promise<SelectedAgent> {
-  if (config.platforms.length !== 1) {
-    throw new ConfigError('P9 CLI 启动暂只支持一个 platform；P10 会接入多 platform 路由');
+): Promise<EngineAgent[]> {
+  const registry: EngineAgent[] = [];
+  for (const agentConfig of config.agents) {
+    const selected = await createAgentRuntime(agentConfig, logger);
+    registry.push({
+      agentName: agentConfig.name,
+      agent: selected.agent,
+      defaultSessionConfig: selected.defaultSessionConfig,
+    });
   }
-  const platform = config.platforms[0];
-  if (!platform) {
-    throw new ConfigError('P9 CLI 启动需要一个 platform');
-  }
-  if (config.bindings.length !== 1) {
-    throw new ConfigError('P9 CLI 启动暂只支持一个 binding；P10 会接入多 agent 路由');
-  }
-  const binding = config.bindings[0];
-  if (!binding) {
-    throw new ConfigError('P9 CLI 启动需要一个 binding');
-  }
-  const agentConfig = config.agents.find(
-    (agent) => agent.name === binding.agentName,
-  );
-  if (!agentConfig) {
-    throw new ConfigError(`binding 引用了不存在的 agent：${binding.agentName}`);
-  }
-  return createAgentRuntime(agentConfig, logger);
+  return registry;
 }

--- a/packages/cli/src/config.test.ts
+++ b/packages/cli/src/config.test.ts
@@ -240,7 +240,7 @@ describe('config loader', () => {
     await expect(loadConfig()).rejects.toThrow(/bindings\[\]\.name.*discord-main-codex-dev/);
   });
 
-  it('P9 在 session 隔离完成前拒绝多个同 type platform 实例', async () => {
+  it('允许多个同 type platform 实例，并按 platform name 派生独立 statePath', async () => {
     await writeFile(
       join(tmp, '.agent-nexus', 'config.json'),
       JSON.stringify(
@@ -253,7 +253,33 @@ describe('config loader', () => {
       ),
     );
 
-    await expect(loadConfig()).rejects.toThrow(/platforms\[\]\.type.*P10|session/);
+    const cfg = await loadConfig();
+    expect(cfg.platforms).toHaveLength(2);
+    expect(cfg.platforms.map((platform) => platform.statePath)).toEqual([
+      join(tmp, '.agent-nexus', 'state', 'discord-discord-main.json'),
+      join(tmp, '.agent-nexus', 'state', 'discord-discord-alt.json'),
+    ]);
+  });
+
+  it('多个 platform 实例显式复用同一 statePath 时 fail-closed', async () => {
+    await writeFile(
+      join(tmp, '.agent-nexus', 'config.json'),
+      JSON.stringify(
+        validConfig({
+          platforms: [
+            { ...VALID_PLATFORM, statePath: '/shared/state.json' },
+            {
+              ...VALID_PLATFORM,
+              name: 'discord-alt',
+              botUserId: '67890',
+              statePath: '/shared/state.json',
+            },
+          ],
+        }),
+      ),
+    );
+
+    await expect(loadConfig()).rejects.toThrow(/platforms\[\]\.statePath.*重复/);
   });
 
   it('未知 platform type / backend → ConfigError', async () => {

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -438,19 +438,6 @@ function parsePlatform(raw: unknown, index: number): PlatformConfig {
   }
 }
 
-function assertSinglePlatformTypeUntilP10(platforms: PlatformConfig[]): void {
-  const seen = new Set<string>();
-  for (const platform of platforms) {
-    if (seen.has(platform.type)) {
-      throw new ConfigError(
-        'platforms[].type 暂不允许配置多个同 type platform；' +
-          'P10 完成 platformName session 隔离后再放开。',
-      );
-    }
-    seen.add(platform.type);
-  }
-}
-
 function assertAgentReferences(
   bindings: BindingConfig[],
   agents: AgentConfig[],
@@ -462,6 +449,17 @@ function assertAgentReferences(
         `字段 bindings[${bindingIndex}].agentName 引用了不存在的 agent "${binding.agentName}"`,
       );
     }
+  }
+}
+
+function assertUniquePlatformStatePaths(platforms: PlatformConfig[]): void {
+  const duplicateStatePaths = duplicateNames(
+    platforms.map((platform) => platform.statePath),
+  );
+  if (duplicateStatePaths.length > 0) {
+    throw new ConfigError(
+      `platforms[].statePath 重复：${duplicateStatePaths.join(', ')}`,
+    );
   }
 }
 
@@ -538,7 +536,7 @@ export async function loadConfig(): Promise<AgentNexusConfig> {
       `platforms[].name 重复：${duplicatePlatformNames.join(', ')}`,
     );
   }
-  assertSinglePlatformTypeUntilP10(platforms);
+  assertUniquePlatformStatePaths(platforms);
   const platformsByName = new Map(
     platforms.map((platform) => [platform.name, platform]),
   );

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,9 +1,14 @@
 #!/usr/bin/env node
 import { mkdir } from 'node:fs/promises';
 import { dirname } from 'node:path';
-import { Engine, SessionStore, createLogger } from '@agent-nexus/daemon';
+import {
+  Engine,
+  SessionStore,
+  createLogger,
+  type RoutingEntry,
+} from '@agent-nexus/daemon';
 import { createDiscordPlatform } from '@agent-nexus/platform-discord';
-import { createSelectedAgent, type SelectedAgent } from './agent.js';
+import { createAgentRegistry } from './agent.js';
 import {
   ConfigError,
   SecretsPermissionError,
@@ -13,14 +18,14 @@ import {
 
 async function main(): Promise<void> {
   let config;
-  let token: string;
+  const tokensByRef = new Map<string, string>();
   try {
     config = await loadConfig();
-    const [firstPlatform] = config.platforms;
-    if (!firstPlatform) {
-      throw new ConfigError('platforms[] 不能是空数组');
+    for (const platform of config.platforms) {
+      if (!tokensByRef.has(platform.tokenRef)) {
+        tokensByRef.set(platform.tokenRef, await loadSecret(platform.tokenRef));
+      }
     }
-    token = await loadSecret(firstPlatform.tokenRef);
   } catch (err) {
     if (err instanceof ConfigError || err instanceof SecretsPermissionError) {
       process.stderr.write(`\n${err.message}\n`);
@@ -30,37 +35,10 @@ async function main(): Promise<void> {
   }
 
   const logger = createLogger({ level: config.log.level });
-  const [platformConfig] = config.platforms;
-  if (!platformConfig) {
-    throw new ConfigError('platforms[] 不能是空数组');
-  }
-  logger.info(
-    { source: 'file', secret: platformConfig.tokenRef },
-    'secret_loaded',
-  );
-  logger.warn(
-    {
-      platformName: platformConfig.name,
-      bindingChannelIds: config.bindings
-        .filter((binding) => binding.platformName === platformConfig.name)
-        .map((binding) => binding.match.discord.channelIds),
-      authFieldsParsedOnly: [
-        'roleIds',
-        'allowedGuildIds',
-        'allowedChannelIds',
-        'allowDM',
-        'requireMentionOrSlash',
-      ],
-      publicChannelMode: platformConfig.publicChannelMode,
-      enforcedInP9: ['auth.allowlist.userIds'],
-      plannedPhase: 'P10',
-    },
-    'p9_platform_constraints_not_enforced_until_router',
-  );
 
-  let selectedAgent: SelectedAgent;
+  let agents;
   try {
-    selectedAgent = await createSelectedAgent(config, logger);
+    agents = await createAgentRegistry(config, logger);
   } catch (err) {
     if (err instanceof ConfigError) {
       process.stderr.write(`\n${err.message}\n`);
@@ -79,39 +57,101 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  // state 目录与 secrets 目录同级，权限 0700 与 secrets 一致
-  // → spec/platform-adapter.md §"运行时状态持久化"
-  await mkdir(dirname(platformConfig.statePath), { recursive: true, mode: 0o700 });
-
-  const platform = createDiscordPlatform({
-    token,
-    botUserId: platformConfig.botUserId,
-    statePath: platformConfig.statePath,
-    allowedUserIds: platformConfig.auth.allowlist.userIds,
-    testGuildId: platformConfig.testGuildId,
-    logger,
+  const platformsByName = new Map(
+    config.platforms.map((platform) => [platform.name, platform]),
+  );
+  const routingTable: RoutingEntry[] = config.bindings.map((binding) => {
+    const platform = platformsByName.get(binding.platformName);
+    if (!platform) {
+      throw new ConfigError(
+        `binding "${binding.name}" 引用了不存在的 platform "${binding.platformName}"`,
+      );
+    }
+    return {
+      bindingName: binding.name,
+      platformName: binding.platformName,
+      platformType: platform.type,
+      agentName: binding.agentName,
+      match: binding.match,
+    };
   });
+  logger.info(
+    {
+      platforms: config.platforms.map((platform) => platform.name),
+      agents: agents.map((agent) => agent.agentName),
+      bindings: routingTable.map((entry) => entry.bindingName),
+    },
+    'routing_table_loaded',
+  );
 
   const sessionStore = new SessionStore();
+  const engines: Engine[] = [];
 
-  const engine = new Engine({
-    platform,
-    agent: selectedAgent.agent,
-    logger,
-    sessionStore,
-    defaultSessionConfig: selectedAgent.defaultSessionConfig,
-    toolMessages: {
-      mode: config.ui.toolMessages,
-    },
-  });
+  for (const platformConfig of config.platforms) {
+    logger.info(
+      {
+        platformName: platformConfig.name,
+        source: 'file',
+        secret: platformConfig.tokenRef,
+      },
+      'secret_loaded',
+    );
+    logger.warn(
+      {
+        platformName: platformConfig.name,
+        authFieldsParsedOnly: [
+          'roleIds',
+          'allowedGuildIds',
+          'allowedChannelIds',
+          'allowDM',
+          'requireMentionOrSlash',
+        ],
+        publicChannelMode: platformConfig.publicChannelMode,
+        enforcedUntilAuthLayer: ['auth.allowlist.userIds'],
+      },
+      'platform_constraints_partially_enforced_until_auth_layer',
+    );
 
-  await engine.start();
-  logger.info({}, 'engine_started');
+    // state 目录与 secrets 目录同级，权限 0700 与 secrets 一致
+    // → spec/platform-adapter.md §"运行时状态持久化"
+    await mkdir(dirname(platformConfig.statePath), { recursive: true, mode: 0o700 });
+
+    const token = tokensByRef.get(platformConfig.tokenRef);
+    if (!token) {
+      throw new ConfigError(`secret ref "${platformConfig.tokenRef}" 未加载`);
+    }
+    const platform = createDiscordPlatform({
+      token,
+      botUserId: platformConfig.botUserId,
+      statePath: platformConfig.statePath,
+      allowedUserIds: platformConfig.auth.allowlist.userIds,
+      testGuildId: platformConfig.testGuildId,
+      logger,
+    });
+
+    engines.push(
+      new Engine({
+        platform,
+        platformName: platformConfig.name,
+        platformType: platformConfig.type,
+        agents,
+        routingTable,
+        logger,
+        sessionStore,
+        toolMessages: {
+          mode: config.ui.toolMessages,
+        },
+      }),
+    );
+  }
+
+  await Promise.all(engines.map((engine) => engine.start()));
+  logger.info({ engines: engines.length }, 'engine_started');
 
   const shutdown = async (signal: string): Promise<void> => {
     logger.info({ signal }, 'shutdown_signal');
     try {
-      await engine.stop();
+      await Promise.all(engines.map((engine) => engine.stop()));
     } catch (err) {
       logger.error({ err }, 'shutdown_error');
     }

--- a/packages/daemon/src/engine.test.ts
+++ b/packages/daemon/src/engine.test.ts
@@ -11,12 +11,15 @@ import type {
   MessageRef,
   NormalizedEvent,
   OutboundMessage,
+  PlatformSessionKey,
   PlatformAdapter,
   SessionConfig,
   SessionKey,
 } from '@agent-nexus/protocol';
+import { withPlatformName } from '@agent-nexus/protocol';
 import { Engine } from './engine.js';
 import { createLogger, type Logger } from './logger.js';
+import type { RoutingEntry } from './router.js';
 import { SessionStore } from './session-store.js';
 
 // ----- mocks -----
@@ -44,11 +47,15 @@ const agentCaps: AgentCapabilitySet = {
   supportsNativeToolWhitelist: false,
 };
 
-const SESSION_KEY: SessionKey = {
+const SESSION_KEY: PlatformSessionKey = {
   platform: 'discord',
   channelId: 'C1',
   initiatorUserId: 'U1',
 };
+const ROUTED_SESSION_KEY: SessionKey = withPlatformName(
+  SESSION_KEY,
+  'mock-platform',
+);
 
 let eventCounter = 0;
 function makeEvent(text: string, overrides: Partial<NormalizedEvent> = {}): NormalizedEvent {
@@ -273,7 +280,7 @@ describe('Engine', () => {
     expect(cfg.resumeFromAgentSessionId).toBeUndefined();
     expect(cfg.sessionId).toBeTruthy();
 
-    expect(store.get(SESSION_KEY)?.agentSessionId).toBe('sid-123');
+    expect(store.get(ROUTED_SESSION_KEY)?.agentSessionId).toBe('sid-123');
 
     expect(platform.send).toHaveBeenCalledTimes(1);
     const sendArgs = platform.send.mock.calls[0]!;
@@ -305,7 +312,7 @@ describe('Engine', () => {
       ev('turn_finished', { reason: 'stop', turnSequence: 1 }),
     ]);
     await dispatchHandler(makeEvent('first prompt'));
-    expect(store.get(SESSION_KEY)?.agentSessionId).toBe('sid-123');
+    expect(store.get(ROUTED_SESSION_KEY)?.agentSessionId).toBe('sid-123');
 
     const firstSession = agent.sendInput.mock.calls[0]![0] as AgentSession;
 
@@ -319,7 +326,7 @@ describe('Engine', () => {
     expect(agent.startSession).toHaveBeenCalledTimes(1);
     expect(agent.onEvent).toHaveBeenCalledTimes(1);
     expect(agent.sendInput.mock.calls[1]![0]).toBe(firstSession);
-    expect(store.get(SESSION_KEY)?.agentSessionId).toBe('sid-123');
+    expect(store.get(ROUTED_SESSION_KEY)?.agentSessionId).toBe('sid-123');
     expect(agent.stopSession).not.toHaveBeenCalled();
   });
 
@@ -357,7 +364,7 @@ describe('Engine', () => {
     expect(agent.startSession).toHaveBeenCalledTimes(2);
     const cfg2 = agent.startSession.mock.calls[1]![1] as SessionConfig;
     expect(cfg2.resumeFromAgentSessionId).toBe('sid-123');
-    expect(store.get(SESSION_KEY)?.agentSessionId).toBe('sid-456');
+    expect(store.get(ROUTED_SESSION_KEY)?.agentSessionId).toBe('sid-456');
   });
 
   it('/new 带后续文本：清 store + 用 trim 后的剩余作 prompt', async () => {
@@ -365,7 +372,7 @@ describe('Engine', () => {
     const agent = makeAgent();
     const store = new SessionStore();
     // 预置一条旧的
-    store.set(SESSION_KEY, { agentSessionId: 'sid-123', lastTurnAt: new Date(0) });
+    store.set(ROUTED_SESSION_KEY, { agentSessionId: 'sid-123', lastTurnAt: new Date(0) });
 
     const engine = new Engine({
       platform,
@@ -395,7 +402,7 @@ describe('Engine', () => {
     expect(input.text).toBe('what is X?');
 
     // 新一轮 session_started 写回 sid-new；旧的 sid-123 已被清掉
-    expect(store.get(SESSION_KEY)?.agentSessionId).toBe('sid-new');
+    expect(store.get(ROUTED_SESSION_KEY)?.agentSessionId).toBe('sid-new');
   });
 
   it('/new 单独：发 [new session ready] 不调 agent', async () => {
@@ -466,7 +473,7 @@ describe('Engine', () => {
     expect(agent.sendInput.mock.calls[1]![0]).toBe(agent.sendInput.mock.calls[0]![0]);
 
     // store 仍保留当前活跃 agent session id；第二轮未重启 session。
-    expect(store.get(SESSION_KEY)?.agentSessionId).toBe('sid-first');
+    expect(store.get(ROUTED_SESSION_KEY)?.agentSessionId).toBe('sid-first');
   });
 
   it('不同 SessionKey 并发不串行：互不阻塞', async () => {
@@ -484,8 +491,8 @@ describe('Engine', () => {
     await engine.start();
     const dispatchHandler = (platform.start as ReturnType<typeof vi.fn>).mock.calls[0]![0] as EventHandler;
 
-    const KEY_A: SessionKey = { platform: 'discord', channelId: 'C1', initiatorUserId: 'A' };
-    const KEY_B: SessionKey = { platform: 'discord', channelId: 'C1', initiatorUserId: 'B' };
+    const KEY_A: PlatformSessionKey = { platform: 'discord', channelId: 'C1', initiatorUserId: 'A' };
+    const KEY_B: PlatformSessionKey = { platform: 'discord', channelId: 'C1', initiatorUserId: 'B' };
 
     // A 慢；B 应该不被 A 拖累，可以早于 A 完成
     agent.queueEventsAfter(
@@ -512,8 +519,8 @@ describe('Engine', () => {
     // B 不应等满 A 的 30ms 延迟；给 25ms 余量足够区分串行/并行
     expect(tBDone).toBeLessThan(25);
 
-    expect(store.get(KEY_A)?.agentSessionId).toBe('sid-a');
-    expect(store.get(KEY_B)?.agentSessionId).toBe('sid-b');
+    expect(store.get(withPlatformName(KEY_A, 'mock-platform'))?.agentSessionId).toBe('sid-a');
+    expect(store.get(withPlatformName(KEY_B, 'mock-platform'))?.agentSessionId).toBe('sid-b');
   });
 
   it('turn_finished 后写 outbound info 日志（含 length、无 text），debug 日志含 text', async () => {
@@ -640,6 +647,274 @@ describe('Engine', () => {
     // 用 fill-1024 重投——还在表内，应被 dedup，agent.startSession 不再增加
     await dispatchHandler(makeEvent('hello', { eventId: 'fill-1024' }));
     expect(agent.startSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('routingTable 未命中：打 route_not_found 且不调用任何 agent', async () => {
+    const platform = makePlatform();
+    const codex = makeAgent();
+    const claude = makeAgent();
+    const store = new SessionStore();
+    const mockLogger = makeMockLogger();
+    const routingTable: RoutingEntry[] = [
+      {
+        bindingName: 'discord-main-codex',
+        platformName: 'discord-main',
+        platformType: 'discord',
+        agentName: 'codex-dev',
+        match: { discord: { channelIds: ['C1'] } },
+      },
+    ];
+    const engine = new Engine({
+      platform,
+      platformName: 'discord-main',
+      platformType: 'discord',
+      agents: [
+        {
+          agentName: 'codex-dev',
+          agent: codex.runtime,
+          defaultSessionConfig: DEFAULT_CFG,
+        },
+        {
+          agentName: 'claude-prod',
+          agent: claude.runtime,
+          defaultSessionConfig: DEFAULT_CFG,
+        },
+      ],
+      routingTable,
+      logger: mockLogger,
+      sessionStore: store,
+    });
+
+    await engine.start();
+    const dispatchHandler = (platform.start as ReturnType<typeof vi.fn>).mock.calls[0]![0] as EventHandler;
+    await dispatchHandler(makeEvent('hello', {
+      sessionKey: { ...SESSION_KEY, channelId: 'C9' },
+    }));
+
+    expect(codex.startSession).not.toHaveBeenCalled();
+    expect(claude.startSession).not.toHaveBeenCalled();
+    const warnCalls = (mockLogger.warn as ReturnType<typeof vi.fn>).mock.calls;
+    expect(warnCalls.find(([, msg]) => msg === 'route_not_found')).toBeDefined();
+  });
+
+  it('routingTable 多重命中：打 route_ambiguous 且不调用任何 agent', async () => {
+    const platform = makePlatform();
+    const codex = makeAgent();
+    const store = new SessionStore();
+    const mockLogger = makeMockLogger();
+    const routingTable: RoutingEntry[] = [
+      {
+        bindingName: 'discord-main-codex-a',
+        platformName: 'discord-main',
+        platformType: 'discord',
+        agentName: 'codex-dev',
+        match: { discord: { channelIds: ['C1'] } },
+      },
+      {
+        bindingName: 'discord-main-codex-b',
+        platformName: 'discord-main',
+        platformType: 'discord',
+        agentName: 'codex-dev',
+        match: { discord: { channelIds: ['C1'] } },
+      },
+    ];
+    const engine = new Engine({
+      platform,
+      platformName: 'discord-main',
+      platformType: 'discord',
+      agents: [
+        {
+          agentName: 'codex-dev',
+          agent: codex.runtime,
+          defaultSessionConfig: DEFAULT_CFG,
+        },
+      ],
+      routingTable,
+      logger: mockLogger,
+      sessionStore: store,
+    });
+
+    await engine.start();
+    const dispatchHandler = (platform.start as ReturnType<typeof vi.fn>).mock.calls[0]![0] as EventHandler;
+    await dispatchHandler(makeEvent('hello'));
+
+    expect(codex.startSession).not.toHaveBeenCalled();
+    const warnCalls = (mockLogger.warn as ReturnType<typeof vi.fn>).mock.calls;
+    const routeLog = warnCalls.find(([, msg]) => msg === 'route_ambiguous');
+    expect(routeLog).toBeDefined();
+    expect(routeLog![0]).toMatchObject({
+      bindingNames: ['discord-main-codex-a', 'discord-main-codex-b'],
+    });
+  });
+
+  it('routingTable 按 platformName + channel 选择 agent，并用 platformName 隔离 session key', async () => {
+    const platform = makePlatform();
+    const codex = makeAgent();
+    const claude = makeAgent();
+    const store = new SessionStore();
+    const routingTable: RoutingEntry[] = [
+      {
+        bindingName: 'discord-main-codex',
+        platformName: 'discord-main',
+        platformType: 'discord',
+        agentName: 'codex-dev',
+        match: { discord: { channelIds: ['C1'] } },
+      },
+      {
+        bindingName: 'discord-main-claude',
+        platformName: 'discord-main',
+        platformType: 'discord',
+        agentName: 'claude-prod',
+        match: { discord: { channelIds: ['C2'] } },
+      },
+    ];
+    const engine = new Engine({
+      platform,
+      platformName: 'discord-main',
+      platformType: 'discord',
+      agents: [
+        {
+          agentName: 'codex-dev',
+          agent: codex.runtime,
+          defaultSessionConfig: DEFAULT_CFG,
+        },
+        {
+          agentName: 'claude-prod',
+          agent: claude.runtime,
+          defaultSessionConfig: DEFAULT_CFG,
+        },
+      ],
+      routingTable,
+      logger: SILENT_LOGGER,
+      sessionStore: store,
+    });
+
+    claude.queueEvents([
+      ev('session_started', { agentSessionId: 'claude-sid' }),
+      ev('text_final', { text: 'from claude' }),
+      ev('turn_finished', { reason: 'stop', turnSequence: 1 }),
+    ]);
+
+    await engine.start();
+    const dispatchHandler = (platform.start as ReturnType<typeof vi.fn>).mock.calls[0]![0] as EventHandler;
+    await dispatchHandler(makeEvent('hello', {
+      sessionKey: { ...SESSION_KEY, channelId: 'C2' },
+    }));
+
+    expect(codex.startSession).not.toHaveBeenCalled();
+    expect(claude.startSession).toHaveBeenCalledTimes(1);
+    const startedKey = claude.startSession.mock.calls[0]![0] as SessionKey;
+    expect(startedKey).toMatchObject({
+      platformName: 'discord-main',
+      platform: 'discord',
+      channelId: 'C2',
+      initiatorUserId: 'U1',
+    });
+    expect(
+      store.get({
+        platformName: 'discord-main',
+        platform: 'discord',
+        channelId: 'C2',
+        initiatorUserId: 'U1',
+      })?.agentSessionId,
+    ).toBe('claude-sid');
+  });
+
+  it('两个同 type Engine 共享 SessionStore 时，同 channel/user 仍按 platformName 隔离', async () => {
+    const platformMain = makePlatform();
+    const platformSide = makePlatform();
+    const codex = makeAgent();
+    const store = new SessionStore();
+    const routingTable: RoutingEntry[] = [
+      {
+        bindingName: 'discord-main-codex',
+        platformName: 'discord-main',
+        platformType: 'discord',
+        agentName: 'codex-dev',
+        match: { discord: { channelIds: ['C1'] } },
+      },
+      {
+        bindingName: 'discord-side-codex',
+        platformName: 'discord-side',
+        platformType: 'discord',
+        agentName: 'codex-dev',
+        match: { discord: { channelIds: ['C1'] } },
+      },
+    ];
+    const agents = [
+      {
+        agentName: 'codex-dev',
+        agent: codex.runtime,
+        defaultSessionConfig: DEFAULT_CFG,
+      },
+    ];
+
+    const mainEngine = new Engine({
+      platform: platformMain,
+      platformName: 'discord-main',
+      platformType: 'discord',
+      agents,
+      routingTable,
+      logger: SILENT_LOGGER,
+      sessionStore: store,
+    });
+    const sideEngine = new Engine({
+      platform: platformSide,
+      platformName: 'discord-side',
+      platformType: 'discord',
+      agents,
+      routingTable,
+      logger: SILENT_LOGGER,
+      sessionStore: store,
+    });
+
+    codex.queueEvents([
+      ev('session_started', { agentSessionId: 'sid-main' }),
+      ev('text_final', { text: 'main' }),
+      ev('turn_finished', { reason: 'stop', turnSequence: 1 }),
+    ]);
+    codex.queueEvents([
+      ev('session_started', { agentSessionId: 'sid-side' }),
+      ev('text_final', { text: 'side' }),
+      ev('turn_finished', { reason: 'stop', turnSequence: 1 }),
+    ]);
+
+    await mainEngine.start();
+    await sideEngine.start();
+    const mainDispatch = (platformMain.start as ReturnType<typeof vi.fn>).mock.calls[0]![0] as EventHandler;
+    const sideDispatch = (platformSide.start as ReturnType<typeof vi.fn>).mock.calls[0]![0] as EventHandler;
+
+    await mainDispatch(makeEvent('hello'));
+    await sideDispatch(makeEvent('hello'));
+
+    expect(codex.startSession).toHaveBeenCalledTimes(2);
+    expect(codex.startSession.mock.calls[0]![0]).toMatchObject({
+      platformName: 'discord-main',
+      channelId: 'C1',
+      initiatorUserId: 'U1',
+    });
+    expect(codex.startSession.mock.calls[1]![0]).toMatchObject({
+      platformName: 'discord-side',
+      channelId: 'C1',
+      initiatorUserId: 'U1',
+    });
+    expect(store.size).toBe(2);
+    expect(
+      store.get({
+        platformName: 'discord-main',
+        platform: 'discord',
+        channelId: 'C1',
+        initiatorUserId: 'U1',
+      })?.agentSessionId,
+    ).toBe('sid-main');
+    expect(
+      store.get({
+        platformName: 'discord-side',
+        platform: 'discord',
+        channelId: 'C1',
+        initiatorUserId: 'U1',
+      })?.agentSessionId,
+    ).toBe('sid-side');
   });
 
   it('supportsEdit=false：text_delta 只缓冲，turn_finished 发送 text_final 且不调用 edit/typing', async () => {
@@ -1403,13 +1678,13 @@ describe('Engine', () => {
     const dispatchHandler = (platform.start as ReturnType<typeof vi.fn>).mock.calls[0]![0] as EventHandler;
     await dispatchHandler(makeEvent('hello'));
 
-    expect(store.get(SESSION_KEY)?.agentSessionId).toBe('sid-1');
+    expect(store.get(ROUTED_SESSION_KEY)?.agentSessionId).toBe('sid-1');
     expect(agent.stopSession).not.toHaveBeenCalled();
 
     await engine.stop();
 
     expect(platform.stop).toHaveBeenCalledTimes(1);
     expect(agent.stopSession).toHaveBeenCalledTimes(1);
-    expect(store.get(SESSION_KEY)).toBeUndefined();
+    expect(store.get(ROUTED_SESSION_KEY)).toBeUndefined();
   });
 });

--- a/packages/daemon/src/engine.ts
+++ b/packages/daemon/src/engine.ts
@@ -7,19 +7,34 @@ import type {
   NormalizedEvent,
   PlatformAdapter,
   SessionConfig,
+  SessionKey,
 } from '@agent-nexus/protocol';
-import { serializeSessionKey } from '@agent-nexus/protocol';
+import { serializeSessionKey, withPlatformName } from '@agent-nexus/protocol';
 import type { ToolMessageMode } from './config.js';
 import type { Logger } from './logger.js';
+import { RouteError, selectRoute, type RoutingEntry } from './router.js';
 import type { SessionStore } from './session-store.js';
+
+export interface EngineAgent {
+  agent: AgentRuntime;
+  agentName: string;
+  defaultSessionConfig: Omit<
+    SessionConfig,
+    'resumeFromAgentSessionId' | 'sessionId'
+  >;
+}
 
 export interface EngineDeps {
   platform: PlatformAdapter;
-  agent: AgentRuntime;
+  platformName?: string;
+  platformType?: 'discord';
+  agent?: AgentRuntime;
+  agents?: readonly EngineAgent[];
+  routingTable?: readonly RoutingEntry[];
   logger: Logger;
   sessionStore: SessionStore;
   /** 每轮 sessionId 由 Engine 生成；resumeFromAgentSessionId 由 store 决定 */
-  defaultSessionConfig: Omit<
+  defaultSessionConfig?: Omit<
     SessionConfig,
     'resumeFromAgentSessionId' | 'sessionId'
   >;
@@ -36,6 +51,8 @@ const DEFAULT_STREAM_EDIT_THROTTLE_MS = 1500;
 const DEFAULT_TYPING_REFRESH_MS = 8000;
 
 interface ActiveAgentSession {
+  agent: AgentRuntime;
+  agentName: string;
   session: AgentSession;
   currentTurn?: {
     eventId: string;
@@ -78,13 +95,12 @@ function renderToolStart(toolName: string, inputSummary: string): string {
  */
 export class Engine {
   private readonly platform: PlatformAdapter;
-  private readonly agent: AgentRuntime;
+  private readonly platformName: string;
+  private readonly platformType: 'discord';
+  private readonly agents: Map<string, EngineAgent>;
+  private readonly routingTable?: readonly RoutingEntry[];
   private readonly logger: Logger;
   private readonly sessionStore: SessionStore;
-  private readonly defaultSessionConfig: Omit<
-    SessionConfig,
-    'resumeFromAgentSessionId' | 'sessionId'
-  >;
   private readonly streamEditThrottleMs: number;
   private readonly typingRefreshMs: number;
   private readonly toolMessageMode: ToolMessageMode;
@@ -107,10 +123,25 @@ export class Engine {
 
   constructor(deps: EngineDeps) {
     this.platform = deps.platform;
-    this.agent = deps.agent;
+    this.platformName = deps.platformName ?? deps.platform.name();
+    this.platformType = deps.platformType ?? 'discord';
+    this.routingTable = deps.routingTable;
+    this.agents = new Map();
+    if (deps.agents) {
+      for (const agent of deps.agents) {
+        this.agents.set(agent.agentName, agent);
+      }
+    } else if (deps.agent && deps.defaultSessionConfig) {
+      this.agents.set(deps.agent.name(), {
+        agent: deps.agent,
+        agentName: deps.agent.name(),
+        defaultSessionConfig: deps.defaultSessionConfig,
+      });
+    } else {
+      throw new Error('Engine requires either agents[] or legacy agent/defaultSessionConfig');
+    }
     this.logger = deps.logger;
     this.sessionStore = deps.sessionStore;
-    this.defaultSessionConfig = deps.defaultSessionConfig;
     this.streamEditThrottleMs =
       deps.streaming?.streamEditThrottleMs ?? DEFAULT_STREAM_EDIT_THROTTLE_MS;
     this.typingRefreshMs =
@@ -126,7 +157,7 @@ export class Engine {
     await this.platform.stop();
     for (const [sessionKey, active] of this.agentSessions) {
       try {
-        this.agent.stopSession(active.session);
+        active.agent.stopSession(active.session);
       } catch (err) {
         this.logger.error({ sessionKey, err }, 'agent_stop_session_failed');
       }
@@ -136,14 +167,34 @@ export class Engine {
   }
 
   private dispatch(event: NormalizedEvent): Promise<void> {
-    const keyStr = serializeSessionKey(event.sessionKey);
+    const route = this.route(event);
+    if (!route) return Promise.resolve();
+    const routedSessionKey = withPlatformName(
+      event.sessionKey,
+      this.platformName,
+    );
+    const routedEvent = { ...event, sessionKey: routedSessionKey };
+    const agentSlot = this.agents.get(route.agentName);
+    if (!agentSlot) {
+      this.logger.error(
+        {
+          traceId: event.traceId,
+          platformName: this.platformName,
+          agentName: route.agentName,
+          bindingName: route.bindingName,
+        },
+        'route_agent_missing',
+      );
+      return Promise.resolve();
+    }
+    const keyStr = serializeSessionKey(routedSessionKey);
     const prev = this.inflight.get(keyStr) ?? Promise.resolve();
     // 链式 await：上一条 settle 后再跑当前这条。前一条若 reject 不影响后续——
     // dispatchImpl 内部已 try/catch + 日志化错误，外层只用 catch swallow 防止
     // 链上某条 throw 把整条链 poison 掉。
     const next = prev
       .catch(() => {})
-      .then(() => this.dispatchImpl(event));
+      .then(() => this.dispatchImpl(routedEvent, agentSlot));
     this.inflight.set(keyStr, next);
     // 链尾 cleanup：当前这条就是最末时清掉 map 项，避免长期累积空 promise。
     void next.finally(() => {
@@ -154,7 +205,48 @@ export class Engine {
     return next;
   }
 
-  private async dispatchImpl(event: NormalizedEvent): Promise<void> {
+  private route(event: NormalizedEvent):
+    | { bindingName: string; agentName: string }
+    | undefined {
+    if (!this.routingTable) {
+      const onlyAgent = [...this.agents.values()][0];
+      if (!onlyAgent) {
+        this.logger.error(
+          { traceId: event.traceId, platformName: this.platformName },
+          'route_agent_missing',
+        );
+        return undefined;
+      }
+      return { bindingName: 'legacy', agentName: onlyAgent.agentName };
+    }
+    try {
+      return selectRoute(this.routingTable, {
+        platformName: this.platformName,
+        platformType: this.platformType,
+        event,
+      });
+    } catch (err) {
+      if (err instanceof RouteError) {
+        this.logger.warn(
+          {
+            traceId: event.traceId,
+            platformName: err.details.platformName,
+            platformType: err.details.platformType,
+            channelId: err.details.channelId,
+            bindingNames: err.details.bindingNames,
+          },
+          err.code,
+        );
+        return undefined;
+      }
+      throw err;
+    }
+  }
+
+  private async dispatchImpl(
+    event: NormalizedEvent & { sessionKey: SessionKey },
+    agentSlot: EngineAgent,
+  ): Promise<void> {
     const sessionKeyStr = serializeSessionKey(event.sessionKey);
     if (this.seenEventIds.has(event.eventId)) {
       this.logger.info(
@@ -490,7 +582,7 @@ export class Engine {
         const current = this.agentSessions.get(sessionKeyStr);
         if (current?.session === session) this.agentSessions.delete(sessionKeyStr);
         try {
-          this.agent.stopSession(session);
+          agentSlot.agent.stopSession(session);
         } catch (stopErr) {
           this.logger.error(
             { traceId: event.traceId, sessionKey: sessionKeyStr, err: stopErr },
@@ -667,7 +759,11 @@ export class Engine {
         }
       };
 
-      const activeSession = this.getOrStartSession(event, sessionKeyStr);
+      const activeSession = this.getOrStartSession(
+        event,
+        sessionKeyStr,
+        agentSlot,
+      );
       session = activeSession.session;
       activeSession.currentTurn = {
         eventId: event.eventId,
@@ -680,7 +776,7 @@ export class Engine {
       startTyping();
       let sendInputErr: unknown;
       try {
-        await this.agent.sendInput(session, {
+        await activeSession.agent.sendInput(session, {
           type: 'user_message',
           text: prompt,
           traceId: event.traceId,
@@ -711,13 +807,14 @@ export class Engine {
   }
 
   private getOrStartSession(
-    event: NormalizedEvent,
+    event: NormalizedEvent & { sessionKey: SessionKey },
     sessionKeyStr: string,
+    agentSlot: EngineAgent,
   ): ActiveAgentSession {
     const active = this.agentSessions.get(sessionKeyStr);
-    if (active) {
+    if (active && active.agentName === agentSlot.agentName) {
       try {
-        if (this.agent.isAlive(active.session)) return active;
+        if (active.agent.isAlive(active.session)) return active;
       } catch (err) {
         this.logger.warn(
           { traceId: event.traceId, sessionKey: sessionKeyStr, err },
@@ -725,7 +822,17 @@ export class Engine {
         );
       }
       try {
-        this.agent.stopSession(active.session);
+        active.agent.stopSession(active.session);
+      } catch (err) {
+        this.logger.error(
+          { traceId: event.traceId, sessionKey: sessionKeyStr, err },
+          'agent_stop_session_failed',
+        );
+      }
+      this.agentSessions.delete(sessionKeyStr);
+    } else if (active) {
+      try {
+        active.agent.stopSession(active.session);
       } catch (err) {
         this.logger.error(
           { traceId: event.traceId, sessionKey: sessionKeyStr, err },
@@ -739,14 +846,18 @@ export class Engine {
       event.sessionKey,
     )?.agentSessionId;
     const config: SessionConfig = {
-      ...this.defaultSessionConfig,
+      ...agentSlot.defaultSessionConfig,
       sessionId: randomUUID(),
       resumeFromAgentSessionId: prevAgentSessionId,
     };
-    const session = this.agent.startSession(event.sessionKey, config);
-    const activeSession: ActiveAgentSession = { session };
+    const session = agentSlot.agent.startSession(event.sessionKey, config);
+    const activeSession: ActiveAgentSession = {
+      agent: agentSlot.agent,
+      agentName: agentSlot.agentName,
+      session,
+    };
     this.agentSessions.set(sessionKeyStr, activeSession);
-    this.agent.onEvent(session, async (agentEvent) => {
+    agentSlot.agent.onEvent(session, async (agentEvent) => {
       const current = this.agentSessions.get(sessionKeyStr);
       if (current !== activeSession) return;
       const turn = current.currentTurn;
@@ -793,7 +904,7 @@ export class Engine {
     if (!active) return;
     this.agentSessions.delete(sessionKeyStr);
     try {
-      this.agent.stopSession(active.session);
+      active.agent.stopSession(active.session);
     } catch (err) {
       this.logger.error(
         { traceId, sessionKey: sessionKeyStr, err },

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -1,5 +1,12 @@
 export { createLogger, type Logger, type CreateLoggerOptions } from './logger.js';
-export { Engine, type EngineDeps } from './engine.js';
+export { Engine, type EngineAgent, type EngineDeps } from './engine.js';
+export {
+  RouteError,
+  selectRoute,
+  type RouteContext,
+  type RouteDecision,
+  type RoutingEntry,
+} from './router.js';
 export {
   parseDaemonConfig,
   parsePlatformAuthConfig,

--- a/packages/daemon/src/router.test.ts
+++ b/packages/daemon/src/router.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import { RouteError, selectRoute, type RoutingEntry } from './router.js';
+import type { NormalizedEvent } from '@agent-nexus/protocol';
+
+const entries: RoutingEntry[] = [
+  {
+    bindingName: 'discord-main-codex',
+    platformName: 'discord-main',
+    platformType: 'discord',
+    agentName: 'codex-dev',
+    match: { discord: { channelIds: ['C1'] } },
+  },
+  {
+    bindingName: 'discord-main-claude',
+    platformName: 'discord-main',
+    platformType: 'discord',
+    agentName: 'claude-prod',
+    match: { discord: { channelIds: ['C2'] } },
+  },
+  {
+    bindingName: 'discord-side-codex',
+    platformName: 'discord-side',
+    platformType: 'discord',
+    agentName: 'codex-dev',
+    match: { discord: { channelIds: ['C1'] } },
+  },
+];
+
+function makeEvent(channelId: string): NormalizedEvent {
+  return {
+    eventId: 'e-1',
+    platform: 'discord',
+    sessionKey: {
+      platform: 'discord',
+      channelId,
+      initiatorUserId: 'U1',
+    },
+    messageId: 'm-1',
+    traceId: 't-1',
+    type: 'message',
+    text: 'hello',
+    rawPayload: {},
+    rawContentType: 'application/json',
+    receivedAt: new Date(0),
+    initiator: { userId: 'U1', displayName: 'U1', isBot: false },
+  };
+}
+
+describe('selectRoute', () => {
+  it('selects the unique agent by platform instance and Discord channel', () => {
+    expect(
+      selectRoute(entries, {
+        platformName: 'discord-main',
+        platformType: 'discord',
+        event: makeEvent('C2'),
+      }),
+    ).toEqual({
+      bindingName: 'discord-main-claude',
+      platformName: 'discord-main',
+      agentName: 'claude-prod',
+    });
+  });
+
+  it('does not let another platform instance match the same channel/user', () => {
+    expect(
+      selectRoute(entries, {
+        platformName: 'discord-side',
+        platformType: 'discord',
+        event: makeEvent('C1'),
+      }),
+    ).toEqual({
+      bindingName: 'discord-side-codex',
+      platformName: 'discord-side',
+      agentName: 'codex-dev',
+    });
+  });
+
+  it('fails closed when no binding matches', () => {
+    expect(() =>
+      selectRoute(entries, {
+        platformName: 'discord-main',
+        platformType: 'discord',
+        event: makeEvent('C3'),
+      }),
+    ).toThrow(RouteError);
+  });
+
+  it('fails closed when multiple bindings match', () => {
+    expect(() =>
+      selectRoute(
+        [
+          entries[0]!,
+          {
+            bindingName: 'discord-main-codex-duplicate',
+            platformName: 'discord-main',
+            platformType: 'discord',
+            agentName: 'codex-dev',
+            match: { discord: { channelIds: ['C1'] } },
+          },
+        ],
+        {
+          platformName: 'discord-main',
+          platformType: 'discord',
+          event: makeEvent('C1'),
+        },
+      ),
+    ).toThrow(RouteError);
+  });
+});

--- a/packages/daemon/src/router.ts
+++ b/packages/daemon/src/router.ts
@@ -1,0 +1,90 @@
+import type { NormalizedEvent } from '@agent-nexus/protocol';
+
+export interface DiscordRouteMatch {
+  channelIds: string[];
+}
+
+export interface RoutingEntry {
+  bindingName: string;
+  platformName: string;
+  platformType: 'discord';
+  agentName: string;
+  match: {
+    discord: DiscordRouteMatch;
+  };
+}
+
+export interface RouteContext {
+  platformName: string;
+  platformType: 'discord';
+  event: NormalizedEvent;
+}
+
+export interface RouteDecision {
+  bindingName: string;
+  platformName: string;
+  agentName: string;
+}
+
+export class RouteError extends Error {
+  constructor(
+    public readonly code: 'route_not_found' | 'route_ambiguous',
+    message: string,
+    public readonly details: {
+      platformName: string;
+      platformType: string;
+      channelId: string;
+      bindingNames?: string[];
+    },
+  ) {
+    super(message);
+    this.name = 'RouteError';
+  }
+}
+
+function matches(entry: RoutingEntry, context: RouteContext): boolean {
+  if (entry.platformName !== context.platformName) return false;
+  if (entry.platformType !== context.platformType) return false;
+  if (context.platformType === 'discord') {
+    return entry.match.discord.channelIds.includes(
+      context.event.sessionKey.channelId,
+    );
+  }
+  return false;
+}
+
+export function selectRoute(
+  entries: readonly RoutingEntry[],
+  context: RouteContext,
+): RouteDecision {
+  const matched = entries.filter((entry) => matches(entry, context));
+  if (matched.length === 0) {
+    throw new RouteError(
+      'route_not_found',
+      `no binding matched platform ${context.platformName}`,
+      {
+        platformName: context.platformName,
+        platformType: context.platformType,
+        channelId: context.event.sessionKey.channelId,
+      },
+    );
+  }
+  if (matched.length > 1) {
+    throw new RouteError(
+      'route_ambiguous',
+      `multiple bindings matched platform ${context.platformName}`,
+      {
+        platformName: context.platformName,
+        platformType: context.platformType,
+        channelId: context.event.sessionKey.channelId,
+        bindingNames: matched.map((entry) => entry.bindingName),
+      },
+    );
+  }
+  const [entry] = matched;
+  return {
+    bindingName: entry!.bindingName,
+    platformName: entry!.platformName,
+    agentName: entry!.agentName,
+  };
+}

--- a/packages/daemon/src/session-store.test.ts
+++ b/packages/daemon/src/session-store.test.ts
@@ -4,6 +4,7 @@ import { serializeSessionKey } from '@agent-nexus/protocol';
 import { SessionStore } from './session-store.js';
 
 const makeKey = (overrides: Partial<SessionKey> = {}): SessionKey => ({
+  platformName: 'discord-main',
   platform: 'discord',
   channelId: 'C1',
   initiatorUserId: 'U1',
@@ -25,27 +26,30 @@ describe('SessionStore', () => {
     expect(store.size).toBe(1);
   });
 
-  it('different platform/channel/user produce different map keys', () => {
+  it('different platformName/platform/channel/user produce different map keys', () => {
     const store = new SessionStore();
-    const k1 = makeKey({ platform: 'discord' });
-    const k2 = makeKey({ platform: 'slack' });
-    const k3 = makeKey({ channelId: 'C2' });
-    const k4 = makeKey({ initiatorUserId: 'U2' });
+    const k1 = makeKey({ platformName: 'discord-main' });
+    const k2 = makeKey({ platformName: 'discord-side' });
+    const k3 = makeKey({ platform: 'slack' });
+    const k4 = makeKey({ channelId: 'C2' });
+    const k5 = makeKey({ initiatorUserId: 'U2' });
 
     store.set(k1, { agentSessionId: 'sid-1', lastTurnAt: new Date(1) });
     store.set(k2, { agentSessionId: 'sid-2', lastTurnAt: new Date(2) });
     store.set(k3, { agentSessionId: 'sid-3', lastTurnAt: new Date(3) });
     store.set(k4, { agentSessionId: 'sid-4', lastTurnAt: new Date(4) });
+    store.set(k5, { agentSessionId: 'sid-5', lastTurnAt: new Date(5) });
 
-    expect(store.size).toBe(4);
+    expect(store.size).toBe(5);
     expect(store.get(k1)?.agentSessionId).toBe('sid-1');
     expect(store.get(k2)?.agentSessionId).toBe('sid-2');
     expect(store.get(k3)?.agentSessionId).toBe('sid-3');
     expect(store.get(k4)?.agentSessionId).toBe('sid-4');
+    expect(store.get(k5)?.agentSessionId).toBe('sid-5');
 
     // 序列化形式确认互不相同
-    const ids = new Set([k1, k2, k3, k4].map(serializeSessionKey));
-    expect(ids.size).toBe(4);
+    const ids = new Set([k1, k2, k3, k4, k5].map(serializeSessionKey));
+    expect(ids.size).toBe(5);
   });
 
   it('delete returns true when present, false when missing', () => {

--- a/packages/platform/discord/src/index.ts
+++ b/packages/platform/discord/src/index.ts
@@ -28,6 +28,7 @@ import type {
   MessageRef,
   NormalizedEvent,
   OutboundMessage,
+  PlatformSessionKey,
   PlatformAdapter,
   SessionKey,
 } from '@agent-nexus/protocol';
@@ -210,7 +211,7 @@ export function parseInbound(
 
   const text = msg.content.replace(buildBotMentionRegex(botUserId), '').trim();
 
-  const sessionKey: SessionKey = {
+  const sessionKey: PlatformSessionKey = {
     platform: 'discord',
     channelId: msg.channelId,
     initiatorUserId: msg.author.id,

--- a/packages/protocol/src/events.ts
+++ b/packages/protocol/src/events.ts
@@ -1,4 +1,4 @@
-import type { SessionKey } from './session-key.js';
+import type { PlatformSessionKey } from './session-key.js';
 
 /** docs/dev/spec/message-protocol.md §EventType。MVP 仅实现 message。 */
 export type EventType =
@@ -33,7 +33,7 @@ export interface Attachment {
 export interface NormalizedEvent {
   eventId: string;
   platform: string;
-  sessionKey: SessionKey;
+  sessionKey: PlatformSessionKey;
   messageId?: string;
   traceId: string;
 

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -1,5 +1,9 @@
-export type { SessionKey } from './session-key.js';
-export { serializeSessionKey } from './session-key.js';
+export type { PlatformSessionKey, SessionKey } from './session-key.js';
+export {
+  serializePlatformSessionKey,
+  serializeSessionKey,
+  withPlatformName,
+} from './session-key.js';
 
 export type {
   Attachment,

--- a/packages/protocol/src/session-key.test.ts
+++ b/packages/protocol/src/session-key.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { serializeSessionKey, withPlatformName } from './session-key.js';
+import type { PlatformSessionKey, SessionKey } from './session-key.js';
+
+describe('SessionKey', () => {
+  it('serializes platform instance name before platform type/channel/user', () => {
+    const key: SessionKey = {
+      platformName: 'discord-main',
+      platform: 'discord',
+      channelId: 'C1',
+      initiatorUserId: 'U1',
+    };
+
+    expect(serializeSessionKey(key)).toBe('discord-main:discord:C1:U1');
+  });
+
+  it('withPlatformName upgrades adapter key into routed session key without mutating input', () => {
+    const adapterKey: PlatformSessionKey = {
+      platform: 'discord',
+      channelId: 'C1',
+      initiatorUserId: 'U1',
+    };
+
+    expect(withPlatformName(adapterKey, 'discord-main')).toEqual({
+      platformName: 'discord-main',
+      platform: 'discord',
+      channelId: 'C1',
+      initiatorUserId: 'U1',
+    });
+    expect(adapterKey).not.toHaveProperty('platformName');
+  });
+});

--- a/packages/protocol/src/session-key.ts
+++ b/packages/protocol/src/session-key.ts
@@ -1,14 +1,44 @@
 /**
- * 入站事件归一化的会话路由 key。
- * 字段定义对齐 docs/dev/spec/message-protocol.md §SessionKey。
+ * Platform adapter 产出的会话容器 key。
+ *
+ * Adapter 不知道配置里的 platform instance name；daemon routing 层会在
+ * dispatch 时用 withPlatformName 升级为 SessionKey。
  */
-export interface SessionKey {
+export interface PlatformSessionKey {
   platform: string;
   channelId: string;
   initiatorUserId: string;
 }
 
-/** `<platform>:<channelId>:<initiatorUserId>` —— 序列化形式（日志、持久化、Map key） */
+/**
+ * daemon/agent 侧使用的完整会话路由 key。
+ * 字段定义对齐 docs/dev/spec/message-protocol.md §SessionKey。
+ */
+export interface SessionKey extends PlatformSessionKey {
+  platformName: string;
+}
+
+export function withPlatformName(
+  key: PlatformSessionKey,
+  platformName: string,
+): SessionKey {
+  return {
+    platformName,
+    platform: key.platform,
+    channelId: key.channelId,
+    initiatorUserId: key.initiatorUserId,
+  };
+}
+
+/**
+ * `<platformName>:<platform>:<channelId>:<initiatorUserId>` — 序列化形式
+ * （日志、持久化、Map key）。
+ */
 export function serializeSessionKey(key: SessionKey): string {
+  return `${key.platformName}:${key.platform}:${key.channelId}:${key.initiatorUserId}`;
+}
+
+/** Adapter 层日志专用；不得用于 daemon session/idempotency 存储 key。 */
+export function serializePlatformSessionKey(key: PlatformSessionKey): string {
   return `${key.platform}:${key.channelId}:${key.initiatorUserId}`;
 }


### PR DESCRIPTION
## Scope

P10 runtime assembly and routing for the multi-platform/multi-agent config model.

- Add daemon routing table selection by `platformName` + Discord `channelIds`, with `route_not_found` / `route_ambiguous` fail-closed behavior.
- Split adapter `PlatformSessionKey` from daemon/agent `SessionKey`, and serialize runtime session keys as `platformName:platform:channelId:initiatorUserId`.
- Let CLI create all configured agent runtimes and one Engine per configured platform adapter, sharing a `SessionStore` while preserving platformName isolation.
- Allow multiple same-type platform configs now that session isolation includes platformName; reject duplicate resolved `statePath` values.

## Required Questions

- 对应 ADR：P8/P10 follows `docs/dev/adr/0015-multi-platform-agent-config` and does not introduce a new architecture decision beyond the accepted routing model.
- 对应 spec：Updated `docs/dev/spec/config-routing.md`, `docs/dev/spec/message-protocol.md`, `docs/dev/spec/platform-adapter.md`, and `docs/dev/spec/infra/persistence.md` for `PlatformSessionKey` vs full `SessionKey` and four-part session key serialization.
- 对应测试：Added protocol session-key tests, daemon router tests, engine fail-closed routing tests, two-engine shared-store isolation test, CLI registry/config tests, and updated backend runtime tests for full session keys.

## Validation

- `corepack pnpm test` (21 files / 319 tests)
- `corepack pnpm typecheck`
- `corepack pnpm build`
- `git diff --check`

## Review

Adversarial review log: `/home/node/.goal/codex-agent/reviews/p10-adversarial-20260524-010938`

Round 1 found 3 important issues. Fixed platformType SSOT, duplicate statePath validation, and shared-store cross-platform isolation coverage. Round 2 marked the important issues resolved/withdrawn and concluded: 接近最优，可停.