### PR TITLE
feat(command-registry): add discord bulk registration port

### DIFF
--- a/packages/platform/discord/src/commands.test.ts
+++ b/packages/platform/discord/src/commands.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
+  createDiscordCommandRegistrationPort,
   plannedCommandToSlashCommandSpec,
   registerSlashCommands,
   type SlashCommandRegistrar,
   type SlashCommandSpec,
 } from './commands.js';
 import { discordReplyModeCommandDescriptor } from './reply-mode.js';
+import type { CommandRegistrationPlan } from '@agent-nexus/protocol';
 
 function makeLogger() {
   return {
@@ -49,56 +51,60 @@ describe('registerSlashCommands', () => {
     );
   });
 
-  it('空 specs → 不调 create，不报错', async () => {
+  it('空 specs → bulk set 空数组，清理 registry 管理的远端命令', async () => {
     const logger = makeLogger();
-    const create = vi.fn(async () => ({}));
-    const registrar: SlashCommandRegistrar = { create };
+    const set = vi.fn(async () => ({}));
+    const registrar: SlashCommandRegistrar = { set };
     await registerSlashCommands(registrar, [], logger);
-    expect(create).not.toHaveBeenCalled();
+    expect(set).toHaveBeenCalledOnce();
+    expect(set).toHaveBeenCalledWith([], undefined);
     expect(logger.error).not.toHaveBeenCalled();
   });
 
-  it('单条成功（不传 guildId）→ create(data, undefined) + scope=global', async () => {
+  it('单条成功（不传 guildId）→ set([data], undefined) + scope=global', async () => {
     const logger = makeLogger();
-    const create = vi.fn(async () => ({}));
-    await registerSlashCommands({ create }, [FAKE_SPEC], logger);
-    expect(create).toHaveBeenCalledOnce();
-    expect(create).toHaveBeenCalledWith(FAKE_SPEC.data, undefined);
+    const set = vi.fn(async () => ({}));
+    await registerSlashCommands({ set }, [FAKE_SPEC], logger);
+    expect(set).toHaveBeenCalledOnce();
+    expect(set).toHaveBeenCalledWith([FAKE_SPEC.data], undefined);
     expect(logger.info).toHaveBeenCalledWith(
       expect.objectContaining({
-        command: 'reply-mode',
+        commands: ['reply-mode'],
+        commandCount: 1,
         scope: 'global',
         guildId: null,
       }),
-      'discord_slash_command_registered',
+      'discord_slash_commands_registered',
     );
   });
 
-  it('传 guildId → create(data, guildId) + scope=guild + 日志含 guildId', async () => {
+  it('传 guildId → set([data], guildId) + scope=guild + 日志含 guildId', async () => {
     const logger = makeLogger();
-    const create = vi.fn(async () => ({}));
-    await registerSlashCommands({ create }, [FAKE_SPEC], logger, 'GUILD123');
-    expect(create).toHaveBeenCalledOnce();
-    expect(create).toHaveBeenCalledWith(FAKE_SPEC.data, 'GUILD123');
+    const set = vi.fn(async () => ({}));
+    await registerSlashCommands({ set }, [FAKE_SPEC], logger, 'GUILD123');
+    expect(set).toHaveBeenCalledOnce();
+    expect(set).toHaveBeenCalledWith([FAKE_SPEC.data], 'GUILD123');
     expect(logger.info).toHaveBeenCalledWith(
       expect.objectContaining({
-        command: 'reply-mode',
+        commands: ['reply-mode'],
+        commandCount: 1,
         scope: 'guild',
         guildId: 'GUILD123',
       }),
-      'discord_slash_command_registered',
+      'discord_slash_commands_registered',
     );
   });
 
-  it('传 guildId 但 create reject（如 bot 不在该 guild）→ error 日志含 scope/guildId', async () => {
+  it('传 guildId 但 bulk set reject（如 bot 不在该 guild）→ error 日志含 scope/guildId', async () => {
     const logger = makeLogger();
-    const create = vi.fn(async () => {
+    const set = vi.fn(async () => {
       throw new Error('Missing Access');
     });
-    await registerSlashCommands({ create }, [FAKE_SPEC], logger, 'GUILD_NOT_JOINED');
+    await registerSlashCommands({ set }, [FAKE_SPEC], logger, 'GUILD_NOT_JOINED');
     expect(logger.error).toHaveBeenCalledWith(
       expect.objectContaining({
-        command: 'reply-mode',
+        commands: ['reply-mode'],
+        commandCount: 1,
         scope: 'guild',
         guildId: 'GUILD_NOT_JOINED',
       }),
@@ -106,34 +112,146 @@ describe('registerSlashCommands', () => {
     );
   });
 
-  it('多条全部成功 → 顺序调用、各打 info', async () => {
+  it('多条全部成功 → 单次 bulk set，打一条批量成功日志', async () => {
     const logger = makeLogger();
-    const create = vi.fn(async () => ({}));
-    await registerSlashCommands({ create }, [FAKE_SPEC, ANOTHER_SPEC], logger);
-    expect(create).toHaveBeenCalledTimes(2);
-    expect(logger.info).toHaveBeenCalledTimes(2);
+    const set = vi.fn(async () => ({}));
+    await registerSlashCommands({ set }, [FAKE_SPEC, ANOTHER_SPEC], logger);
+    expect(set).toHaveBeenCalledOnce();
+    expect(set).toHaveBeenCalledWith(
+      [FAKE_SPEC.data, ANOTHER_SPEC.data],
+      undefined,
+    );
+    expect(logger.info).toHaveBeenCalledTimes(1);
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        commands: ['reply-mode', 'other'],
+        commandCount: 2,
+      }),
+      'discord_slash_commands_registered',
+    );
   });
 
-  it('某条 create reject → 记 error 但继续后续，整体不抛', async () => {
+  it('bulk set reject → 记 error、整体不抛且不记录原始错误内容', async () => {
     const logger = makeLogger();
-    const create = vi.fn(async (data: unknown) => {
-      if ((data as { name: string }).name === 'reply-mode') {
-        throw new Error('discord 5xx');
-      }
-      return {};
+    const set = vi.fn(async () => {
+      throw new Error('SECRET_PAYLOAD discord 5xx');
     });
     await expect(
-      registerSlashCommands({ create }, [FAKE_SPEC, ANOTHER_SPEC], logger),
+      registerSlashCommands({ set }, [FAKE_SPEC, ANOTHER_SPEC], logger),
     ).resolves.toBeUndefined();
-    expect(create).toHaveBeenCalledTimes(2);
+    expect(set).toHaveBeenCalledOnce();
     expect(logger.error).toHaveBeenCalledWith(
-      expect.objectContaining({ command: 'reply-mode' }),
+      expect.objectContaining({
+        commands: ['reply-mode', 'other'],
+        commandCount: 2,
+      }),
       'discord_slash_command_register_failed',
     );
-    expect(logger.info).toHaveBeenCalledWith(
-      expect.objectContaining({ command: 'other' }),
-      'discord_slash_command_registered',
+    expect(JSON.stringify(logger.error.mock.calls[0]![0])).not.toContain(
+      'SECRET_PAYLOAD',
     );
+  });
+});
+
+describe('createDiscordCommandRegistrationPort', () => {
+  it('maps a daemon registration plan to one Discord bulk replacement and returns applied generation', async () => {
+    const logger = makeLogger();
+    const set = vi.fn(async () => ({}));
+    const plan: CommandRegistrationPlan = {
+      scope: {
+        platformName: 'discord-main',
+        platformType: 'discord',
+        nativeScope: { kind: 'guild', guildId: 'GUILD123' },
+      },
+      commands: [
+        {
+          commandName: 'discord-reply-mode',
+          canonicalId: 'platform:discord:reply-mode',
+          aliasKind: 'stable',
+          descriptor: discordReplyModeCommandDescriptor,
+        },
+        {
+          commandName: 'reply-mode',
+          canonicalId: 'platform:discord:reply-mode',
+          aliasKind: 'legacy',
+          descriptor: discordReplyModeCommandDescriptor,
+        },
+      ],
+      reverseMap: { entries: {} },
+      generation: 'generation-1',
+    };
+
+    const port = createDiscordCommandRegistrationPort({ set }, logger);
+    const result = await port.applyCommandPlan(plan);
+
+    expect(result).toEqual({ status: 'applied', generation: 'generation-1' });
+    expect(set).toHaveBeenCalledOnce();
+    expect(set.mock.calls[0]![0]).toMatchObject([
+      { name: 'discord-reply-mode' },
+      { name: 'reply-mode' },
+    ]);
+    expect(set.mock.calls[0]![1]).toBe('GUILD123');
+  });
+
+  it('returns failed result when Discord bulk replacement fails', async () => {
+    const logger = makeLogger();
+    const set = vi.fn(async () => {
+      throw new Error('SECRET_PAYLOAD missing access');
+    });
+    const plan: CommandRegistrationPlan = {
+      scope: {
+        platformName: 'discord-main',
+        platformType: 'discord',
+        nativeScope: { kind: 'global' },
+      },
+      commands: [],
+      reverseMap: { entries: {} },
+      generation: 'generation-2',
+    };
+
+    const port = createDiscordCommandRegistrationPort({ set }, logger);
+    const result = await port.applyCommandPlan(plan);
+
+    expect(result).toMatchObject({
+      status: 'failed',
+      error: {
+        code: 'command_registration_failed',
+        message: 'discord slash command bulk registration failed',
+      },
+    });
+    if (result.status === 'failed') {
+      expect(result.error).not.toHaveProperty('cause');
+    }
+    expect(JSON.stringify(logger.error.mock.calls[0]![0])).not.toContain(
+      'SECRET_PAYLOAD',
+    );
+  });
+
+  it('rejects non-discord scopes without calling Discord bulk replacement', async () => {
+    const logger = makeLogger();
+    const set = vi.fn(async () => ({}));
+    const plan: CommandRegistrationPlan = {
+      scope: {
+        platformName: 'chat-main',
+        platformType: 'telegram',
+        nativeScope: { kind: 'global' },
+      },
+      commands: [],
+      reverseMap: { entries: {} },
+      generation: 'generation-3',
+    };
+
+    const port = createDiscordCommandRegistrationPort({ set }, logger);
+    const result = await port.applyCommandPlan(plan);
+
+    expect(result).toMatchObject({
+      status: 'failed',
+      error: {
+        code: 'command_registration_failed',
+        message: 'discord command registrar received a non-discord scope',
+      },
+    });
+    expect(set).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/platform/discord/src/commands.ts
+++ b/packages/platform/discord/src/commands.ts
@@ -1,5 +1,10 @@
 import type { Logger } from '@agent-nexus/daemon';
-import type { PlannedCommand } from '@agent-nexus/protocol';
+import type {
+  CommandRegistrationPlan,
+  CommandRegistrationPort,
+  CommandRegistrationResult,
+  PlannedCommand,
+} from '@agent-nexus/protocol';
 import {
   ApplicationCommandOptionType,
   type ApplicationCommandDataResolvable,
@@ -48,23 +53,82 @@ export function plannedCommandToSlashCommandSpec(
 /**
  * `client.application?.commands` 的最小子集，便于测试 mock。
  *
- * 用 `create`（按 name upsert）而不是 `set`（用整数组覆盖全部全局命令）——
- * 见 spec/platform-adapter.md §"Discord Trigger 策略 / 切换面板"，
- * 避免误删同一 application 下手动注册或未来新增的其它 slash command。
+ * 用 `set` 提交 registry 管理的期望全集；见
+ * docs/dev/spec/command-registry.md §Remote Registration Activation。
  *
  * `guildId` 可选——传则注册到指定 guild（瞬时生效，dev 用），不传则注册为
  * global command（生产用，缓存延迟最长 1 小时）。见 spec §"注册作用域"。
  */
 export interface SlashCommandRegistrar {
-  create(
-    data: ApplicationCommandDataResolvable,
+  set(
+    data: readonly ApplicationCommandDataResolvable[],
     guildId?: string,
   ): Promise<unknown>;
 }
 
+interface SlashCommandSubmitResult {
+  ok: boolean;
+  message?: string;
+}
+
+function errorName(err: unknown): string {
+  return err instanceof Error ? err.name : typeof err;
+}
+
+function commandNames(specs: readonly SlashCommandSpec[]): string[] {
+  return specs.map((spec) => spec.name);
+}
+
+async function submitSlashCommandSet(
+  registrar: SlashCommandRegistrar | null | undefined,
+  specs: readonly SlashCommandSpec[],
+  logger: Logger,
+  guildId?: string,
+): Promise<SlashCommandSubmitResult> {
+  const scope = guildId ? 'guild' : 'global';
+  const logFields = {
+    commands: commandNames(specs),
+    commandCount: specs.length,
+    scope,
+    guildId: guildId ?? null,
+  };
+
+  if (!registrar) {
+    logger.error(
+      logFields,
+      'discord_slash_command_register_skipped_no_application',
+    );
+    return {
+      ok: false,
+      message: 'discord application commands are not available',
+    };
+  }
+
+  try {
+    await registrar.set(
+      specs.map((spec) => spec.data),
+      guildId,
+    );
+    logger.info(logFields, 'discord_slash_commands_registered');
+    return { ok: true };
+  } catch (err) {
+    logger.error(
+      {
+        ...logFields,
+        error: { name: errorName(err) },
+      },
+      'discord_slash_command_register_failed',
+    );
+    return {
+      ok: false,
+      message: 'discord slash command bulk registration failed',
+    };
+  }
+}
+
 /**
- * 注册一组 slash command。逐条 `create` upsert：
- * - 单条失败只打 error 日志，不抛、不影响其它条目
+ * 注册一组 slash command。一次性 `set` 为期望全集：
+ * - bulk set 失败只打 error 日志，不抛
  * - registrar 为 null/undefined（client.application 还没就绪）→ 整体 skip + error 日志
  * - `guildId` 非空 → 注册到指定 guild（dev / 测试，瞬时生效）；空/缺省 → global
  *
@@ -76,23 +140,50 @@ export async function registerSlashCommands(
   logger: Logger,
   guildId?: string,
 ): Promise<void> {
-  if (!registrar) {
-    logger.error({}, 'discord_slash_command_register_skipped_no_application');
-    return;
-  }
-  const scope = guildId ? 'guild' : 'global';
-  for (const spec of specs) {
-    try {
-      await registrar.create(spec.data, guildId);
-      logger.info(
-        { command: spec.name, scope, guildId: guildId ?? null },
-        'discord_slash_command_registered',
+  await submitSlashCommandSet(registrar, specs, logger, guildId);
+}
+
+function guildIdForPlan(plan: CommandRegistrationPlan): string | undefined {
+  return plan.scope.nativeScope.kind === 'guild'
+    ? plan.scope.nativeScope.guildId
+    : undefined;
+}
+
+export function createDiscordCommandRegistrationPort(
+  registrar: SlashCommandRegistrar | null | undefined,
+  logger: Logger,
+): CommandRegistrationPort {
+  return {
+    async applyCommandPlan(
+      plan: CommandRegistrationPlan,
+    ): Promise<CommandRegistrationResult> {
+      if (plan.scope.platformType !== 'discord') {
+        return {
+          status: 'failed',
+          error: {
+            code: 'command_registration_failed',
+            message: 'discord command registrar received a non-discord scope',
+          },
+        };
+      }
+
+      const result = await submitSlashCommandSet(
+        registrar,
+        plan.commands.map(plannedCommandToSlashCommandSpec),
+        logger,
+        guildIdForPlan(plan),
       );
-    } catch (err) {
-      logger.error(
-        { err, command: spec.name, scope, guildId: guildId ?? null },
-        'discord_slash_command_register_failed',
-      );
-    }
-  }
+      if (!result.ok) {
+        return {
+          status: 'failed',
+          error: {
+            code: 'command_registration_failed',
+            message:
+              result.message ?? 'discord slash command bulk registration failed',
+          },
+        };
+      }
+      return { status: 'applied', generation: plan.generation };
+    },
+  };
 }

--- a/packages/platform/discord/src/index.ts
+++ b/packages/platform/discord/src/index.ts
@@ -8,6 +8,11 @@ export {
   type DiscordPlatformConfig,
   type DiscordPublicChannelMode,
 } from './config.js';
+export {
+  createDiscordCommandRegistrationPort,
+  plannedCommandToSlashCommandSpec,
+} from './commands.js';
+export { discordReplyModeCommandDescriptor } from './reply-mode.js';
 
 // TODO MVP 跳过：
 // - DM 消息（intents 没开 DirectMessages）


### PR DESCRIPTION
## Summary
- replace Discord slash command registration with one bulk `set` call for the managed command set
- add a Discord `CommandRegistrationPort` that maps daemon registration plans to slash payloads and returns applied/failed results
- export the registry-facing Discord descriptor/mapper/port APIs from the package root

## Verification
- `COREPACK_HOME=/cache/corepack corepack pnpm exec vitest run packages/platform/discord/src/commands.test.ts packages/platform/discord/src/reply-mode.test.ts`
- `COREPACK_HOME=/cache/corepack corepack pnpm exec tsc --noEmit --pretty false`
- `COREPACK_HOME=/cache/corepack corepack pnpm test`
- `git diff --check`

## Review
- Independent Claude review: `/home/node/.goal/slash-command-registry/reviews/p5-bulk-registration-claude-review.md`
- Rereview after fixes: `/home/node/.goal/slash-command-registry/reviews/p5-bulk-registration-claude-rereview.md`