### PR TITLE
feat(command-registry): add daemon command dispatch resolver

### DIFF
--- a/packages/daemon/src/command-dispatch.test.ts
+++ b/packages/daemon/src/command-dispatch.test.ts
@@ -1,0 +1,391 @@
+import { describe, expect, it, vi } from 'vitest';
+import type {
+  CapabilitySet,
+  CommandDescriptor,
+  CommandRegistrationScope,
+  NormalizedEvent,
+} from '@agent-nexus/protocol';
+import {
+  ActiveCommandRegistry,
+  buildCommandRegistrationPlan,
+  DEFAULT_COMMAND_NAME_POLICY,
+} from './command-registry.js';
+import {
+  dispatchCommandEvent,
+  resolveCommandDispatch,
+  type CommandDispatchAgentTarget,
+  type CommandDispatchLogger,
+} from './command-dispatch.js';
+import type { RoutingEntry } from './router.js';
+
+const scope: CommandRegistrationScope = {
+  platformName: 'discord-main',
+  platformType: 'discord',
+  nativeScope: { kind: 'guild', guildId: 'G1' },
+};
+
+const caps: CapabilitySet = {
+  maxTextLength: 2000,
+  supportsEdit: false,
+  supportsDelete: false,
+  supportsReactions: false,
+  supportsEmbeds: false,
+  supportsButtons: false,
+  supportsThreads: false,
+  supportsEphemeral: true,
+  supportsAttachments: false,
+  maxAttachmentsPerMessage: 0,
+  supportsTypingIndicator: false,
+  supportsSlashCommands: true,
+};
+
+const routeToCodex: RoutingEntry = {
+  bindingName: 'discord-main-codex',
+  platformName: 'discord-main',
+  platformType: 'discord',
+  agentName: 'codex-dev',
+  match: { discord: { channelIds: ['C1'] } },
+};
+
+const codexTarget: CommandDispatchAgentTarget = {
+  agentName: 'codex-dev',
+  agentOwner: 'codex',
+  handlerKeys: ['new'],
+};
+
+function agentCommand(agentOwner: string, localName: string): CommandDescriptor {
+  return {
+    canonicalId: `agent:${agentOwner}:${localName}`,
+    owner: { type: 'agent', agentOwner },
+    localName,
+    summary: `Run ${localName}`,
+    options: [],
+    handlerKey: localName,
+    applicability: { requiredCapabilities: ['slash-command-registration'] },
+    legacyNames: [],
+  };
+}
+
+function platformCommand(): CommandDescriptor {
+  return {
+    canonicalId: 'platform:discord:reply-mode',
+    owner: { type: 'platform', platformType: 'discord' },
+    localName: 'reply-mode',
+    summary: 'Switch reply mode',
+    options: [],
+    handlerKey: 'reply-mode',
+    applicability: {
+      platformTypes: ['discord'],
+      requiredCapabilities: [
+        'slash-command-registration',
+        'ephemeral-response',
+      ],
+    },
+    legacyNames: [{ name: 'reply-mode', reason: 'historical-compatibility' }],
+  };
+}
+
+function daemonCommand(): CommandDescriptor {
+  return {
+    canonicalId: 'daemon:status',
+    owner: { type: 'daemon' },
+    localName: 'status',
+    summary: 'Show daemon status',
+    options: [],
+    handlerKey: 'status',
+    applicability: {
+      platformTypes: ['discord'],
+      requiredCapabilities: ['slash-command-registration'],
+    },
+    legacyNames: [],
+  };
+}
+
+function makeRegistry(descriptors: CommandDescriptor[]): ActiveCommandRegistry {
+  const plan = buildCommandRegistrationPlan({
+    descriptors,
+    scope,
+    capabilities: caps,
+    policy: DEFAULT_COMMAND_NAME_POLICY,
+    agentOwnersInScope: ['codex'],
+    generation: 'g1',
+  });
+  const registry = new ActiveCommandRegistry();
+  registry.activate(plan, new Date(0));
+  return registry;
+}
+
+function makeCommandEvent(commandName: string, channelId = 'C1'): NormalizedEvent {
+  return {
+    eventId: `e-${commandName}`,
+    platform: 'discord',
+    sessionKey: {
+      platform: 'discord',
+      channelId,
+      initiatorUserId: 'U1',
+    },
+    messageId: 'm-1',
+    traceId: 't-1',
+    type: 'command',
+    command: {
+      name: commandName,
+      args: {},
+      registrationScope: scope,
+    },
+    rawPayload: {},
+    rawContentType: 'application/json',
+    receivedAt: new Date(0),
+    initiator: { userId: 'U1', displayName: 'U1', isBot: false },
+  };
+}
+
+function logger(): CommandDispatchLogger & {
+  error: ReturnType<typeof vi.fn>;
+} {
+  return { error: vi.fn() };
+}
+
+describe('resolveCommandDispatch', () => {
+  it('routes agent commands through the active reverse map and binding owner', () => {
+    const decision = resolveCommandDispatch({
+      event: makeCommandEvent('codex-new'),
+      registry: makeRegistry([agentCommand('codex', 'new')]),
+      platformName: 'discord-main',
+      platformType: 'discord',
+      routingTable: [routeToCodex],
+      agentTargets: [codexTarget],
+      platformHandlerKeys: [],
+      daemonHandlerKeys: [],
+    });
+
+    expect(decision).toMatchObject({
+      ownerType: 'agent',
+      canonicalId: 'agent:codex:new',
+      commandName: 'codex-new',
+      bindingName: 'discord-main-codex',
+      agentName: 'codex-dev',
+      agentOwner: 'codex',
+      handlerKey: 'new',
+    });
+  });
+
+  it('routes platform and daemon commands to their owner handlers', () => {
+    const registry = makeRegistry([platformCommand(), daemonCommand()]);
+
+    expect(
+      resolveCommandDispatch({
+        event: makeCommandEvent('reply-mode'),
+        registry,
+        platformName: 'discord-main',
+        platformType: 'discord',
+        routingTable: [routeToCodex],
+        agentTargets: [codexTarget],
+        platformHandlerKeys: ['reply-mode'],
+        daemonHandlerKeys: ['status'],
+      }),
+    ).toMatchObject({
+      ownerType: 'platform',
+      canonicalId: 'platform:discord:reply-mode',
+      handlerKey: 'reply-mode',
+    });
+
+    expect(
+      resolveCommandDispatch({
+        event: makeCommandEvent('nexus-status'),
+        registry,
+        platformName: 'discord-main',
+        platformType: 'discord',
+        routingTable: [routeToCodex],
+        agentTargets: [codexTarget],
+        platformHandlerKeys: ['reply-mode'],
+        daemonHandlerKeys: ['status'],
+      }),
+    ).toMatchObject({
+      ownerType: 'daemon',
+      canonicalId: 'daemon:status',
+      handlerKey: 'status',
+    });
+  });
+});
+
+describe('dispatchCommandEvent', () => {
+  it('returns the dispatch decision for a valid agent command', () => {
+    const log = logger();
+
+    const decision = dispatchCommandEvent({
+      event: makeCommandEvent('codex-new'),
+      registry: makeRegistry([agentCommand('codex', 'new')]),
+      platformName: 'discord-main',
+      platformType: 'discord',
+      routingTable: [routeToCodex],
+      agentTargets: [codexTarget],
+      platformHandlerKeys: [],
+      daemonHandlerKeys: [],
+      logger: log,
+    });
+
+    expect(decision).toMatchObject({
+      ownerType: 'agent',
+      canonicalId: 'agent:codex:new',
+      bindingName: 'discord-main-codex',
+    });
+    expect(log.error).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when an agent command does not match a binding', () => {
+    const log = logger();
+
+    const decision = dispatchCommandEvent({
+      event: makeCommandEvent('codex-new', 'C2'),
+      registry: makeRegistry([agentCommand('codex', 'new')]),
+      platformName: 'discord-main',
+      platformType: 'discord',
+      routingTable: [routeToCodex],
+      agentTargets: [codexTarget],
+      platformHandlerKeys: [],
+      daemonHandlerKeys: [],
+      logger: log,
+    });
+
+    expect(decision).toBeUndefined();
+    expect(log.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        commandName: 'codex-new',
+        canonicalId: 'agent:codex:new',
+        routeCode: 'route_not_found',
+      }),
+      'command_agent_binding_miss',
+    );
+  });
+
+  it('fails closed when the reverse map route agent owner differs from the channel binding owner', () => {
+    const log = logger();
+
+    const decision = dispatchCommandEvent({
+      event: makeCommandEvent('codex-new'),
+      registry: makeRegistry([agentCommand('codex', 'new')]),
+      platformName: 'discord-main',
+      platformType: 'discord',
+      routingTable: [routeToCodex],
+      agentTargets: [
+        { agentName: 'codex-dev', agentOwner: 'claudecode', handlerKeys: ['new'] },
+      ],
+      platformHandlerKeys: [],
+      daemonHandlerKeys: [],
+      logger: log,
+    });
+
+    expect(decision).toBeUndefined();
+    expect(log.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        traceId: 't-1',
+        platformName: 'discord-main',
+        commandName: 'codex-new',
+        canonicalId: 'agent:codex:new',
+      }),
+      'command_agent_owner_mismatch',
+    );
+  });
+
+  it('fails closed when an owner handler key is missing', () => {
+    const log = logger();
+
+    const decision = dispatchCommandEvent({
+      event: makeCommandEvent('nexus-status'),
+      registry: makeRegistry([daemonCommand()]),
+      platformName: 'discord-main',
+      platformType: 'discord',
+      routingTable: [routeToCodex],
+      agentTargets: [codexTarget],
+      platformHandlerKeys: [],
+      daemonHandlerKeys: [],
+      logger: log,
+    });
+
+    expect(decision).toBeUndefined();
+    expect(log.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        commandName: 'nexus-status',
+        canonicalId: 'daemon:status',
+        handlerKey: 'status',
+      }),
+      'command_handler_missing',
+    );
+  });
+
+  it('fails closed when an agent handler key is missing', () => {
+    const log = logger();
+
+    const decision = dispatchCommandEvent({
+      event: makeCommandEvent('codex-new'),
+      registry: makeRegistry([agentCommand('codex', 'new')]),
+      platformName: 'discord-main',
+      platformType: 'discord',
+      routingTable: [routeToCodex],
+      agentTargets: [{ ...codexTarget, handlerKeys: [] }],
+      platformHandlerKeys: [],
+      daemonHandlerKeys: [],
+      logger: log,
+    });
+
+    expect(decision).toBeUndefined();
+    expect(log.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        commandName: 'codex-new',
+        canonicalId: 'agent:codex:new',
+        handlerKey: 'new',
+      }),
+      'command_handler_missing',
+    );
+  });
+
+  it('fails closed when a platform handler key is missing', () => {
+    const log = logger();
+
+    const decision = dispatchCommandEvent({
+      event: makeCommandEvent('reply-mode'),
+      registry: makeRegistry([platformCommand()]),
+      platformName: 'discord-main',
+      platformType: 'discord',
+      routingTable: [routeToCodex],
+      agentTargets: [codexTarget],
+      platformHandlerKeys: [],
+      daemonHandlerKeys: [],
+      logger: log,
+    });
+
+    expect(decision).toBeUndefined();
+    expect(log.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        commandName: 'reply-mode',
+        canonicalId: 'platform:discord:reply-mode',
+        handlerKey: 'reply-mode',
+      }),
+      'command_handler_missing',
+    );
+  });
+
+  it('fails closed when a command name misses the active reverse map', () => {
+    const log = logger();
+
+    const decision = dispatchCommandEvent({
+      event: makeCommandEvent('discord-reply-mode'),
+      registry: makeRegistry([agentCommand('codex', 'new')]),
+      platformName: 'discord-main',
+      platformType: 'discord',
+      routingTable: [routeToCodex],
+      agentTargets: [codexTarget],
+      platformHandlerKeys: [],
+      daemonHandlerKeys: [],
+      logger: log,
+    });
+
+    expect(decision).toBeUndefined();
+    expect(log.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        commandName: 'discord-reply-mode',
+      }),
+      'command_reverse_map_miss',
+    );
+  });
+});

--- a/packages/daemon/src/command-dispatch.ts
+++ b/packages/daemon/src/command-dispatch.ts
@@ -1,0 +1,230 @@
+import type {
+  CommandRoute,
+  NormalizedEvent,
+} from '@agent-nexus/protocol';
+import {
+  ActiveCommandRegistry,
+  CommandRegistryError,
+} from './command-registry.js';
+import {
+  RouteError,
+  selectRoute,
+  type RouteDecision,
+  type RoutingEntry,
+} from './router.js';
+
+export interface CommandDispatchAgentTarget {
+  agentName: string;
+  agentOwner: string;
+  handlerKeys: readonly string[];
+}
+
+export interface CommandDispatchLogger {
+  error(obj: Record<string, unknown>, msg: string): void;
+}
+
+export type CommandDispatchDecision =
+  | {
+      ownerType: 'agent';
+      commandName: string;
+      canonicalId: string;
+      aliasKind: CommandRoute['aliasKind'];
+      handlerKey: string;
+      bindingName: string;
+      agentName: string;
+      agentOwner: string;
+    }
+  | {
+      ownerType: 'platform';
+      commandName: string;
+      canonicalId: string;
+      aliasKind: CommandRoute['aliasKind'];
+      handlerKey: string;
+      platformType: string;
+    }
+  | {
+      ownerType: 'daemon';
+      commandName: string;
+      canonicalId: string;
+      aliasKind: CommandRoute['aliasKind'];
+      handlerKey: string;
+    };
+
+export interface CommandDispatchInput {
+  event: NormalizedEvent;
+  registry: ActiveCommandRegistry;
+  platformName: string;
+  platformType: 'discord';
+  routingTable: readonly RoutingEntry[];
+  agentTargets: readonly CommandDispatchAgentTarget[];
+  platformHandlerKeys: readonly string[];
+  daemonHandlerKeys: readonly string[];
+}
+
+export interface DispatchCommandEventInput extends CommandDispatchInput {
+  logger: CommandDispatchLogger;
+}
+
+function requireCommand(event: NormalizedEvent): NonNullable<NormalizedEvent['command']> {
+  if (event.type !== 'command' || !event.command) {
+    throw new CommandRegistryError(
+      'command_handler_missing',
+      'command event requires command payload',
+      { eventType: event.type },
+    );
+  }
+  return event.command;
+}
+
+function hasHandler(handlerKeys: readonly string[], handlerKey: string): boolean {
+  return handlerKeys.includes(handlerKey);
+}
+
+function dispatchError(
+  code:
+    | 'command_agent_binding_miss'
+    | 'command_agent_owner_mismatch'
+    | 'command_handler_missing',
+  message: string,
+  route: CommandRoute,
+  commandName: string,
+  details: Record<string, unknown>,
+): CommandRegistryError {
+  return new CommandRegistryError(code, message, {
+    ...details,
+    commandName,
+    canonicalId: route.canonicalId,
+    aliasKind: route.aliasKind,
+    handlerKey: route.handlerKey,
+  });
+}
+
+export function resolveCommandDispatch(
+  input: CommandDispatchInput,
+): CommandDispatchDecision {
+  const command = requireCommand(input.event);
+  const route = input.registry.resolve(command.registrationScope, command.name);
+
+  if (route.owner.type === 'agent') {
+    let routed: RouteDecision;
+    try {
+      routed = selectRoute(input.routingTable, {
+        platformName: input.platformName,
+        platformType: input.platformType,
+        event: input.event,
+      });
+    } catch (err) {
+      if (err instanceof RouteError) {
+        throw dispatchError(
+          'command_agent_binding_miss',
+          'agent command did not match exactly one binding',
+          route,
+          command.name,
+          { routeCode: err.code, routeDetails: err.details },
+        );
+      }
+      throw err;
+    }
+
+    const target = input.agentTargets.find(
+      (candidate) => candidate.agentName === routed.agentName,
+    );
+    if (!target || target.agentOwner !== route.owner.agentOwner) {
+      throw dispatchError(
+        'command_agent_owner_mismatch',
+        'routed agent owner does not match command owner',
+        route,
+        command.name,
+        {
+          bindingName: routed.bindingName,
+          agentName: routed.agentName,
+          expectedAgentOwner: route.owner.agentOwner,
+          actualAgentOwner: target?.agentOwner ?? null,
+        },
+      );
+    }
+    if (!hasHandler(target.handlerKeys, route.handlerKey)) {
+      throw dispatchError(
+        'command_handler_missing',
+        'agent command handler is missing',
+        route,
+        command.name,
+        { bindingName: routed.bindingName, agentName: routed.agentName },
+      );
+    }
+    return {
+      ownerType: 'agent',
+      commandName: command.name,
+      canonicalId: route.canonicalId,
+      aliasKind: route.aliasKind,
+      handlerKey: route.handlerKey,
+      bindingName: routed.bindingName,
+      agentName: routed.agentName,
+      agentOwner: target.agentOwner,
+    };
+  }
+
+  if (route.owner.type === 'platform') {
+    if (
+      route.owner.platformType !== input.platformType ||
+      !hasHandler(input.platformHandlerKeys, route.handlerKey)
+    ) {
+      throw dispatchError(
+        'command_handler_missing',
+        'platform command handler is missing',
+        route,
+        command.name,
+        { platformType: route.owner.platformType },
+      );
+    }
+    return {
+      ownerType: 'platform',
+      commandName: command.name,
+      canonicalId: route.canonicalId,
+      aliasKind: route.aliasKind,
+      handlerKey: route.handlerKey,
+      platformType: route.owner.platformType,
+    };
+  }
+
+  if (!hasHandler(input.daemonHandlerKeys, route.handlerKey)) {
+    throw dispatchError(
+      'command_handler_missing',
+      'daemon command handler is missing',
+      route,
+      command.name,
+      {},
+    );
+  }
+  return {
+    ownerType: 'daemon',
+    commandName: command.name,
+    canonicalId: route.canonicalId,
+    aliasKind: route.aliasKind,
+    handlerKey: route.handlerKey,
+  };
+}
+
+export function dispatchCommandEvent(
+  input: DispatchCommandEventInput,
+): CommandDispatchDecision | undefined {
+  try {
+    return resolveCommandDispatch(input);
+  } catch (err) {
+    if (err instanceof CommandRegistryError) {
+      const command = input.event.command;
+      input.logger.error(
+        {
+          traceId: input.event.traceId,
+          platformName: input.platformName,
+          scope: command?.registrationScope,
+          commandName: command?.name,
+          ...err.details,
+        },
+        err.code,
+      );
+      return undefined;
+    }
+    throw err;
+  }
+}

--- a/packages/daemon/src/command-registry.ts
+++ b/packages/daemon/src/command-registry.ts
@@ -30,7 +30,10 @@ export type CommandRegistryErrorCode =
   | 'command_name_collision'
   | 'command_name_reserved'
   | 'command_active_map_missing'
-  | 'command_reverse_map_miss';
+  | 'command_reverse_map_miss'
+  | 'command_agent_binding_miss'
+  | 'command_agent_owner_mismatch'
+  | 'command_handler_missing';
 
 export class CommandRegistryError extends Error {
   constructor(

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -18,6 +18,15 @@ export {
   type CommandRegistryErrorCode,
 } from './command-registry.js';
 export {
+  dispatchCommandEvent,
+  resolveCommandDispatch,
+  type CommandDispatchAgentTarget,
+  type CommandDispatchDecision,
+  type CommandDispatchInput,
+  type CommandDispatchLogger,
+  type DispatchCommandEventInput,
+} from './command-dispatch.js';
+export {
   parseDaemonConfig,
   parsePlatformAuthConfig,
   DaemonConfigError,


### PR DESCRIPTION
## Summary

- Add a daemon command dispatch resolver that uses the active reverse map to route command events to agent, platform, or daemon owners.
- Verify agent command binding selection and agent-owner compatibility before returning an agent dispatch target.
- Fail closed with structured logs for binding miss, owner mismatch, handler missing, and reverse-map miss.

## Tests

- Red step: new tests failed because `packages/daemon/src/command-dispatch.ts` did not exist.
- `COREPACK_HOME=/cache/corepack corepack pnpm exec vitest run packages/daemon/src/command-dispatch.test.ts`
- `COREPACK_HOME=/cache/corepack corepack pnpm exec tsc --noEmit --pretty false`
- `COREPACK_HOME=/cache/corepack corepack pnpm test`
- `git diff --check`

## Review

- Independent Claude review saved outside the repo at `/home/node/.goal/slash-command-registry/reviews/p4-dispatch-claude-review.md`.
- Follow-up rereview saved at `/home/node/.goal/slash-command-registry/reviews/p4-dispatch-claude-rereview.md`.
- Review response saved at `/home/node/.goal/slash-command-registry/reviews/p4-dispatch-review-response.md`.
- Initial important findings about route error semantics and missing tests were fixed; rereview found no blocker or important findings.

## Notes

- PR base is `feature/slash-command-registry-main`.
- This is P4 daemon dispatch seam work. Full Engine/Discord slash-command integration remains for P5.