### PR TITLE
feat(command-registry): build cli registration plans

### DIFF
--- a/packages/cli/src/command-registry.test.ts
+++ b/packages/cli/src/command-registry.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from 'vitest';
+import type { CapabilitySet } from '@agent-nexus/protocol';
+import { ConfigError, type AgentConfig, type AgentNexusConfig } from './config.js';
+import { buildCliCommandRegistrationPlan } from './command-registry.js';
+
+const capabilities: CapabilitySet = {
+  maxTextLength: 2000,
+  supportsEdit: false,
+  supportsDelete: false,
+  supportsReactions: false,
+  supportsEmbeds: false,
+  supportsButtons: false,
+  supportsThreads: false,
+  supportsEphemeral: true,
+  supportsAttachments: false,
+  maxAttachmentsPerMessage: 0,
+  supportsTypingIndicator: false,
+  supportsSlashCommands: true,
+};
+
+const codexAgent: AgentConfig = {
+  name: 'codex-dev',
+  backend: 'codex',
+  codex: {
+    bin: 'codex',
+    workingDir: '/codex',
+    sandbox: 'read-only',
+    addDirs: [],
+    loadUserConfig: false,
+    loadRules: false,
+  },
+};
+
+const claudeAgent: AgentConfig = {
+  name: 'claude-prod',
+  backend: 'claudecode',
+  claudeCode: {
+    bin: 'claude',
+    workingDir: '/claude',
+    allowedTools: ['Read'],
+    permissionLevel: 'default',
+  },
+};
+
+function baseConfig(overrides: Partial<AgentNexusConfig> = {}): AgentNexusConfig {
+  return {
+    platforms: [
+      {
+        name: 'discord-main',
+        type: 'discord',
+        botUserId: 'bot',
+        tokenRef: 'DISCORD_BOT_TOKEN',
+        statePath: '/state/discord-main.json',
+        publicChannelMode: 'thread',
+        auth: {
+          allowlist: {
+            userIds: ['U1'],
+            roleIds: [],
+            allowedGuildIds: ['G1'],
+            allowedChannelIds: [],
+            allowDM: true,
+            requireMentionOrSlash: true,
+          },
+        },
+      },
+    ],
+    agents: [codexAgent],
+    bindings: [
+      {
+        name: 'discord-main-codex',
+        platformName: 'discord-main',
+        agentName: 'codex-dev',
+        match: { discord: { channelIds: ['C1'] } },
+      },
+    ],
+    ui: { toolMessages: 'append' },
+    log: { level: 'info' },
+    ...overrides,
+  };
+}
+
+function commandKeys(plan: ReturnType<typeof buildCliCommandRegistrationPlan>): string[] {
+  return plan.commands.map(
+    (command) =>
+      `${command.commandName}:${command.canonicalId}:${command.aliasKind}`,
+  );
+}
+
+describe('buildCliCommandRegistrationPlan', () => {
+  it('builds a Discord plan with platform commands and a single-agent alias for the bound Codex owner', () => {
+    const plan = buildCliCommandRegistrationPlan({
+      config: baseConfig(),
+      platformName: 'discord-main',
+      capabilities,
+      generation: 'g1',
+    });
+
+    expect(plan.scope).toEqual({
+      platformName: 'discord-main',
+      platformType: 'discord',
+      nativeScope: { kind: 'global' },
+    });
+    expect(commandKeys(plan)).toEqual([
+      'discord-reply-mode:platform:discord:reply-mode:stable',
+      'codex-new:agent:codex:new:stable',
+      'reply-mode:platform:discord:reply-mode:legacy',
+      'new:agent:codex:new:single-agent-alias',
+    ]);
+    expect(plan.reverseMap.entries['new']).toMatchObject({
+      canonicalId: 'agent:codex:new',
+      aliasKind: 'single-agent-alias',
+    });
+  });
+
+  it('removes the bare /new alias when one platform scope exposes multiple agent owners', () => {
+    const plan = buildCliCommandRegistrationPlan({
+      config: baseConfig({
+        agents: [codexAgent, claudeAgent],
+        bindings: [
+          {
+            name: 'discord-main-codex',
+            platformName: 'discord-main',
+            agentName: 'codex-dev',
+            match: { discord: { channelIds: ['C1'] } },
+          },
+          {
+            name: 'discord-main-claude',
+            platformName: 'discord-main',
+            agentName: 'claude-prod',
+            match: { discord: { channelIds: ['C2'] } },
+          },
+        ],
+      }),
+      platformName: 'discord-main',
+      capabilities,
+      generation: 'g2',
+    });
+
+    expect(commandKeys(plan)).toEqual([
+      'discord-reply-mode:platform:discord:reply-mode:stable',
+      'codex-new:agent:codex:new:stable',
+      'claudecode-new:agent:claudecode:new:stable',
+      'reply-mode:platform:discord:reply-mode:legacy',
+    ]);
+    expect(plan.reverseMap.entries).not.toHaveProperty('new');
+  });
+
+  it('deduplicates descriptors when multiple agent instances use the same backend owner', () => {
+    const secondCodexAgent: AgentConfig = {
+      ...codexAgent,
+      name: 'codex-prod',
+    };
+
+    const plan = buildCliCommandRegistrationPlan({
+      config: baseConfig({
+        agents: [codexAgent, secondCodexAgent],
+        bindings: [
+          {
+            name: 'discord-main-codex-dev',
+            platformName: 'discord-main',
+            agentName: 'codex-dev',
+            match: { discord: { channelIds: ['C1'] } },
+          },
+          {
+            name: 'discord-main-codex-prod',
+            platformName: 'discord-main',
+            agentName: 'codex-prod',
+            match: { discord: { channelIds: ['C2'] } },
+          },
+        ],
+      }),
+      platformName: 'discord-main',
+      capabilities,
+      generation: 'g2b',
+    });
+
+    expect(
+      plan.commands.filter((command) => command.canonicalId === 'agent:codex:new'),
+    ).toHaveLength(2);
+    expect(plan.reverseMap.entries['new']).toMatchObject({
+      canonicalId: 'agent:codex:new',
+      aliasKind: 'single-agent-alias',
+    });
+  });
+
+  it('uses testGuildId as the native registration scope', () => {
+    const plan = buildCliCommandRegistrationPlan({
+      config: baseConfig({
+        platforms: [
+          {
+            ...baseConfig().platforms[0]!,
+            testGuildId: 'GUILD123',
+          },
+        ],
+      }),
+      platformName: 'discord-main',
+      capabilities,
+      generation: 'g3',
+    });
+
+    expect(plan.scope.nativeScope).toEqual({
+      kind: 'guild',
+      guildId: 'GUILD123',
+    });
+  });
+
+  it('fails clearly when the requested platform is absent', () => {
+    expect(() =>
+      buildCliCommandRegistrationPlan({
+        config: baseConfig(),
+        platformName: 'discord-missing',
+        capabilities,
+        generation: 'g4',
+      }),
+    ).toThrow(ConfigError);
+  });
+});

--- a/packages/cli/src/command-registry.ts
+++ b/packages/cli/src/command-registry.ts
@@ -1,0 +1,101 @@
+import { claudeCodeCommandDescriptors } from '@agent-nexus/agent-claudecode';
+import { codexCommandDescriptors } from '@agent-nexus/agent-codex';
+import {
+  discordReplyModeCommandDescriptor,
+} from '@agent-nexus/platform-discord';
+import {
+  buildCommandRegistrationPlan,
+  DEFAULT_COMMAND_NAME_POLICY,
+} from '@agent-nexus/daemon';
+import type {
+  CapabilitySet,
+  CommandDescriptor,
+  CommandRegistrationPlan,
+  CommandRegistrationScope,
+} from '@agent-nexus/protocol';
+import {
+  ConfigError,
+  type AgentConfig,
+  type AgentNexusConfig,
+  type PlatformConfig,
+} from './config.js';
+
+export interface BuildCliCommandRegistrationPlanInput {
+  config: AgentNexusConfig;
+  platformName: string;
+  capabilities: CapabilitySet;
+  generation: string;
+}
+
+function commandScopeForPlatform(
+  platform: PlatformConfig,
+): CommandRegistrationScope {
+  return {
+    platformName: platform.name,
+    platformType: platform.type,
+    nativeScope: platform.testGuildId
+      ? { kind: 'guild', guildId: platform.testGuildId }
+      : { kind: 'global' },
+  };
+}
+
+function descriptorsForAgent(agent: AgentConfig): readonly CommandDescriptor[] {
+  if (agent.backend === 'codex') return codexCommandDescriptors;
+  return claudeCodeCommandDescriptors;
+}
+
+function enabledCommandDescriptors(
+  config: AgentNexusConfig,
+): CommandDescriptor[] {
+  const descriptors: CommandDescriptor[] = [discordReplyModeCommandDescriptor];
+  const seenAgentOwners = new Set<AgentConfig['backend']>();
+  for (const agent of config.agents) {
+    if (seenAgentOwners.has(agent.backend)) continue;
+    seenAgentOwners.add(agent.backend);
+    descriptors.push(...descriptorsForAgent(agent));
+  }
+  return descriptors;
+}
+
+function agentByName(config: AgentNexusConfig): Map<string, AgentConfig> {
+  return new Map(config.agents.map((agent) => [agent.name, agent]));
+}
+
+function agentOwnersForPlatform(
+  config: AgentNexusConfig,
+  platformName: string,
+): string[] {
+  const agents = agentByName(config);
+  const owners = new Set<string>();
+  for (const binding of config.bindings) {
+    if (binding.platformName !== platformName) continue;
+    const agent = agents.get(binding.agentName);
+    if (!agent) {
+      throw new ConfigError(
+        `binding "${binding.name}" 引用了不存在的 agent "${binding.agentName}"`,
+      );
+    }
+    owners.add(agent.backend);
+  }
+  return [...owners];
+}
+
+export function buildCliCommandRegistrationPlan(
+  input: BuildCliCommandRegistrationPlanInput,
+): CommandRegistrationPlan {
+  const platform = input.config.platforms.find(
+    (candidate) => candidate.name === input.platformName,
+  );
+  if (!platform) {
+    throw new ConfigError(`platform "${input.platformName}" 不存在`);
+  }
+
+  return buildCommandRegistrationPlan({
+    descriptors: enabledCommandDescriptors(input.config),
+    scope: commandScopeForPlatform(platform),
+    capabilities: input.capabilities,
+    policy: DEFAULT_COMMAND_NAME_POLICY,
+    agentOwnersInScope: agentOwnersForPlatform(input.config, platform.name),
+    generation: input.generation,
+  });
+}


### PR DESCRIPTION
## Summary

- Add a CLI registration plan builder that assembles platform and enabled agent command descriptors.
- Derive Discord global/guild registration scope from platform config.
- Filter agent owners by bindings for the requested platform and deduplicate backend-owned descriptors so same-backend multi-agent instances do not duplicate canonical ids.

## Review

- Initial independent Claude review: `/home/node/.goal/slash-command-registry/reviews/p5-cli-plan-claude-review.md`
- Review response: `/home/node/.goal/slash-command-registry/reviews/p5-cli-plan-review-response.md`
- Rereview after network recovery: `/home/node/.goal/slash-command-registry/reviews/p5-cli-plan-claude-rereview-after-network.md` found no blocker/important findings.

## Verification

- `COREPACK_HOME=/cache/corepack corepack pnpm exec vitest run packages/cli/src/command-registry.test.ts`
- `COREPACK_HOME=/cache/corepack corepack pnpm exec tsc --noEmit --pretty false`
- `COREPACK_HOME=/cache/corepack corepack pnpm test`
- `git diff --check`

Note: the local worktree also contains unrelated unstaged runtime wiring WIP files; they were not staged, committed, or included in this PR.