### PR TITLE
feat(command-registry): add package command descriptors

### DIFF
--- a/packages/agent/claudecode/src/command-descriptors.test.ts
+++ b/packages/agent/claudecode/src/command-descriptors.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { claudeCodeCommandDescriptors } from './command-descriptors.js';
+
+describe('claudeCodeCommandDescriptors', () => {
+  it('exposes the platform-neutral /new command descriptor', () => {
+    expect(claudeCodeCommandDescriptors).toEqual([
+      expect.objectContaining({
+        canonicalId: 'agent:claudecode:new',
+        owner: { type: 'agent', agentOwner: 'claudecode' },
+        localName: 'new',
+        handlerKey: 'new',
+        applicability: {
+          requiredCapabilities: ['slash-command-registration'],
+        },
+        legacyNames: [],
+      }),
+    ]);
+  });
+});

--- a/packages/agent/claudecode/src/command-descriptors.ts
+++ b/packages/agent/claudecode/src/command-descriptors.ts
@@ -1,0 +1,16 @@
+import type { CommandDescriptor } from '@agent-nexus/protocol';
+
+export const claudeCodeCommandDescriptors: readonly CommandDescriptor[] = [
+  {
+    canonicalId: 'agent:claudecode:new',
+    owner: { type: 'agent', agentOwner: 'claudecode' },
+    localName: 'new',
+    summary: 'Start a new Claude Code conversation',
+    options: [],
+    handlerKey: 'new',
+    applicability: {
+      requiredCapabilities: ['slash-command-registration'],
+    },
+    legacyNames: [],
+  },
+];

--- a/packages/agent/claudecode/src/index.ts
+++ b/packages/agent/claudecode/src/index.ts
@@ -1,4 +1,7 @@
 export {
+  claudeCodeCommandDescriptors,
+} from './command-descriptors.js';
+export {
   claudeCodePermissionModeError,
   parseClaudeCodeConfig,
   type ClaudeCodeConfig,

--- a/packages/agent/codex/src/command-descriptors.test.ts
+++ b/packages/agent/codex/src/command-descriptors.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { codexCommandDescriptors } from './command-descriptors.js';
+
+describe('codexCommandDescriptors', () => {
+  it('exposes the platform-neutral /new command descriptor', () => {
+    expect(codexCommandDescriptors).toEqual([
+      expect.objectContaining({
+        canonicalId: 'agent:codex:new',
+        owner: { type: 'agent', agentOwner: 'codex' },
+        localName: 'new',
+        handlerKey: 'new',
+        applicability: {
+          requiredCapabilities: ['slash-command-registration'],
+        },
+        legacyNames: [],
+      }),
+    ]);
+  });
+});

--- a/packages/agent/codex/src/command-descriptors.ts
+++ b/packages/agent/codex/src/command-descriptors.ts
@@ -1,0 +1,16 @@
+import type { CommandDescriptor } from '@agent-nexus/protocol';
+
+export const codexCommandDescriptors: readonly CommandDescriptor[] = [
+  {
+    canonicalId: 'agent:codex:new',
+    owner: { type: 'agent', agentOwner: 'codex' },
+    localName: 'new',
+    summary: 'Start a new Codex conversation',
+    options: [],
+    handlerKey: 'new',
+    applicability: {
+      requiredCapabilities: ['slash-command-registration'],
+    },
+    legacyNames: [],
+  },
+];

--- a/packages/agent/codex/src/index.ts
+++ b/packages/agent/codex/src/index.ts
@@ -1,4 +1,7 @@
 export {
+  codexCommandDescriptors,
+} from './command-descriptors.js';
+export {
   CodexConfigError,
   DEFAULT_BIN,
   DEFAULT_SANDBOX,

--- a/packages/platform/discord/src/commands.test.ts
+++ b/packages/platform/discord/src/commands.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
+  plannedCommandToSlashCommandSpec,
   registerSlashCommands,
   type SlashCommandRegistrar,
   type SlashCommandSpec,
 } from './commands.js';
+import { discordReplyModeCommandDescriptor } from './reply-mode.js';
 
 function makeLogger() {
   return {
@@ -132,5 +134,80 @@ describe('registerSlashCommands', () => {
       expect.objectContaining({ command: 'other' }),
       'discord_slash_command_registered',
     );
+  });
+});
+
+describe('plannedCommandToSlashCommandSpec', () => {
+  it('maps stable descriptor commands to Discord slash command payloads', () => {
+    const spec = plannedCommandToSlashCommandSpec({
+      commandName: 'discord-reply-mode',
+      canonicalId: 'platform:discord:reply-mode',
+      aliasKind: 'stable',
+      descriptor: discordReplyModeCommandDescriptor,
+    });
+
+    expect(spec.name).toBe('discord-reply-mode');
+    expect(spec.data).toMatchObject({
+      name: 'discord-reply-mode',
+      description: 'Query or switch the bot reply trigger mode',
+      options: [
+        expect.objectContaining({
+          name: 'mode',
+          required: false,
+          choices: [
+            { name: 'mention', value: 'mention' },
+            { name: 'all', value: 'all' },
+          ],
+        }),
+      ],
+    });
+  });
+
+  it('maps the legacy /reply-mode alias to the same handler descriptor payload', () => {
+    const spec = plannedCommandToSlashCommandSpec({
+      commandName: 'reply-mode',
+      canonicalId: 'platform:discord:reply-mode',
+      aliasKind: 'legacy',
+      descriptor: discordReplyModeCommandDescriptor,
+    });
+
+    expect(spec.name).toBe('reply-mode');
+    expect(spec.data).toMatchObject({
+      name: 'reply-mode',
+      description: 'Query or switch the bot reply trigger mode',
+    });
+  });
+
+  it('omits empty choices so Discord does not reject boolean or empty-choice options', () => {
+    const spec = plannedCommandToSlashCommandSpec({
+      commandName: 'nexus-status',
+      canonicalId: 'daemon:status',
+      aliasKind: 'stable',
+      descriptor: {
+        canonicalId: 'daemon:status',
+        owner: { type: 'daemon' },
+        localName: 'status',
+        summary: 'Show daemon status',
+        options: [
+          {
+            name: 'verbose',
+            type: 'boolean',
+            required: false,
+            description: 'Show verbose status',
+            choices: [],
+          },
+        ],
+        handlerKey: 'status',
+        applicability: {
+          platformTypes: ['discord'],
+          requiredCapabilities: ['slash-command-registration'],
+        },
+        legacyNames: [],
+      },
+    });
+
+    expect(spec.data).toMatchObject({
+      options: [expect.not.objectContaining({ choices: expect.any(Array) })],
+    });
   });
 });

--- a/packages/platform/discord/src/commands.ts
+++ b/packages/platform/discord/src/commands.ts
@@ -1,5 +1,9 @@
 import type { Logger } from '@agent-nexus/daemon';
-import type { ApplicationCommandDataResolvable } from 'discord.js';
+import type { PlannedCommand } from '@agent-nexus/protocol';
+import {
+  ApplicationCommandOptionType,
+  type ApplicationCommandDataResolvable,
+} from 'discord.js';
 
 /**
  * 一条 slash command 注册描述。`name` 仅用于结构化日志（注册成功/失败时识别）；
@@ -8,6 +12,37 @@ import type { ApplicationCommandDataResolvable } from 'discord.js';
 export interface SlashCommandSpec {
   name: string;
   data: ApplicationCommandDataResolvable;
+}
+
+function optionType(type: PlannedCommand['descriptor']['options'][number]['type']) {
+  if (type === 'string') return ApplicationCommandOptionType.String;
+  if (type === 'integer') return ApplicationCommandOptionType.Integer;
+  if (type === 'number') return ApplicationCommandOptionType.Number;
+  return ApplicationCommandOptionType.Boolean;
+}
+
+export function plannedCommandToSlashCommandSpec(
+  command: PlannedCommand,
+): SlashCommandSpec {
+  return {
+    name: command.commandName,
+    data: {
+      name: command.commandName,
+      description: command.descriptor.summary,
+      options: command.descriptor.options.map((option) => {
+        const mapped = {
+          type: optionType(option.type),
+          name: option.name,
+          description: option.description,
+          required: option.required,
+        };
+        if (option.type === 'boolean' || option.choices.length === 0) {
+          return mapped;
+        }
+        return { ...mapped, choices: option.choices };
+      }),
+    } as ApplicationCommandDataResolvable,
+  };
 }
 
 /**

--- a/packages/platform/discord/src/index.ts
+++ b/packages/platform/discord/src/index.ts
@@ -40,10 +40,13 @@ import {
 } from './state.js';
 import {
   assertBotUserIdMatch,
+  discordReplyModeCommandDescriptor,
   handleReplyModeInteraction,
-  replyModeCommandDefinition,
 } from './reply-mode.js';
-import { registerSlashCommands } from './commands.js';
+import {
+  plannedCommandToSlashCommandSpec,
+  registerSlashCommands,
+} from './commands.js';
 
 export interface DiscordPlatformOptions {
   token: string;
@@ -331,7 +334,20 @@ export function createDiscordPlatform(opts: DiscordPlatformOptions): PlatformAda
         });
         void registerSlashCommands(
           client.application?.commands,
-          [{ name: 'reply-mode', data: replyModeCommandDefinition() }],
+          [
+            plannedCommandToSlashCommandSpec({
+              commandName: 'discord-reply-mode',
+              canonicalId: discordReplyModeCommandDescriptor.canonicalId,
+              aliasKind: 'stable',
+              descriptor: discordReplyModeCommandDescriptor,
+            }),
+            plannedCommandToSlashCommandSpec({
+              commandName: 'reply-mode',
+              canonicalId: discordReplyModeCommandDescriptor.canonicalId,
+              aliasKind: 'legacy',
+              descriptor: discordReplyModeCommandDescriptor,
+            }),
+          ],
           logger,
           testGuildId,
         );
@@ -339,7 +355,12 @@ export function createDiscordPlatform(opts: DiscordPlatformOptions): PlatformAda
 
       client.on('interactionCreate', async (interaction: Interaction) => {
         if (!interaction.isChatInputCommand()) return;
-        if (interaction.commandName !== 'reply-mode') return;
+        if (
+          interaction.commandName !== 'reply-mode' &&
+          interaction.commandName !== 'discord-reply-mode'
+        ) {
+          return;
+        }
         try {
           await handleReplyModeInteraction(interaction, {
             allowedUserIds,

--- a/packages/platform/discord/src/reply-mode.test.ts
+++ b/packages/platform/discord/src/reply-mode.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   assertBotUserIdMatch,
+  discordReplyModeCommandDescriptor,
   handleReplyModeInteraction,
   replyModeCommandDefinition,
   type ReplyModeContext,
@@ -38,6 +39,23 @@ function makeInteraction(overrides: {
 }
 
 describe('replyModeCommandDefinition', () => {
+  it('暴露 platform:discord:reply-mode descriptor，含 stable command 所需字段与 legacy alias', () => {
+    expect(discordReplyModeCommandDescriptor).toMatchObject({
+      canonicalId: 'platform:discord:reply-mode',
+      owner: { type: 'platform', platformType: 'discord' },
+      localName: 'reply-mode',
+      handlerKey: 'reply-mode',
+      applicability: {
+        platformTypes: ['discord'],
+        requiredCapabilities: [
+          'slash-command-registration',
+          'ephemeral-response',
+        ],
+      },
+      legacyNames: [{ name: 'reply-mode', reason: 'historical-compatibility' }],
+    });
+  });
+
   it('暴露 name=reply-mode + 一个可选的 mode 选项（choices: mention/all）', () => {
     const def = replyModeCommandDefinition();
     expect(def.name).toBe('reply-mode');
@@ -47,6 +65,12 @@ describe('replyModeCommandDefinition', () => {
     expect(opt.required).toBe(false);
     const choiceValues = opt.choices?.map((c) => c.value).sort();
     expect(choiceValues).toEqual(['all', 'mention']);
+  });
+
+  it('允许生成 stable name=discord-reply-mode 的注册 payload', () => {
+    const def = replyModeCommandDefinition('discord-reply-mode');
+    expect(def.name).toBe('discord-reply-mode');
+    expect(def.options).toHaveLength(1);
   });
 });
 

--- a/packages/platform/discord/src/reply-mode.ts
+++ b/packages/platform/discord/src/reply-mode.ts
@@ -1,6 +1,7 @@
 import type { Logger } from '@agent-nexus/daemon';
-import { ApplicationCommandOptionType } from 'discord.js';
+import type { CommandDescriptor } from '@agent-nexus/protocol';
 import type { ReplyMode } from './state.js';
+import { plannedCommandToSlashCommandSpec } from './commands.js';
 
 export interface ReplyModeContext {
   allowedUserIds: readonly string[];
@@ -21,25 +22,46 @@ export interface ReplyModeInteractionLike {
 }
 
 /**
+ * Platform-neutral command descriptor. Discord payload mapping lives in commands.ts.
+ */
+export const discordReplyModeCommandDescriptor: CommandDescriptor = {
+  canonicalId: 'platform:discord:reply-mode',
+  owner: { type: 'platform', platformType: 'discord' },
+  localName: 'reply-mode',
+  summary: 'Query or switch the bot reply trigger mode',
+  options: [
+    {
+      name: 'mode',
+      type: 'string',
+      required: false,
+      description: 'New mode (omit to query current)',
+      choices: [
+        { name: 'mention', value: 'mention' },
+        { name: 'all', value: 'all' },
+      ],
+    },
+  ],
+  handlerKey: 'reply-mode',
+  applicability: {
+    platformTypes: ['discord'],
+    requiredCapabilities: [
+      'slash-command-registration',
+      'ephemeral-response',
+    ],
+  },
+  legacyNames: [{ name: 'reply-mode', reason: 'historical-compatibility' }],
+};
+
+/**
  * Slash command 注册描述。formatted as ApplicationCommandData (discord.js 接受 plain JSON)。
  */
-export function replyModeCommandDefinition() {
-  return {
-    name: 'reply-mode',
-    description: 'Query or switch the bot reply trigger mode',
-    options: [
-      {
-        type: ApplicationCommandOptionType.String,
-        name: 'mode',
-        description: 'New mode (omit to query current)',
-        required: false,
-        choices: [
-          { name: 'mention', value: 'mention' },
-          { name: 'all', value: 'all' },
-        ],
-      },
-    ],
-  } as const;
+export function replyModeCommandDefinition(name = 'reply-mode') {
+  return plannedCommandToSlashCommandSpec({
+    commandName: name,
+    canonicalId: discordReplyModeCommandDescriptor.canonicalId,
+    aliasKind: name === 'reply-mode' ? 'legacy' : 'stable',
+    descriptor: discordReplyModeCommandDescriptor,
+  }).data;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Add platform-neutral `/new` command descriptors for Codex and Claude Code agent packages.
- Add the Discord `platform:discord:reply-mode` command descriptor.
- Add `PlannedCommand` to Discord slash command payload mapping.
- Register both stable `/discord-reply-mode` and legacy `/reply-mode` through the descriptor mapper and route both to the existing reply-mode handler.

## Tests

- Red step: descriptor/mapper tests failed because descriptor modules and mapper did not exist, and `replyModeCommandDefinition` did not accept the stable name.
- `COREPACK_HOME=/cache/corepack corepack pnpm exec vitest run packages/agent/codex/src/command-descriptors.test.ts packages/agent/claudecode/src/command-descriptors.test.ts packages/platform/discord/src/reply-mode.test.ts packages/platform/discord/src/commands.test.ts`
- `COREPACK_HOME=/cache/corepack corepack pnpm exec tsc --noEmit --pretty false`
- `COREPACK_HOME=/cache/corepack corepack pnpm test`
- `git diff --check`

## Review

- Independent Claude review saved outside the repo at `/home/node/.goal/slash-command-registry/reviews/p5-descriptors-claude-review.md`.
- Follow-up rereview saved at `/home/node/.goal/slash-command-registry/reviews/p5-descriptors-claude-rereview.md`.
- Review response saved at `/home/node/.goal/slash-command-registry/reviews/p5-descriptors-review-response.md`.
- Initial important finding about reply-mode dual truth sources was fixed; rereview found no blocker or important findings.

## Notes

- PR base is `feature/slash-command-registry-main`.
- This is P5 descriptors/payload mapping slice. Full daemon-planned bulk registration and broader routing integration remain for the next P5 slice.