### PR TITLE
feat(command-registry): add protocol and daemon scaffold

### DIFF
--- a/packages/daemon/src/command-registry.test.ts
+++ b/packages/daemon/src/command-registry.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  CapabilitySet,
+  CommandDescriptor,
+  CommandRegistrationScope,
+} from '@agent-nexus/protocol';
+import {
+  ActiveCommandRegistry,
+  buildCommandRegistrationPlan,
+  CommandRegistryError,
+  DEFAULT_COMMAND_NAME_POLICY,
+} from './command-registry.js';
+
+const scope: CommandRegistrationScope = {
+  platformName: 'discord-main',
+  platformType: 'discord',
+  nativeScope: { kind: 'guild', guildId: 'G1' },
+};
+
+const caps: CapabilitySet = {
+  maxTextLength: 2000,
+  supportsEdit: false,
+  supportsDelete: false,
+  supportsReactions: false,
+  supportsEmbeds: false,
+  supportsButtons: false,
+  supportsThreads: false,
+  supportsEphemeral: true,
+  supportsAttachments: false,
+  maxAttachmentsPerMessage: 0,
+  supportsTypingIndicator: false,
+  supportsSlashCommands: true,
+};
+
+function agentCommand(agentOwner: string, localName: string): CommandDescriptor {
+  return {
+    canonicalId: `agent:${agentOwner}:${localName}`,
+    owner: { type: 'agent', agentOwner },
+    localName,
+    summary: `Start a new ${agentOwner} conversation`,
+    options: [],
+    handlerKey: localName,
+    applicability: { requiredCapabilities: ['slash-command-registration'] },
+    legacyNames: [],
+  };
+}
+
+describe('buildCommandRegistrationPlan', () => {
+  it('fails closed when canonical ids are duplicated', () => {
+    const descriptor = agentCommand('codex', 'new');
+
+    expect(() =>
+      buildCommandRegistrationPlan({
+        descriptors: [descriptor, descriptor],
+        scope,
+        capabilities: caps,
+        policy: DEFAULT_COMMAND_NAME_POLICY,
+        agentOwnersInScope: ['codex'],
+        generation: 'g1',
+      }),
+    ).toThrow(CommandRegistryError);
+  });
+
+  it('fails closed when canonical id disagrees with owner or local name', () => {
+    expect(() =>
+      buildCommandRegistrationPlan({
+        descriptors: [
+          {
+            ...agentCommand('codex', 'new'),
+            canonicalId: 'agent:claudecode:new',
+          },
+        ],
+        scope,
+        capabilities: caps,
+        policy: DEFAULT_COMMAND_NAME_POLICY,
+        agentOwnersInScope: ['codex'],
+        generation: 'g1',
+      }),
+    ).toThrow(CommandRegistryError);
+  });
+
+  it('fails closed when handler keys repeat within one owner', () => {
+    expect(() =>
+      buildCommandRegistrationPlan({
+        descriptors: [
+          agentCommand('codex', 'new'),
+          { ...agentCommand('codex', 'reset'), handlerKey: 'new' },
+        ],
+        scope,
+        capabilities: caps,
+        policy: DEFAULT_COMMAND_NAME_POLICY,
+        agentOwnersInScope: ['codex'],
+        generation: 'g1',
+      }),
+    ).toThrow(CommandRegistryError);
+  });
+
+  it('rejects active agent prefixes that collide with product reserved prefixes', () => {
+    expect(() =>
+      buildCommandRegistrationPlan({
+        descriptors: [agentCommand('nexus', 'new')],
+        scope,
+        capabilities: caps,
+        policy: DEFAULT_COMMAND_NAME_POLICY,
+        agentOwnersInScope: ['nexus'],
+        generation: 'g1',
+      }),
+    ).toThrow(CommandRegistryError);
+  });
+
+  it('does not generate a bare alias for a historical reserved name', () => {
+    expect(() =>
+      buildCommandRegistrationPlan({
+        descriptors: [agentCommand('codex', 'reply-mode')],
+        scope,
+        capabilities: caps,
+        policy: DEFAULT_COMMAND_NAME_POLICY,
+        agentOwnersInScope: ['codex'],
+        generation: 'g1',
+      }),
+    ).toThrow(CommandRegistryError);
+  });
+
+  it('does not generate a bare alias that looks like an active agent stable name', () => {
+    expect(() =>
+      buildCommandRegistrationPlan({
+        descriptors: [agentCommand('codex', 'codex-new')],
+        scope,
+        capabilities: caps,
+        policy: DEFAULT_COMMAND_NAME_POLICY,
+        agentOwnersInScope: ['codex'],
+        generation: 'g1',
+      }),
+    ).toThrow(CommandRegistryError);
+  });
+
+  it('generates a single-agent alias and removes it in multi-agent scope', () => {
+    const single = buildCommandRegistrationPlan({
+      descriptors: [agentCommand('codex', 'new')],
+      scope,
+      capabilities: caps,
+      policy: DEFAULT_COMMAND_NAME_POLICY,
+      agentOwnersInScope: ['codex'],
+      generation: 'g1',
+    });
+
+    expect(single.commands.map((command) => command.commandName).sort()).toEqual([
+      'codex-new',
+      'new',
+    ]);
+    expect(single.reverseMap.entries['new']).toMatchObject({
+      canonicalId: 'agent:codex:new',
+      aliasKind: 'single-agent-alias',
+    });
+
+    const multi = buildCommandRegistrationPlan({
+      descriptors: [
+        agentCommand('codex', 'new'),
+        agentCommand('claudecode', 'new'),
+      ],
+      scope,
+      capabilities: caps,
+      policy: DEFAULT_COMMAND_NAME_POLICY,
+      agentOwnersInScope: ['codex', 'claudecode'],
+      generation: 'g2',
+    });
+
+    expect(multi.commands.map((command) => command.commandName).sort()).toEqual([
+      'claudecode-new',
+      'codex-new',
+    ]);
+    expect(multi.reverseMap.entries['new']).toBeUndefined();
+  });
+});
+
+describe('ActiveCommandRegistry', () => {
+  it('fails closed when a command name misses the active reverse map', () => {
+    const plan = buildCommandRegistrationPlan({
+      descriptors: [agentCommand('codex', 'new')],
+      scope,
+      capabilities: caps,
+      policy: DEFAULT_COMMAND_NAME_POLICY,
+      agentOwnersInScope: ['codex'],
+      generation: 'g1',
+    });
+    const registry = new ActiveCommandRegistry();
+    registry.activate(plan, new Date(0));
+
+    expect(() => registry.resolve(scope, 'discord-reply-mode')).toThrow(
+      CommandRegistryError,
+    );
+  });
+});

--- a/packages/daemon/src/command-registry.ts
+++ b/packages/daemon/src/command-registry.ts
@@ -1,0 +1,452 @@
+import type {
+  ActiveCommandMap,
+  CapabilitySet,
+  CommandAliasKind,
+  CommandDescriptor,
+  CommandOwner,
+  CommandRegistrationPlan,
+  CommandRegistrationScope,
+  CommandRequiredCapability,
+  CommandRoute,
+  PlannedCommand,
+} from '@agent-nexus/protocol';
+
+export interface CommandNamePolicy {
+  productReservedPrefixes: string[];
+  platformReservedPrefixes: string[];
+  historicalReservedBareNames: string[];
+}
+
+export const DEFAULT_COMMAND_NAME_POLICY: CommandNamePolicy = {
+  productReservedPrefixes: ['nexus-'],
+  platformReservedPrefixes: ['discord-'],
+  historicalReservedBareNames: ['reply-mode'],
+};
+
+export type CommandRegistryErrorCode =
+  | 'command_descriptor_invalid'
+  | 'command_name_collision'
+  | 'command_name_reserved'
+  | 'command_active_map_missing'
+  | 'command_reverse_map_miss';
+
+export class CommandRegistryError extends Error {
+  constructor(
+    public readonly code: CommandRegistryErrorCode,
+    message: string,
+    public readonly details: Record<string, unknown> = {},
+  ) {
+    super(message);
+    this.name = 'CommandRegistryError';
+  }
+}
+
+export interface BuildCommandRegistrationPlanInput {
+  descriptors: readonly CommandDescriptor[];
+  scope: CommandRegistrationScope;
+  capabilities: CapabilitySet;
+  policy: CommandNamePolicy;
+  agentOwnersInScope: readonly string[];
+  generation: string;
+}
+
+interface ParsedCanonicalId {
+  owner: CommandOwner;
+  localName: string;
+}
+
+const KEBAB_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+function assertKebab(value: string, field: string): void {
+  if (!KEBAB_RE.test(value)) {
+    throw new CommandRegistryError(
+      'command_descriptor_invalid',
+      `${field} must be non-empty lowercase kebab-case`,
+      { field, value },
+    );
+  }
+}
+
+function parseCanonicalId(canonicalId: string): ParsedCanonicalId {
+  const parts = canonicalId.split(':');
+  if (parts[0] === 'agent' && parts.length === 3) {
+    const agentOwner = parts[1]!;
+    const localName = parts[2]!;
+    assertKebab(agentOwner, 'canonicalId.agentOwner');
+    assertKebab(localName, 'canonicalId.localName');
+    return { owner: { type: 'agent', agentOwner }, localName };
+  }
+  if (parts[0] === 'platform' && parts.length === 3) {
+    const platformType = parts[1]!;
+    const localName = parts[2]!;
+    assertKebab(platformType, 'canonicalId.platformType');
+    assertKebab(localName, 'canonicalId.localName');
+    return { owner: { type: 'platform', platformType }, localName };
+  }
+  if (parts[0] === 'daemon' && parts.length === 2) {
+    const localName = parts[1]!;
+    assertKebab(localName, 'canonicalId.localName');
+    return { owner: { type: 'daemon' }, localName };
+  }
+  throw new CommandRegistryError(
+    'command_descriptor_invalid',
+    'canonicalId has invalid command owner shape',
+    { canonicalId },
+  );
+}
+
+function sameOwner(a: CommandOwner, b: CommandOwner): boolean {
+  if (a.type !== b.type) return false;
+  if (a.type === 'agent' && b.type === 'agent') {
+    return a.agentOwner === b.agentOwner;
+  }
+  if (a.type === 'platform' && b.type === 'platform') {
+    return a.platformType === b.platformType;
+  }
+  return true;
+}
+
+function ownerKey(owner: CommandOwner): string {
+  if (owner.type === 'agent') return `agent:${owner.agentOwner}`;
+  if (owner.type === 'platform') return `platform:${owner.platformType}`;
+  return 'daemon';
+}
+
+function validateDescriptor(descriptor: CommandDescriptor): void {
+  const parsed = parseCanonicalId(descriptor.canonicalId);
+  assertKebab(descriptor.localName, 'localName');
+  if (descriptor.owner.type === 'agent') {
+    assertKebab(descriptor.owner.agentOwner, 'owner.agentOwner');
+  } else if (descriptor.owner.type === 'platform') {
+    assertKebab(descriptor.owner.platformType, 'owner.platformType');
+  }
+  if (
+    !sameOwner(parsed.owner, descriptor.owner) ||
+    parsed.localName !== descriptor.localName
+  ) {
+    throw new CommandRegistryError(
+      'command_descriptor_invalid',
+      'canonicalId must match owner and localName',
+      {
+        canonicalId: descriptor.canonicalId,
+        owner: descriptor.owner,
+        localName: descriptor.localName,
+      },
+    );
+  }
+  if (descriptor.summary.trim().length === 0) {
+    throw new CommandRegistryError(
+      'command_descriptor_invalid',
+      'summary must be non-empty',
+      { canonicalId: descriptor.canonicalId },
+    );
+  }
+  if (descriptor.handlerKey.trim().length === 0) {
+    throw new CommandRegistryError(
+      'command_descriptor_invalid',
+      'handlerKey must be non-empty',
+      { canonicalId: descriptor.canonicalId },
+    );
+  }
+  if (descriptor.owner.type === 'daemon') {
+    const hasExplicitScope =
+      (descriptor.applicability.platformTypes?.length ?? 0) > 0 ||
+      descriptor.applicability.requiredCapabilities.length > 0;
+    if (!hasExplicitScope) {
+      throw new CommandRegistryError(
+        'command_descriptor_invalid',
+        'daemon command must declare platformTypes or requiredCapabilities',
+        { canonicalId: descriptor.canonicalId },
+      );
+    }
+  }
+  if (
+    descriptor.owner.type === 'platform' &&
+    descriptor.applicability.platformTypes &&
+    !descriptor.applicability.platformTypes.includes(descriptor.owner.platformType)
+  ) {
+    throw new CommandRegistryError(
+      'command_descriptor_invalid',
+      'platform command applicability must include owner platformType',
+      {
+        canonicalId: descriptor.canonicalId,
+        platformType: descriptor.owner.platformType,
+      },
+    );
+  }
+  for (const option of descriptor.options) {
+    assertKebab(option.name, 'option.name');
+  }
+  for (const legacy of descriptor.legacyNames) {
+    assertKebab(legacy.name, 'legacy.name');
+  }
+}
+
+function hasCapability(
+  capability: CommandRequiredCapability,
+  capabilities: CapabilitySet,
+): boolean {
+  if (capability === 'slash-command-registration') {
+    return capabilities.supportsSlashCommands;
+  }
+  return capabilities.supportsEphemeral;
+}
+
+function appliesToScope(
+  descriptor: CommandDescriptor,
+  scope: CommandRegistrationScope,
+  capabilities: CapabilitySet,
+  agentOwnersInScope: ReadonlySet<string>,
+): boolean {
+  const { applicability } = descriptor;
+  if (
+    applicability.platformTypes &&
+    !applicability.platformTypes.includes(scope.platformType)
+  ) {
+    return false;
+  }
+  if (
+    descriptor.owner.type === 'platform' &&
+    descriptor.owner.platformType !== scope.platformType
+  ) {
+    return false;
+  }
+  if (
+    descriptor.owner.type === 'agent' &&
+    !agentOwnersInScope.has(descriptor.owner.agentOwner)
+  ) {
+    return false;
+  }
+  return applicability.requiredCapabilities.every((capability) =>
+    hasCapability(capability, capabilities),
+  );
+}
+
+function stableName(descriptor: CommandDescriptor): string {
+  if (descriptor.owner.type === 'agent') {
+    return `${descriptor.owner.agentOwner}-${descriptor.localName}`;
+  }
+  if (descriptor.owner.type === 'platform') {
+    return `${descriptor.owner.platformType}-${descriptor.localName}`;
+  }
+  return `nexus-${descriptor.localName}`;
+}
+
+function activeAgentPrefixes(agentOwnersInScope: readonly string[]): string[] {
+  return [...new Set(agentOwnersInScope)].map((owner) => `${owner}-`);
+}
+
+function ensureAgentPrefixesAllowed(
+  agentOwnersInScope: readonly string[],
+  policy: CommandNamePolicy,
+): void {
+  const reserved = [
+    ...policy.productReservedPrefixes,
+    ...policy.platformReservedPrefixes,
+  ];
+  for (const prefix of activeAgentPrefixes(agentOwnersInScope)) {
+    if (reserved.some((reservedPrefix) => prefix.startsWith(reservedPrefix))) {
+      throw new CommandRegistryError(
+        'command_name_reserved',
+        'agent owner prefix collides with a reserved command prefix',
+        { prefix },
+      );
+    }
+  }
+}
+
+function matchesReservedBareName(
+  name: string,
+  policy: CommandNamePolicy,
+  agentPrefixes: readonly string[],
+): boolean {
+  return (
+    policy.historicalReservedBareNames.includes(name) ||
+    policy.productReservedPrefixes.some((prefix) => name.startsWith(prefix)) ||
+    policy.platformReservedPrefixes.some((prefix) => name.startsWith(prefix)) ||
+    agentPrefixes.some((prefix) => name.startsWith(prefix))
+  );
+}
+
+function makeRoute(
+  descriptor: CommandDescriptor,
+  aliasKind: CommandAliasKind,
+): CommandRoute {
+  return {
+    canonicalId: descriptor.canonicalId,
+    aliasKind,
+    owner: descriptor.owner,
+    handlerKey: descriptor.handlerKey,
+  };
+}
+
+function addCommand(
+  commandsByName: Map<string, PlannedCommand>,
+  descriptor: CommandDescriptor,
+  commandName: string,
+  aliasKind: CommandAliasKind,
+): void {
+  assertKebab(commandName, 'commandName');
+  if (commandsByName.has(commandName)) {
+    throw new CommandRegistryError(
+      'command_name_collision',
+      'command name must be unique within a registration scope',
+      { commandName },
+    );
+  }
+  commandsByName.set(commandName, {
+    commandName,
+    canonicalId: descriptor.canonicalId,
+    aliasKind,
+    descriptor,
+  });
+}
+
+export function buildCommandRegistrationPlan(
+  input: BuildCommandRegistrationPlanInput,
+): CommandRegistrationPlan {
+  ensureAgentPrefixesAllowed(input.agentOwnersInScope, input.policy);
+
+  const seenCanonicalIds = new Set<string>();
+  const handlerKeysByOwner = new Map<string, Set<string>>();
+  const agentOwnersInScope = new Set(input.agentOwnersInScope);
+  const applicable: CommandDescriptor[] = [];
+  for (const descriptor of input.descriptors) {
+    validateDescriptor(descriptor);
+    if (seenCanonicalIds.has(descriptor.canonicalId)) {
+      throw new CommandRegistryError(
+        'command_descriptor_invalid',
+        'canonicalId must be globally unique',
+        { canonicalId: descriptor.canonicalId },
+      );
+    }
+    seenCanonicalIds.add(descriptor.canonicalId);
+    const ownerHandlerKeys =
+      handlerKeysByOwner.get(ownerKey(descriptor.owner)) ?? new Set<string>();
+    if (ownerHandlerKeys.has(descriptor.handlerKey)) {
+      throw new CommandRegistryError(
+        'command_descriptor_invalid',
+        'handlerKey must be unique within one command owner',
+        {
+          canonicalId: descriptor.canonicalId,
+          owner: descriptor.owner,
+          handlerKey: descriptor.handlerKey,
+        },
+      );
+    }
+    ownerHandlerKeys.add(descriptor.handlerKey);
+    handlerKeysByOwner.set(ownerKey(descriptor.owner), ownerHandlerKeys);
+    if (
+      appliesToScope(
+        descriptor,
+        input.scope,
+        input.capabilities,
+        agentOwnersInScope,
+      )
+    ) {
+      applicable.push(descriptor);
+    }
+  }
+
+  const commandsByName = new Map<string, PlannedCommand>();
+  for (const descriptor of applicable) {
+    addCommand(commandsByName, descriptor, stableName(descriptor), 'stable');
+  }
+
+  for (const descriptor of applicable) {
+    for (const legacy of descriptor.legacyNames) {
+      if (!input.policy.historicalReservedBareNames.includes(legacy.name)) {
+        throw new CommandRegistryError(
+          'command_name_reserved',
+          'legacy command name must remain historically reserved',
+          { canonicalId: descriptor.canonicalId, legacyName: legacy.name },
+        );
+      }
+      addCommand(commandsByName, descriptor, legacy.name, 'legacy');
+    }
+  }
+
+  const agentPrefixes = activeAgentPrefixes(input.agentOwnersInScope);
+  const agentOwnersByLocalName = new Map<string, Set<string>>();
+  for (const descriptor of applicable) {
+    if (descriptor.owner.type !== 'agent') continue;
+    const owners =
+      agentOwnersByLocalName.get(descriptor.localName) ?? new Set<string>();
+    owners.add(descriptor.owner.agentOwner);
+    agentOwnersByLocalName.set(descriptor.localName, owners);
+  }
+
+  for (const descriptor of applicable) {
+    if (descriptor.owner.type !== 'agent') continue;
+    const owners = agentOwnersByLocalName.get(descriptor.localName);
+    if (!owners || owners.size !== 1) continue;
+
+    const aliasName = descriptor.localName;
+    if (matchesReservedBareName(aliasName, input.policy, agentPrefixes)) {
+      throw new CommandRegistryError(
+        'command_name_reserved',
+        'single-agent alias collides with a reserved command name',
+        { canonicalId: descriptor.canonicalId, aliasName },
+      );
+    }
+    addCommand(commandsByName, descriptor, aliasName, 'single-agent-alias');
+  }
+
+  const commands = [...commandsByName.values()];
+  const entries: Record<string, CommandRoute> = {};
+  for (const command of commands) {
+    entries[command.commandName] = makeRoute(command.descriptor, command.aliasKind);
+  }
+
+  return {
+    scope: input.scope,
+    commands,
+    reverseMap: { entries },
+    generation: input.generation,
+  };
+}
+
+function scopeKey(scope: CommandRegistrationScope): string {
+  const native =
+    scope.nativeScope.kind === 'global'
+      ? 'global'
+      : `guild:${scope.nativeScope.guildId}`;
+  return `${scope.platformName}:${scope.platformType}:${native}`;
+}
+
+export class ActiveCommandRegistry {
+  private readonly activeMaps = new Map<string, ActiveCommandMap>();
+
+  activate(plan: CommandRegistrationPlan, activatedAt: Date): void {
+    this.activeMaps.set(scopeKey(plan.scope), {
+      scope: plan.scope,
+      reverseMap: plan.reverseMap,
+      generation: plan.generation,
+      activatedAt,
+    });
+  }
+
+  resolve(scope: CommandRegistrationScope, commandName: string): CommandRoute {
+    const active = this.activeMaps.get(scopeKey(scope));
+    if (!active) {
+      throw new CommandRegistryError(
+        'command_active_map_missing',
+        'command dispatch requires an active command map',
+        { scope },
+      );
+    }
+    const route = active.reverseMap.entries[commandName];
+    if (!route) {
+      throw new CommandRegistryError(
+        'command_reverse_map_miss',
+        'command name is not present in the active reverse map',
+        {
+          scope,
+          commandName,
+          generation: active.generation,
+        },
+      );
+    }
+    return route;
+  }
+}

--- a/packages/daemon/src/engine.test.ts
+++ b/packages/daemon/src/engine.test.ts
@@ -36,6 +36,7 @@ const platformCaps: CapabilitySet = {
   supportsAttachments: false,
   maxAttachmentsPerMessage: 0,
   supportsTypingIndicator: false,
+  supportsSlashCommands: false,
 };
 
 const agentCaps: AgentCapabilitySet = {

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -9,6 +9,15 @@ export {
   type RoutingEntry,
 } from './router.js';
 export {
+  ActiveCommandRegistry,
+  buildCommandRegistrationPlan,
+  CommandRegistryError,
+  DEFAULT_COMMAND_NAME_POLICY,
+  type BuildCommandRegistrationPlanInput,
+  type CommandNamePolicy,
+  type CommandRegistryErrorCode,
+} from './command-registry.js';
+export {
   parseDaemonConfig,
   parsePlatformAuthConfig,
   DaemonConfigError,

--- a/packages/platform/discord/src/index.test.ts
+++ b/packages/platform/discord/src/index.test.ts
@@ -285,6 +285,7 @@ describe('edit / typing capabilities', () => {
     expect(platform.capabilities()).toMatchObject({
       supportsEdit: true,
       supportsTypingIndicator: true,
+      supportsSlashCommands: true,
     });
   });
 

--- a/packages/platform/discord/src/index.ts
+++ b/packages/platform/discord/src/index.ts
@@ -303,6 +303,7 @@ export function createDiscordPlatform(opts: DiscordPlatformOptions): PlatformAda
         supportsAttachments: false,
         maxAttachmentsPerMessage: 0,
         supportsTypingIndicator: true,
+        supportsSlashCommands: true,
       };
     },
 

--- a/packages/protocol/src/command.ts
+++ b/packages/protocol/src/command.ts
@@ -1,0 +1,101 @@
+export type CommandCanonicalId = string;
+
+export type CommandOwner =
+  | { type: 'agent'; agentOwner: string }
+  | { type: 'platform'; platformType: string }
+  | { type: 'daemon' };
+
+export type CommandOptionType = 'string' | 'integer' | 'number' | 'boolean';
+
+export interface CommandChoice {
+  name: string;
+  value: string | number;
+}
+
+export interface CommandOption {
+  name: string;
+  type: CommandOptionType;
+  required: boolean;
+  description: string;
+  choices: CommandChoice[];
+}
+
+export type CommandRequiredCapability =
+  | 'slash-command-registration'
+  | 'ephemeral-response';
+
+export interface CommandApplicability {
+  platformTypes?: string[];
+  requiredCapabilities: CommandRequiredCapability[];
+}
+
+export interface LegacyCommandName {
+  name: string;
+  reason: 'historical-compatibility';
+}
+
+/** docs/dev/spec/command-registry.md §CommandDescriptor */
+export interface CommandDescriptor {
+  canonicalId: CommandCanonicalId;
+  owner: CommandOwner;
+  localName: string;
+  summary: string;
+  options: CommandOption[];
+  handlerKey: string;
+  applicability: CommandApplicability;
+  legacyNames: LegacyCommandName[];
+}
+
+export type NativeCommandScope =
+  | { kind: 'global' }
+  | { kind: 'guild'; guildId: string };
+
+/** docs/dev/spec/command-registry.md §Registration Scope */
+export interface CommandRegistrationScope {
+  platformName: string;
+  platformType: string;
+  nativeScope: NativeCommandScope;
+}
+
+export type CommandAliasKind = 'stable' | 'single-agent-alias' | 'legacy';
+
+export interface CommandRoute {
+  canonicalId: CommandCanonicalId;
+  aliasKind: CommandAliasKind;
+  owner: CommandOwner;
+  handlerKey: string;
+}
+
+export interface CommandReverseMap {
+  entries: Record<string, CommandRoute>;
+}
+
+export interface PlannedCommand {
+  commandName: string;
+  canonicalId: CommandCanonicalId;
+  aliasKind: CommandAliasKind;
+  descriptor: CommandDescriptor;
+}
+
+export interface CommandRegistrationPlan {
+  scope: CommandRegistrationScope;
+  commands: PlannedCommand[];
+  reverseMap: CommandReverseMap;
+  generation: string;
+}
+
+export interface ActiveCommandMap {
+  scope: CommandRegistrationScope;
+  reverseMap: CommandReverseMap;
+  generation: string;
+  activatedAt: Date;
+}
+
+export type CommandArgValue = string | number | boolean | null;
+
+/** docs/dev/spec/message-protocol.md §CommandPayload */
+export interface CommandPayload {
+  name: string;
+  args: Record<string, CommandArgValue>;
+  registrationScope: CommandRegistrationScope;
+}

--- a/packages/protocol/src/events.ts
+++ b/packages/protocol/src/events.ts
@@ -1,4 +1,5 @@
 import type { PlatformSessionKey } from './session-key.js';
+import type { CommandPayload } from './command.js';
 
 /** docs/dev/spec/message-protocol.md §EventType。MVP 仅实现 message。 */
 export type EventType =
@@ -40,6 +41,7 @@ export interface NormalizedEvent {
   type: EventType;
 
   text?: string;
+  command?: CommandPayload;
   attachments?: Attachment[];
 
   rawPayload: unknown;

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -19,6 +19,28 @@ export type {
 } from './outbound.js';
 
 export type {
+  ActiveCommandMap,
+  CommandAliasKind,
+  CommandApplicability,
+  CommandArgValue,
+  CommandCanonicalId,
+  CommandChoice,
+  CommandDescriptor,
+  CommandOption,
+  CommandOptionType,
+  CommandOwner,
+  CommandPayload,
+  CommandRegistrationPlan,
+  CommandRegistrationScope,
+  CommandRequiredCapability,
+  CommandReverseMap,
+  CommandRoute,
+  LegacyCommandName,
+  NativeCommandScope,
+  PlannedCommand,
+} from './command.js';
+
+export type {
   AgentEvent,
   AgentCapabilitySet,
   AgentInput,

--- a/packages/protocol/src/outbound.ts
+++ b/packages/protocol/src/outbound.ts
@@ -39,4 +39,5 @@ export interface CapabilitySet {
   supportsAttachments: boolean;
   maxAttachmentsPerMessage: number;
   supportsTypingIndicator: boolean;
+  supportsSlashCommands: boolean;
 }


### PR DESCRIPTION
## Summary

- Add platform-neutral command descriptor, registration scope, plan, route, and payload types to `@agent-nexus/protocol`.
- Add daemon command registry scaffold for descriptor validation, name policy checks, plan construction, single-agent alias generation/removal, and active reverse-map lookup.
- Add `supportsSlashCommands` to platform capabilities and set Discord to true.

## Tests

- Red step: `COREPACK_HOME=/cache/corepack corepack pnpm exec vitest run packages/daemon/src/command-registry.test.ts` initially failed because the scaffold module did not exist.
- `COREPACK_HOME=/cache/corepack corepack pnpm exec vitest run packages/daemon/src/command-registry.test.ts`
- `COREPACK_HOME=/cache/corepack corepack pnpm exec tsc --noEmit --pretty false`
- `COREPACK_HOME=/cache/corepack corepack pnpm test`
- `git diff --check`

## Review

- Independent Claude review saved outside the repo at `/home/node/.goal/slash-command-registry/reviews/p3-scaffold-claude-review.md`.
- Review response saved at `/home/node/.goal/slash-command-registry/reviews/p3-scaffold-review-response.md`.
- Reviewer found no blocker or important findings. Two code nits were fixed after review: descriptor validation placement and handlerKey same-owner uniqueness.

## Notes

- PR base is `feature/slash-command-registry-main`.
- This is P3 scaffold only; remote registration activation and full owner dispatch remain for P4/P5.