### PR TITLE
feat(command-registry): wire slash command runtime dispatch

### DIFF
--- a/packages/cli/src/agent.test.ts
+++ b/packages/cli/src/agent.test.ts
@@ -12,11 +12,13 @@ const createCodexRuntimeMock = vi.hoisted(() => vi.fn(() => codexRuntime));
 const runCodexProbeMock = vi.hoisted(() => vi.fn(async () => {}));
 
 vi.mock('@agent-nexus/agent-claudecode', () => ({
+  claudeCodeCommandDescriptors: [{ handlerKey: 'new' }],
   createClaudeCodeRuntime: createClaudeCodeRuntimeMock,
   runCompatibilityProbe: runClaudeProbeMock,
 }));
 
 vi.mock('@agent-nexus/agent-codex', () => ({
+  codexCommandDescriptors: [{ handlerKey: 'new' }],
   createCodexRuntime: createCodexRuntimeMock,
   runCompatibilityProbe: runCodexProbeMock,
 }));
@@ -173,10 +175,14 @@ describe('createAgentRegistry', () => {
     expect(registry).toHaveLength(2);
     expect(registry[0]).toMatchObject({
       agentName: 'codex-dev',
+      agentOwner: 'codex',
+      commandHandlerKeys: ['new'],
       agent: codexRuntime,
     });
     expect(registry[1]).toMatchObject({
       agentName: 'claude-prod',
+      agentOwner: 'claudecode',
+      commandHandlerKeys: ['new'],
       agent: claudeRuntime,
     });
   });

--- a/packages/cli/src/agent.ts
+++ b/packages/cli/src/agent.ts
@@ -1,8 +1,10 @@
 import {
+  claudeCodeCommandDescriptors,
   createClaudeCodeRuntime,
   runCompatibilityProbe as runClaudeCodeCompatibilityProbe,
 } from '@agent-nexus/agent-claudecode';
 import {
+  codexCommandDescriptors,
   createCodexRuntime,
   runCompatibilityProbe as runCodexCompatibilityProbe,
 } from '@agent-nexus/agent-codex';
@@ -86,6 +88,11 @@ export async function createAgentRegistry(
     const selected = await createAgentRuntime(agentConfig, logger);
     registry.push({
       agentName: agentConfig.name,
+      agentOwner: agentConfig.backend,
+      commandHandlerKeys:
+        agentConfig.backend === 'codex'
+          ? codexCommandDescriptors.map((descriptor) => descriptor.handlerKey)
+          : claudeCodeCommandDescriptors.map((descriptor) => descriptor.handlerKey),
       agent: selected.agent,
       defaultSessionConfig: selected.defaultSessionConfig,
     });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,13 +2,18 @@
 import { mkdir } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import {
+  ActiveCommandRegistry,
   Engine,
   SessionStore,
   createLogger,
   type RoutingEntry,
 } from '@agent-nexus/daemon';
-import { createDiscordPlatform } from '@agent-nexus/platform-discord';
+import {
+  DISCORD_CAPABILITIES,
+  createDiscordPlatform,
+} from '@agent-nexus/platform-discord';
 import { createAgentRegistry } from './agent.js';
+import { buildCliCommandRegistrationPlan } from './command-registry.js';
 import {
   ConfigError,
   SecretsPermissionError,
@@ -85,6 +90,7 @@ async function main(): Promise<void> {
   );
 
   const sessionStore = new SessionStore();
+  const commandRegistry = new ActiveCommandRegistry();
   const engines: Engine[] = [];
 
   for (const platformConfig of config.platforms) {
@@ -122,6 +128,12 @@ async function main(): Promise<void> {
     if (!token) {
       throw new ConfigError(`secret ref "${platformConfig.tokenRef}" 未加载`);
     }
+    const commandPlan = buildCliCommandRegistrationPlan({
+      config,
+      platformName: platformConfig.name,
+      capabilities: DISCORD_CAPABILITIES,
+      generation: `${platformConfig.name}:${Date.now()}`,
+    });
     const platform = createDiscordPlatform({
       token,
       botUserId: platformConfig.botUserId,
@@ -130,6 +142,15 @@ async function main(): Promise<void> {
       inboundAllowedUserIds: null,
       testGuildId: platformConfig.testGuildId,
       logger,
+      commandRegistration: {
+        plan: commandPlan,
+        apply: (port, plan) =>
+          commandRegistry.applyRegistrationPlan(plan, {
+            port,
+            logger,
+            activatedAt: new Date(),
+          }),
+      },
     });
 
     engines.push(
@@ -138,6 +159,7 @@ async function main(): Promise<void> {
         platformName: platformConfig.name,
         platformType: platformConfig.type,
         platformAuth: platformConfig.auth,
+        commandRegistry,
         agents,
         routingTable,
         logger,

--- a/packages/daemon/src/command-registry.ts
+++ b/packages/daemon/src/command-registry.ts
@@ -31,6 +31,7 @@ export type CommandRegistryErrorCode =
   | 'command_name_reserved'
   | 'command_active_map_missing'
   | 'command_reverse_map_miss'
+  | 'command_scope_mismatch'
   | 'command_agent_binding_miss'
   | 'command_agent_owner_mismatch'
   | 'command_handler_missing';

--- a/packages/daemon/src/engine.test.ts
+++ b/packages/daemon/src/engine.test.ts
@@ -7,6 +7,8 @@ import type {
   AgentRuntime,
   AgentSession,
   CapabilitySet,
+  CommandDescriptor,
+  CommandRegistrationScope,
   EventHandler,
   MessageRef,
   NormalizedEvent,
@@ -17,6 +19,11 @@ import type {
   SessionKey,
 } from '@agent-nexus/protocol';
 import { withPlatformName } from '@agent-nexus/protocol';
+import {
+  ActiveCommandRegistry,
+  buildCommandRegistrationPlan,
+  DEFAULT_COMMAND_NAME_POLICY,
+} from './command-registry.js';
 import { Engine } from './engine.js';
 import { createLogger, type Logger } from './logger.js';
 import type { RoutingEntry } from './router.js';
@@ -257,6 +264,54 @@ const PLATFORM_AUTH_ALLOW_U1 = {
     requireMentionOrSlash: true,
   },
 };
+
+const COMMAND_SCOPE: CommandRegistrationScope = {
+  platformName: 'discord-main',
+  platformType: 'discord',
+  nativeScope: { kind: 'global' },
+};
+
+const CODEX_NEW_COMMAND: CommandDescriptor = {
+  canonicalId: 'agent:codex:new',
+  owner: { type: 'agent', agentOwner: 'codex' },
+  localName: 'new',
+  summary: 'Start a new Codex conversation',
+  options: [],
+  handlerKey: 'new',
+  applicability: { requiredCapabilities: ['slash-command-registration'] },
+  legacyNames: [],
+};
+
+function makeCommandEvent(
+  commandName: string,
+  overrides: Partial<NormalizedEvent> = {},
+): NormalizedEvent {
+  return makeEvent('', {
+    type: 'command',
+    text: undefined,
+    command: {
+      name: commandName,
+      args: {},
+      registrationScope: COMMAND_SCOPE,
+    },
+    rawContentType: 'discord:interaction',
+    ...overrides,
+  });
+}
+
+function makeActiveRegistry(): ActiveCommandRegistry {
+  const registry = new ActiveCommandRegistry();
+  const plan = buildCommandRegistrationPlan({
+    descriptors: [CODEX_NEW_COMMAND],
+    scope: COMMAND_SCOPE,
+    capabilities: { ...platformCaps, supportsSlashCommands: true },
+    policy: DEFAULT_COMMAND_NAME_POLICY,
+    agentOwnersInScope: ['codex'],
+    generation: 'g-command',
+  });
+  registry.activate(plan, new Date(0));
+  return registry;
+}
 
 // ----- tests -----
 
@@ -1046,6 +1101,104 @@ describe('Engine', () => {
         initiatorUserId: 'U1',
       })?.agentSessionId,
     ).toBe('claude-sid');
+  });
+
+  it('command event 通过 active reverse map 路由 agent /new，不从 commandName 拆 owner', async () => {
+    const platform = makePlatform({ supportsSlashCommands: true });
+    const codex = makeAgent();
+    const store = new SessionStore();
+    const routingTable: RoutingEntry[] = [
+      {
+        bindingName: 'discord-main-codex',
+        platformName: 'discord-main',
+        platformType: 'discord',
+        agentName: 'codex-dev',
+        match: { discord: { channelIds: ['C1'] } },
+      },
+    ];
+    const engine = new Engine({
+      platform,
+      platformName: 'discord-main',
+      platformType: 'discord',
+      agents: [
+        {
+          agentName: 'codex-dev',
+          agentOwner: 'codex',
+          commandHandlerKeys: ['new'],
+          agent: codex.runtime,
+          defaultSessionConfig: DEFAULT_CFG,
+        },
+      ],
+      routingTable,
+      platformAuth: PLATFORM_AUTH_ALLOW_U1,
+      commandRegistry: makeActiveRegistry(),
+      logger: SILENT_LOGGER,
+      sessionStore: store,
+    });
+
+    await engine.start();
+    const dispatchHandler = (platform.start as ReturnType<typeof vi.fn>).mock.calls[0]![0] as EventHandler;
+    await dispatchHandler(makeCommandEvent('new'));
+
+    expect(platform.send).toHaveBeenCalledTimes(1);
+    expect((platform.send.mock.calls[0]![1] as OutboundMessage).text).toBe(
+      '[new session ready]',
+    );
+    expect(codex.startSession).not.toHaveBeenCalled();
+    expect(codex.sendInput).not.toHaveBeenCalled();
+  });
+
+  it('command event scope 与当前 Engine platform 不一致时 fail-closed', async () => {
+    const platform = makePlatform({ supportsSlashCommands: true });
+    const codex = makeAgent();
+    const store = new SessionStore();
+    const mockLogger = makeMockLogger();
+    const routingTable: RoutingEntry[] = [
+      {
+        bindingName: 'discord-main-codex',
+        platformName: 'discord-main',
+        platformType: 'discord',
+        agentName: 'codex-dev',
+        match: { discord: { channelIds: ['C1'] } },
+      },
+    ];
+    const engine = new Engine({
+      platform,
+      platformName: 'discord-main',
+      platformType: 'discord',
+      agents: [
+        {
+          agentName: 'codex-dev',
+          agentOwner: 'codex',
+          commandHandlerKeys: ['new'],
+          agent: codex.runtime,
+          defaultSessionConfig: DEFAULT_CFG,
+        },
+      ],
+      routingTable,
+      platformAuth: PLATFORM_AUTH_ALLOW_U1,
+      commandRegistry: makeActiveRegistry(),
+      logger: mockLogger,
+      sessionStore: store,
+    });
+
+    await engine.start();
+    const dispatchHandler = (platform.start as ReturnType<typeof vi.fn>).mock.calls[0]![0] as EventHandler;
+    await dispatchHandler(makeCommandEvent('new', {
+      command: {
+        name: 'new',
+        args: {},
+        registrationScope: {
+          ...COMMAND_SCOPE,
+          platformName: 'discord-side',
+        },
+      },
+    }));
+
+    expect(codex.startSession).not.toHaveBeenCalled();
+    expect(platform.send).not.toHaveBeenCalled();
+    const errorCalls = (mockLogger.error as ReturnType<typeof vi.fn>).mock.calls;
+    expect(errorCalls.find(([, msg]) => msg === 'command_scope_mismatch')).toBeDefined();
   });
 
   it('两个同 type Engine 共享 SessionStore 时，同 channel/user 仍按 platformName 隔离', async () => {

--- a/packages/daemon/src/engine.ts
+++ b/packages/daemon/src/engine.ts
@@ -3,6 +3,7 @@ import type {
   AgentEvent,
   AgentRuntime,
   AgentSession,
+  CommandPayload,
   MessageRef,
   NormalizedEvent,
   PlatformAdapter,
@@ -11,6 +12,10 @@ import type {
 } from '@agent-nexus/protocol';
 import { serializeSessionKey, withPlatformName } from '@agent-nexus/protocol';
 import { checkPlatformAuth } from './auth.js';
+import {
+  ActiveCommandRegistry,
+} from './command-registry.js';
+import { dispatchCommandEvent } from './command-dispatch.js';
 import type { PlatformAuthConfig, ToolMessageMode } from './config.js';
 import type { Logger } from './logger.js';
 import { RouteError, selectRoute, type RoutingEntry } from './router.js';
@@ -19,6 +24,8 @@ import type { SessionStore } from './session-store.js';
 export interface EngineAgent {
   agent: AgentRuntime;
   agentName: string;
+  agentOwner?: string;
+  commandHandlerKeys?: readonly string[];
   defaultSessionConfig: Omit<
     SessionConfig,
     'resumeFromAgentSessionId' | 'sessionId'
@@ -33,6 +40,9 @@ export interface EngineDeps {
   agents?: readonly EngineAgent[];
   routingTable?: readonly RoutingEntry[];
   platformAuth?: PlatformAuthConfig;
+  commandRegistry?: ActiveCommandRegistry;
+  platformCommandHandlerKeys?: readonly string[];
+  daemonCommandHandlerKeys?: readonly string[];
   logger: Logger;
   sessionStore: SessionStore;
   /** 每轮 sessionId 由 Engine 生成；resumeFromAgentSessionId 由 store 决定 */
@@ -99,6 +109,9 @@ export class Engine {
   private readonly platformName: string;
   private readonly platformType: 'discord';
   private readonly platformAuth?: PlatformAuthConfig;
+  private readonly commandRegistry?: ActiveCommandRegistry;
+  private readonly platformCommandHandlerKeys: readonly string[];
+  private readonly daemonCommandHandlerKeys: readonly string[];
   private readonly agents: Map<string, EngineAgent>;
   private readonly routingTable?: readonly RoutingEntry[];
   private readonly logger: Logger;
@@ -131,6 +144,9 @@ export class Engine {
       throw new Error('Engine with routingTable requires platformAuth');
     }
     this.platformAuth = deps.platformAuth;
+    this.commandRegistry = deps.commandRegistry;
+    this.platformCommandHandlerKeys = deps.platformCommandHandlerKeys ?? [];
+    this.daemonCommandHandlerKeys = deps.daemonCommandHandlerKeys ?? [];
     this.routingTable = deps.routingTable;
     this.agents = new Map();
     if (deps.agents) {
@@ -173,25 +189,37 @@ export class Engine {
   }
 
   private dispatch(event: NormalizedEvent): Promise<void> {
+    if (event.type === 'command') {
+      return this.dispatchCommand(event);
+    }
     const route = this.route(event);
     if (!route) return Promise.resolve();
-    if (this.platformAuth) {
-      const decision = checkPlatformAuth(this.platformAuth, event);
-      if (!decision.allowed) {
-        this.logger.info(
-          {
-            traceId: event.traceId,
-            platformName: this.platformName,
-            guildId: event.guildId,
-            channelId: event.sessionKey.channelId,
-            userId: event.initiator.userId,
-            reason: decision.reason,
-          },
-          'auth_denied',
-        );
-        return Promise.resolve();
-      }
-    }
+    if (!this.checkAuth(event)) return Promise.resolve();
+    return this.dispatchToAgent(event, route);
+  }
+
+  private checkAuth(event: NormalizedEvent): boolean {
+    if (!this.platformAuth) return true;
+    const decision = checkPlatformAuth(this.platformAuth, event);
+    if (decision.allowed) return true;
+    this.logger.info(
+      {
+        traceId: event.traceId,
+        platformName: this.platformName,
+        guildId: event.guildId,
+        channelId: event.sessionKey.channelId,
+        userId: event.initiator.userId,
+        reason: decision.reason,
+      },
+      'auth_denied',
+    );
+    return false;
+  }
+
+  private dispatchToAgent(
+    event: NormalizedEvent,
+    route: { bindingName: string; agentName: string },
+  ): Promise<void> {
     const routedSessionKey = withPlatformName(
       event.sessionKey,
       this.platformName,
@@ -226,6 +254,106 @@ export class Engine {
       }
     });
     return next;
+  }
+
+  private dispatchCommand(event: NormalizedEvent): Promise<void> {
+    if (!this.checkAuth(event)) return Promise.resolve();
+    if (!this.commandRegistry || !this.routingTable) {
+      this.logger.error(
+        {
+          traceId: event.traceId,
+          platformName: this.platformName,
+          commandName: event.command?.name,
+        },
+        'command_handler_missing',
+      );
+      return Promise.resolve();
+    }
+    if (!this.commandScopeMatchesEngine(event.command?.registrationScope)) {
+      this.logger.error(
+        {
+          traceId: event.traceId,
+          platformName: this.platformName,
+          platformType: this.platformType,
+          scope: event.command?.registrationScope,
+          commandName: event.command?.name,
+        },
+        'command_scope_mismatch',
+      );
+      return Promise.resolve();
+    }
+
+    const decision = dispatchCommandEvent({
+      event,
+      registry: this.commandRegistry,
+      platformName: this.platformName,
+      platformType: this.platformType,
+      routingTable: this.routingTable,
+      agentTargets: [...this.agents.values()].map((agent) => ({
+        agentName: agent.agentName,
+        agentOwner: agent.agentOwner ?? agent.agent.name(),
+        handlerKeys: agent.commandHandlerKeys ?? [],
+      })),
+      platformHandlerKeys: this.platformCommandHandlerKeys,
+      daemonHandlerKeys: this.daemonCommandHandlerKeys,
+      logger: this.logger,
+    });
+    if (!decision) return Promise.resolve();
+    if (decision.ownerType !== 'agent') {
+      this.logger.error(
+        {
+          traceId: event.traceId,
+          platformName: this.platformName,
+          commandName: decision.commandName,
+          canonicalId: decision.canonicalId,
+          handlerKey: decision.handlerKey,
+          ownerType: decision.ownerType,
+        },
+        'command_handler_missing',
+      );
+      return Promise.resolve();
+    }
+    const commandEvent = this.eventForAgentCommand(
+      event,
+      event.command,
+      decision.handlerKey,
+    );
+    if (!commandEvent) return Promise.resolve();
+    return this.dispatchToAgent(commandEvent, {
+      bindingName: decision.bindingName,
+      agentName: decision.agentName,
+    });
+  }
+
+  private commandScopeMatchesEngine(
+    scope: CommandPayload['registrationScope'] | undefined,
+  ): boolean {
+    return (
+      scope?.platformName === this.platformName &&
+      scope.platformType === this.platformType
+    );
+  }
+
+  private eventForAgentCommand(
+    event: NormalizedEvent,
+    command: CommandPayload | undefined,
+    handlerKey: string,
+  ): NormalizedEvent | undefined {
+    if (handlerKey === 'new') {
+      const { command: _command, ...messageEvent } = event;
+      void _command;
+      return { ...messageEvent, type: 'message', text: '/new' };
+    }
+    this.logger.error(
+      {
+        traceId: event.traceId,
+        platformName: this.platformName,
+        commandName: command?.name,
+        handlerKey,
+      },
+      'command_handler_missing',
+    );
+    return undefined;
   }
 
   private route(event: NormalizedEvent):

--- a/packages/platform/discord/src/index.test.ts
+++ b/packages/platform/discord/src/index.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { Message } from 'discord.js';
+import { ApplicationCommandOptionType, type Message } from 'discord.js';
 import {
   buildBotMentionRegex,
   buildSlices,
@@ -11,6 +11,7 @@ import {
 } from './index.js';
 
 const discordMock = vi.hoisted(() => ({
+  applicationCommands: undefined as undefined | { set: ReturnType<typeof vi.fn> },
   channelsFetch: vi.fn(),
   clientDestroy: vi.fn(async () => undefined),
   clientLogin: vi.fn(async () => 'logged-in'),
@@ -26,7 +27,7 @@ vi.mock('discord.js', async (importOriginal) => {
       destroy: discordMock.clientDestroy,
       login: discordMock.clientLogin,
       on: discordMock.clientOn,
-      application: { commands: undefined },
+      application: { commands: discordMock.applicationCommands },
       user: { id: '900000000000000001', tag: 'bot#0000' },
     })),
   };
@@ -50,6 +51,7 @@ const ALLOWED: readonly string[] = [OTHER_ID, 'U7', 'U-init', 'U_X'];
 
 beforeEach(() => {
   vi.clearAllMocks();
+  discordMock.applicationCommands = undefined;
 });
 
 function makeLogger() {
@@ -62,6 +64,14 @@ function makeLogger() {
     fatal: vi.fn(),
     child: vi.fn(),
   };
+}
+
+function registeredHandler(eventName: string) {
+  const call = discordMock.clientOn.mock.calls.find(
+    ([name]) => name === eventName,
+  );
+  if (!call) throw new Error(`missing handler for ${eventName}`);
+  return call[1] as (...args: unknown[]) => unknown;
 }
 
 function makeMsg(overrides: {
@@ -116,6 +126,169 @@ function makePlatform() {
     allowedUserIds: ALLOWED,
   });
 }
+
+describe('command registry integration', () => {
+  it('ready 时用外部 command registration plan apply，而不是 adapter 内置 legacy 注册', async () => {
+    const set = vi.fn(async () => undefined);
+    discordMock.applicationCommands = { set };
+    const apply = vi.fn(async () => ({ status: 'applied' as const, generation: 'g1' }));
+    const platform = createDiscordPlatform({
+      token: 'test-token',
+      botUserId: BOT_ID,
+      logger: makeLogger(),
+      statePath: '/tmp/agent-nexus-discord-state-test.json',
+      allowedUserIds: ALLOWED,
+      commandRegistration: {
+        plan: {
+          scope: {
+            platformName: 'discord-main',
+            platformType: 'discord',
+            nativeScope: { kind: 'global' },
+          },
+          commands: [],
+          reverseMap: { entries: {} },
+          generation: 'g1',
+        },
+        apply,
+      },
+    });
+
+    await platform.start(vi.fn());
+    const ready = registeredHandler('ready');
+    ready();
+    await Promise.resolve();
+
+    expect(apply).toHaveBeenCalledTimes(1);
+    const [port, plan] = apply.mock.calls[0]!;
+    expect(plan.generation).toBe('g1');
+    await port.applyCommandPlan(plan);
+    expect(set).toHaveBeenCalledWith([], undefined);
+  });
+
+  it('把非 reply-mode chat input slash command 转成 normalized command event', async () => {
+    const platform = createDiscordPlatform({
+      token: 'test-token',
+      botUserId: BOT_ID,
+      logger: makeLogger(),
+      statePath: '/tmp/agent-nexus-discord-state-test.json',
+      allowedUserIds: ALLOWED,
+      testGuildId: 'G-dev',
+    });
+    const handler = vi.fn(async () => undefined);
+
+    await platform.start(handler);
+    const interactionCreate = registeredHandler('interactionCreate');
+    const deferReply = vi.fn(async () => undefined);
+    const deleteReply = vi.fn(async () => undefined);
+    const editReply = vi.fn(async () => undefined);
+    await interactionCreate({
+      id: 'i-1',
+      commandName: 'new',
+      channelId: 'C1',
+      guildId: 'G-dev',
+      createdAt: new Date(123),
+      user: { id: OTHER_ID, username: 'alice', bot: false },
+      member: { roles: { cache: new Map([['R1', { id: 'R1' }]]) } },
+      options: {
+        data: [
+          {
+            name: 'reason',
+            type: ApplicationCommandOptionType.String,
+            value: 'fresh',
+          },
+        ],
+      },
+      deferReply,
+      deleteReply,
+      editReply,
+      isChatInputCommand: () => true,
+    });
+
+    expect(deferReply).toHaveBeenCalledWith({ ephemeral: true });
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(deleteReply).toHaveBeenCalledTimes(1);
+    expect(editReply).not.toHaveBeenCalled();
+    const event = handler.mock.calls[0]![0];
+    expect(event).toMatchObject({
+      eventId: 'i-1',
+      platform: 'discord',
+      type: 'command',
+      command: {
+        name: 'new',
+        args: { reason: 'fresh' },
+        registrationScope: {
+          platformName: 'discord',
+          platformType: 'discord',
+          nativeScope: { kind: 'guild', guildId: 'G-dev' },
+        },
+      },
+      sessionKey: {
+        platform: 'discord',
+        channelId: 'C1',
+        initiatorUserId: OTHER_ID,
+      },
+      guildId: 'G-dev',
+      initiatorRoleIds: ['R1'],
+      initiator: {
+        userId: OTHER_ID,
+        displayName: 'alice',
+        isBot: false,
+      },
+      rawContentType: 'discord:interaction',
+    });
+    expect(event.traceId).toBeTruthy();
+  });
+
+  it('command registration plan 存在时用 plan scope 构造 command event', async () => {
+    const plan = {
+      scope: {
+        platformName: 'discord-main',
+        platformType: 'discord' as const,
+        nativeScope: { kind: 'guild' as const, guildId: 'G-dev' },
+      },
+      commands: [],
+      reverseMap: { entries: {} },
+      generation: 'g-scope',
+    };
+    const platform = createDiscordPlatform({
+      token: 'test-token',
+      botUserId: BOT_ID,
+      logger: makeLogger(),
+      statePath: '/tmp/agent-nexus-discord-state-test.json',
+      allowedUserIds: ALLOWED,
+      commandRegistration: {
+        plan,
+        apply: vi.fn(async () => ({ status: 'applied' as const, generation: 'g-scope' })),
+      },
+    });
+    const handler = vi.fn(async () => undefined);
+
+    await platform.start(handler);
+    const interactionCreate = registeredHandler('interactionCreate');
+    await interactionCreate({
+      id: 'i-scope',
+      commandName: 'new',
+      channelId: 'C1',
+      guildId: 'G-dev',
+      createdAt: new Date(123),
+      user: { id: OTHER_ID, username: 'alice', bot: false },
+      member: { roles: { cache: new Map() } },
+      options: { data: [] },
+      deferReply: vi.fn(async () => undefined),
+      deleteReply: vi.fn(async () => undefined),
+      editReply: vi.fn(async () => undefined),
+      isChatInputCommand: () => true,
+    });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler.mock.calls[0]![0]).toMatchObject({
+      command: {
+        name: 'new',
+        registrationScope: plan.scope,
+      },
+    });
+  });
+});
 
 function makeTextChannel(overrides: {
   edit?: ReturnType<typeof vi.fn>;

--- a/packages/platform/discord/src/index.ts
+++ b/packages/platform/discord/src/index.ts
@@ -24,11 +24,17 @@ import { randomUUID } from 'node:crypto';
 import {
   Client,
   GatewayIntentBits,
+  type ChatInputCommandInteraction,
   type Interaction,
   type Message,
 } from 'discord.js';
 import type {
   CapabilitySet,
+  CommandArgValue,
+  CommandRegistrationPlan,
+  CommandRegistrationPort,
+  CommandRegistrationResult,
+  CommandRegistrationScope,
   EventHandler,
   MessageRef,
   NormalizedEvent,
@@ -49,9 +55,18 @@ import {
   handleReplyModeInteraction,
 } from './reply-mode.js';
 import {
+  createDiscordCommandRegistrationPort,
   plannedCommandToSlashCommandSpec,
   registerSlashCommands,
 } from './commands.js';
+
+export interface DiscordCommandRegistration {
+  plan: CommandRegistrationPlan;
+  apply(
+    port: CommandRegistrationPort,
+    plan: CommandRegistrationPlan,
+  ): Promise<CommandRegistrationResult>;
+}
 
 export interface DiscordPlatformOptions {
   token: string;
@@ -79,6 +94,7 @@ export interface DiscordPlatformOptions {
    * 详见 spec/platform-adapter.md §"注册作用域"。
    */
   testGuildId?: string;
+  commandRegistration?: DiscordCommandRegistration;
 }
 
 /**
@@ -87,6 +103,21 @@ export interface DiscordPlatformOptions {
  * UTF-16 取 1900。
  */
 export const SLICE_SIZE = 1900;
+
+export const DISCORD_CAPABILITIES: CapabilitySet = {
+  maxTextLength: 2000,
+  supportsEdit: true,
+  supportsDelete: false,
+  supportsReactions: false,
+  supportsEmbeds: false,
+  supportsButtons: false,
+  supportsThreads: false,
+  supportsEphemeral: true,
+  supportsAttachments: false,
+  maxAttachmentsPerMessage: 0,
+  supportsTypingIndicator: true,
+  supportsSlashCommands: true,
+};
 
 export type { ReplyMode } from './state.js';
 
@@ -177,6 +208,139 @@ function discordMemberRoleIds(msg: Message): string[] {
   return [...cache.keys()];
 }
 
+function discordInteractionRoleIds(interaction: ChatInputCommandInteraction): string[] {
+  const roles = interaction.member?.roles;
+  if (Array.isArray(roles)) return roles;
+  const cache =
+    roles && typeof roles === 'object' && 'cache' in roles
+      ? roles.cache
+      : undefined;
+  if (cache && typeof cache.keys === 'function') return [...cache.keys()];
+  return [];
+}
+
+function commandArgValue(value: unknown): CommandArgValue | undefined {
+  if (
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean' ||
+    value === null
+  ) {
+    return value;
+  }
+  return undefined;
+}
+
+function commandArgs(
+  interaction: ChatInputCommandInteraction,
+): Record<string, CommandArgValue> {
+  const args: Record<string, CommandArgValue> = {};
+  for (const option of interaction.options.data) {
+    const value = commandArgValue(option.value ?? null);
+    if (value !== undefined) args[option.name] = value;
+  }
+  return args;
+}
+
+function commandScope(testGuildId?: string): CommandRegistrationScope {
+  return {
+    platformName: 'discord',
+    platformType: 'discord',
+    nativeScope: testGuildId
+      ? { kind: 'guild', guildId: testGuildId }
+      : { kind: 'global' },
+  };
+}
+
+function commandEventFromInteraction(
+  interaction: ChatInputCommandInteraction,
+  scope: CommandRegistrationScope,
+): NormalizedEvent {
+  return {
+    eventId: interaction.id,
+    platform: 'discord',
+    sessionKey: {
+      platform: 'discord',
+      channelId: interaction.channelId,
+      initiatorUserId: interaction.user.id,
+    },
+    traceId: randomUUID(),
+    type: 'command',
+    command: {
+      name: interaction.commandName,
+      args: commandArgs(interaction),
+      registrationScope: scope,
+    },
+    rawPayload: interaction,
+    rawContentType: 'discord:interaction',
+    receivedAt: new Date(),
+    platformTimestamp: interaction.createdAt,
+    ...(interaction.guildId ? { guildId: interaction.guildId } : {}),
+    initiatorRoleIds: discordInteractionRoleIds(interaction),
+    initiator: {
+      userId: interaction.user.id,
+      displayName: interaction.user.username,
+      isBot: interaction.user.bot,
+    },
+  };
+}
+
+async function deferCommandInteraction(
+  interaction: ChatInputCommandInteraction,
+  logger: Logger,
+): Promise<boolean> {
+  try {
+    await interaction.deferReply({ ephemeral: true });
+    return true;
+  } catch (err) {
+    logger.error(
+      { err, interactionId: interaction.id, commandName: interaction.commandName },
+      'discord_command_ack_failed',
+    );
+    return false;
+  }
+}
+
+async function deleteDeferredCommandReply(
+  interaction: ChatInputCommandInteraction,
+  logger: Logger,
+  event: NormalizedEvent,
+): Promise<void> {
+  try {
+    await interaction.deleteReply();
+  } catch (err) {
+    logger.error(
+      {
+        err,
+        traceId: event.traceId,
+        interactionId: interaction.id,
+        commandName: interaction.commandName,
+      },
+      'discord_command_ack_cleanup_failed',
+    );
+  }
+}
+
+async function markDeferredCommandFailed(
+  interaction: ChatInputCommandInteraction,
+  logger: Logger,
+  event: NormalizedEvent,
+): Promise<void> {
+  try {
+    await interaction.editReply({ content: 'Command failed.' });
+  } catch (err) {
+    logger.error(
+      {
+        err,
+        traceId: event.traceId,
+        interactionId: interaction.id,
+        commandName: interaction.commandName,
+      },
+      'discord_command_ack_failure_update_failed',
+    );
+  }
+}
+
 /**
  * `parseInbound` 的返回形态——tagged union，让 caller 拿到"为什么被丢"。
  * `drop.reason` 只用于决定上层日志策略，不参与业务逻辑。
@@ -260,7 +424,15 @@ export function parseInbound(
 }
 
 export function createDiscordPlatform(opts: DiscordPlatformOptions): PlatformAdapter {
-  const { token, botUserId, logger, statePath, allowedUserIds, testGuildId } = opts;
+  const {
+    token,
+    botUserId,
+    logger,
+    statePath,
+    allowedUserIds,
+    testGuildId,
+    commandRegistration,
+  } = opts;
   const inboundAllowedUserIds = opts.inboundAllowedUserIds ?? allowedUserIds;
 
   const client = new Client({
@@ -299,20 +471,7 @@ export function createDiscordPlatform(opts: DiscordPlatformOptions): PlatformAda
     },
 
     capabilities(): CapabilitySet {
-      return {
-        maxTextLength: 2000,
-        supportsEdit: true,
-        supportsDelete: false,
-        supportsReactions: false,
-        supportsEmbeds: false,
-        supportsButtons: false,
-        supportsThreads: false,
-        supportsEphemeral: false,
-        supportsAttachments: false,
-        maxAttachmentsPerMessage: 0,
-        supportsTypingIndicator: true,
-        supportsSlashCommands: true,
-      };
+      return DISCORD_CAPABILITIES;
     },
 
     async start(handler: EventHandler): Promise<void> {
@@ -337,25 +496,37 @@ export function createDiscordPlatform(opts: DiscordPlatformOptions): PlatformAda
           tag: client.user?.tag,
           logger,
         });
-        void registerSlashCommands(
-          client.application?.commands,
-          [
-            plannedCommandToSlashCommandSpec({
-              commandName: 'discord-reply-mode',
-              canonicalId: discordReplyModeCommandDescriptor.canonicalId,
-              aliasKind: 'stable',
-              descriptor: discordReplyModeCommandDescriptor,
-            }),
-            plannedCommandToSlashCommandSpec({
-              commandName: 'reply-mode',
-              canonicalId: discordReplyModeCommandDescriptor.canonicalId,
-              aliasKind: 'legacy',
-              descriptor: discordReplyModeCommandDescriptor,
-            }),
-          ],
-          logger,
-          testGuildId,
-        );
+        if (commandRegistration) {
+          void commandRegistration.apply(
+            createDiscordCommandRegistrationPort(client.application?.commands, logger),
+            commandRegistration.plan,
+          ).catch((err) => {
+            logger.error(
+              { err, generation: commandRegistration.plan.generation },
+              'command_registration_apply_failed',
+            );
+          });
+        } else {
+          void registerSlashCommands(
+            client.application?.commands,
+            [
+              plannedCommandToSlashCommandSpec({
+                commandName: 'discord-reply-mode',
+                canonicalId: discordReplyModeCommandDescriptor.canonicalId,
+                aliasKind: 'stable',
+                descriptor: discordReplyModeCommandDescriptor,
+              }),
+              plannedCommandToSlashCommandSpec({
+                commandName: 'reply-mode',
+                canonicalId: discordReplyModeCommandDescriptor.canonicalId,
+                aliasKind: 'legacy',
+                descriptor: discordReplyModeCommandDescriptor,
+              }),
+            ],
+            logger,
+            testGuildId,
+          );
+        }
       });
 
       client.on('interactionCreate', async (interaction: Interaction) => {
@@ -364,6 +535,21 @@ export function createDiscordPlatform(opts: DiscordPlatformOptions): PlatformAda
           interaction.commandName !== 'reply-mode' &&
           interaction.commandName !== 'discord-reply-mode'
         ) {
+          if (!(await deferCommandInteraction(interaction, logger))) return;
+          const event = commandEventFromInteraction(
+            interaction,
+            commandRegistration?.plan.scope ?? commandScope(testGuildId),
+          );
+          try {
+            await handler(event);
+            await deleteDeferredCommandReply(interaction, logger, event);
+          } catch (err) {
+            logger.error(
+              { err, traceId: event.traceId, commandName: interaction.commandName },
+              'platform_handler_error',
+            );
+            await markDeferredCommandFailed(interaction, logger, event);
+          }
           return;
         }
         try {


### PR DESCRIPTION
## Summary

- wire CLI-built command registration plans into Discord startup registration and daemon active-map activation
- convert non-reply-mode Discord slash interactions into normalized command events
- route agent `/new` slash commands through the active reverse map with scope-mismatch fail-closed checks
- derive agent command handler keys from Codex/Claude Code command descriptors

## Review

- Claude review saved at `/home/node/.goal/slash-command-registry/reviews/p5-runtime-wiring-claude-review.md`
- Claude rereview saved at `/home/node/.goal/slash-command-registry/reviews/p5-runtime-wiring-claude-rereview.md`
- Initial important findings were fixed; rereview found no blocker/important findings.

## Verification

- `COREPACK_HOME=/cache/corepack corepack pnpm exec vitest run packages/daemon/src/engine.test.ts packages/cli/src/agent.test.ts packages/platform/discord/src/index.test.ts packages/cli/src/command-registry.test.ts`
- `COREPACK_HOME=/cache/corepack corepack pnpm exec tsc --noEmit --pretty false`
- `COREPACK_HOME=/cache/corepack corepack pnpm test`
- `git diff --check`

Base branch is `feature/slash-command-registry-main`.