### PR TITLE
docs(command-registry): document slash command names

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ agent-nexus 让你在 IM（当前：Discord）里直接和本机 Claude Code 对
 **Discord + 本机 Claude Code CLI MVP** 已可端到端运行：
 
 - Discord `@mention` → daemon `Engine` → 长驻 Claude Code `stream-json` 子进程 → Discord 回复。
-- 同一 `(channelId, userId)` 复用活跃 session；`/new` 文本前缀重置该会话。
+- 同一 `(channelId, userId)` 复用活跃 session；`/new` 文本前缀或 agent slash command 可重置该会话。
 - IM 侧可看到工具调用状态、流式文本、typing 指示与原地 edit。
 - 白名单外工具会在执行前被拒绝；机制见 [`docs/dev/spec/security/tool-boundary.md`](docs/dev/spec/security/tool-boundary.md)。`Bash` 不在默认允许集。
 
@@ -136,7 +136,7 @@ chmod 600 ~/.agent-nexus/config.json
 - `platforms[].botUserId`（必填）：bot 的 Discord user ID
 - `platforms[].auth.allowlist.userIds` / `roleIds`（必填其一）：允许使用 bot 的 Discord user 或 role ID
 - `platforms[].auth.allowlist.allowedGuildIds` / `allowedChannelIds`（可选）：进一步收窄允许的 guild / channel；空数组表示不按该维度收窄
-- `platforms[].testGuildId`（可选）：把 `/reply-mode` slash command 限定注册到某个测试 guild，开发时更快生效
+- `platforms[].testGuildId`（可选）：把 slash command 限定注册到某个测试 guild，开发时更快生效
 - `agents[].backend`（必填）：选择 `claudecode` 或 `codex`
 - `agents[].claudeCode.workingDir`（`backend=claudecode` 时必填）：CC 默认工作目录，per-session 可覆盖
 - `agents[].claudeCode.bin`（可选，默认 `claude`）：CC CLI 可执行路径
@@ -184,7 +184,10 @@ agent-nexus
 - `@bot <prompt>`：发起一轮 CC 对话；同 `(channelId, userId)` 后续消息复用活跃 session
 - `@bot /new`：清当前 (channel, user) 的内存 session，回复 `[new session ready]`
 - `@bot /new <prompt>`：清 + 立即用 `<prompt>` 起新一轮
-- `/reply-mode mode:<mention|all>`：在 allowlist 内切换 Discord 消息触发模式
+- `/claudecode-new` / `/codex-new`：按绑定到当前频道的 agent owner 清当前会话，回复 `[new session ready]`；只有对应 backend 已配置且在该 Discord 注册 scope 有 binding 时才会出现
+- `/new`：仅在同一个 Discord 注册 scope 里只有一种 agent owner 时作为便捷 alias 出现
+- `/discord-reply-mode mode:<mention|all>`：在 allowlist 内切换 Discord 消息触发模式
+- `/reply-mode mode:<mention|all>`：legacy alias；迁移期内等价于 `/discord-reply-mode`
 
 约束：
 

--- a/docs/ops/runbook.md
+++ b/docs/ops/runbook.md
@@ -62,7 +62,7 @@ agent-nexus
 
 首次运行会创建前两个文件的模板 / 空文件，但不会替你填真实 bot id、allowlist、working directory 或 token。
 
-`config.json` 变更后需要重启进程。`discord.json` 由 `/reply-mode` 写入，通常不手动改。
+`config.json` 变更后需要重启进程。`discord.json` 由 `/discord-reply-mode` 或 legacy `/reply-mode` 写入，通常不手动改。
 
 ## 常见故障
 
@@ -74,7 +74,8 @@ agent-nexus
 | `cc_compat_probe_failed` | 先跑 `claude --version`；确认 Claude Code 已登录，且当前版本支持长驻 `stream-json` 与工具权限检查 |
 | `agent_compat_probe_failed` 且 `agentBackend=codex` | 先跑 `codex --version`；确认 Codex CLI 已登录；再跑 `scripts/verify-codex-agent.sh` 看 resume、错误或中断验证失败原因 |
 | Discord 里无响应 | 确认 `platforms[].auth.allowlist` 包含发送者 user id 或 role；确认当前频道命中某条 `bindings[].match.discord.channelIds`；默认模式下确认消息显式 @bot |
-| `/reply-mode` 不出现 | 开发时配置 `platforms[].testGuildId`，避免全局 slash command 缓存延迟 |
+| `/discord-reply-mode` / `/reply-mode` 不出现 | 开发时配置 `platforms[].testGuildId`，避免全局 slash command 缓存延迟；确认 bot 邀请包含 `applications.commands` scope |
+| `/codex-new` / `/claudecode-new` 不出现 | 确认对应 backend 的 agent 已配置，且当前 platform 至少有一条 binding 指向该 agent；裸 `/new` 只在同一注册 scope 只有一种 agent owner 时出现 |
 | bot 回复自己或循环 | 检查 `platforms[].botUserId` 是否等于实际 bot user id；启动日志中不应出现 `discord_bot_user_id_mismatch` |
 
 ## 升级

--- a/docs/product/faq.md
+++ b/docs/product/faq.md
@@ -52,9 +52,13 @@ Codex CLI 当前没有 Claude Code 那种执行前工具审批。它的边界来
 
 也可以配置 `acceptEdits` / `auto` / `bypassPermissions` / `dontAsk` / `plan`，agent-nexus 会把字符串原样传给 Claude Code。非 `default` 模式会跳过工具权限控制 probe，并在启动日志打 warn；如果 Claude Code 实际 `init.permissionMode` 与配置不一致（例如 `auto` 不可用回退到 `default`），agent-nexus 会拒绝启动该 session。
 
-## `/reply-mode all` 会让所有人都能用吗？
+## `/discord-reply-mode all` 会让所有人都能用吗？
 
-不会。`all` 只表示“不必 @bot 也触发”，仍然先检查 `platforms[].auth.allowlist`。
+不会。`all` 只表示“不必 @bot 也触发”，仍然先检查 `platforms[].auth.allowlist`。`/reply-mode all` 是迁移期 legacy alias，行为相同。
+
+## 为什么看不到 `/new`？
+
+`/codex-new` 和 `/claudecode-new` 是稳定的 agent slash command 名称。每个 `-new` 命令只在对应 backend 已配置且在该 Discord 注册 scope 有 binding 时注册；只启用一个 backend 时只会看到对应的那一个。裸 `/new` 只在同一个 Discord 注册 scope 里只有一种 agent owner 时注册；如果同一个 scope 同时暴露 Codex 和 Claude Code，系统不会注册 `/new`，避免用户看不出会路由到哪个 backend。
 
 ## 数据和密钥放在哪里？
 

--- a/docs/product/platforms/discord.md
+++ b/docs/product/platforms/discord.md
@@ -31,7 +31,9 @@ related:
 - bot 出现在 server 成员列表里
 - portal 里 `Bot Token` 已生成并可用
 - `MESSAGE CONTENT INTENT` 已开启
-- 用 `@bot ping` 或 slash command 能收到响应
+- 用 `@bot ping` 能收到响应
+- slash command 列表里能看到 `/discord-reply-mode`，迁移期内还会看到 legacy `/reply-mode`
+- slash command 列表里能看到已绑定 backend 对应的 `/claudecode-new` 或 `/codex-new`
 
 ## 参考
 

--- a/docs/product/user-guide.md
+++ b/docs/product/user-guide.md
@@ -117,7 +117,7 @@ chmod 600 ~/.agent-nexus/config.json
 | `platforms[].auth.allowlist.allowedGuildIds` | 否 | 限定可用 server/guild；`[]` 表示不按 guild 收窄 |
 | `platforms[].auth.allowlist.allowedChannelIds` | 否 | 限定可用 channel/thread；`[]` 表示不按 channel 收窄 |
 | `platforms[].auth.allowlist.allowDM` | 否 | 默认 `true`；DM 仍必须命中 `userIds` |
-| `platforms[].testGuildId` | 否 | 开发时把 `/reply-mode` 限定注册到一个 guild，避免全局 slash command 缓存延迟 |
+| `platforms[].testGuildId` | 否 | 开发时把 slash command 限定注册到一个 guild，避免全局 slash command 缓存延迟 |
 | `agents[].name` | 是 | agent 配置稳定名称；binding 用它引用该 agent |
 | `agents[].backend` | 是 | `claudecode` 或 `codex` |
 | `agents[].claudeCode.workingDir` | backend 为 `claudecode` 时是 | Claude Code 默认工作目录 |
@@ -262,14 +262,22 @@ agent-nexus
 ```text
 @bot /new
 @bot /new 从这个问题重新开始
+/claudecode-new  # 配置并绑定 Claude Code backend 时出现
+/codex-new       # 配置并绑定 Codex backend 时出现
 ```
+
+`/claudecode-new` 和 `/codex-new` 是 agent slash command 的稳定名称，按当前频道 binding 路由到对应 backend。每个 `-new` 命令只在对应 backend 已配置且在该 Discord 注册 scope 有 binding 时注册；只启用一个 backend 时只会看到对应的那一个。`/new` 只有在同一个 Discord 注册 scope 里只有一种 agent owner 时才会作为 slash command alias 出现；多 backend 共用同一个 scope 时不会注册裸 `/new`，避免歧义。`@bot /new <prompt>` 仍是文本前缀形式，可以在重置后立即带 prompt 开新一轮。
 
 切换触发模式：
 
 ```text
+/discord-reply-mode mode:mention
+/discord-reply-mode mode:all
 /reply-mode mode:mention
 /reply-mode mode:all
 ```
+
+`/discord-reply-mode` 是稳定名称；`/reply-mode` 是迁移期 legacy alias。
 
 `all` 模式只影响消息触发条件，不绕过 `allowedUserIds`。不在 allowlist 里的用户仍不能驱动 bot。
 


### PR DESCRIPTION
## Summary

- document stable agent slash command names `/codex-new` and `/claudecode-new`
- document `/new` as a single-agent-owner slash alias only, while keeping `@bot /new` as the text prefix reset form
- document stable `/discord-reply-mode` and migration-period legacy `/reply-mode`
- update runbook troubleshooting for missing slash commands and `testGuildId`

## Review

- Claude review saved at `/home/node/.goal/slash-command-registry/reviews/p6-docs-claude-review.md`
- Claude rereview saved at `/home/node/.goal/slash-command-registry/reviews/p6-docs-claude-rereview.md`
- Initial important finding about implying both backend commands always appear was fixed; rereview found no blocker/important findings.

## Verification

- `git diff --check`
- `COREPACK_HOME=/cache/corepack corepack pnpm test`

Base branch is `feature/slash-command-registry-main`.