### PR TITLE
feat(command-registry): add daemon config controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,29 @@ pnpm typecheck     # 仅 tsc --build；不生成 npm bin bundle
       }
     }
   ],
+  "daemon": {
+    "commandRegistry": {
+      "registration": {
+        "enabled": true,
+        "applyTimeoutMs": 30000,
+        "retry": {
+          "maxAttempts": 1,
+          "backoffMs": 0
+        }
+      },
+      "aliases": {
+        "singleAgent": {
+          "enabled": true
+        },
+        "legacy": {
+          "replyMode": true
+        }
+      },
+      "textPrefixes": {
+        "newSession": true
+      }
+    }
+  },
   "ui": {
     "toolMessages": "append"
   },
@@ -143,6 +166,11 @@ chmod 600 ~/.agent-nexus/config.json
 - `agents[].claudeCode.permissionLevel`（可选，默认 `default`）：原样传给 Claude Code 子进程的 `--permission-mode`，允许 `default` / `acceptEdits` / `auto` / `bypassPermissions` / `dontAsk` / `plan`
 - `agents[].claudeCode.allowedTools`（可选）：默认 `Read/Grep/Glob/Edit/Write`。**`Bash` 不在默认集**——启用须显式列出，启动会打 warn（参见 [`docs/dev/spec/security/tool-boundary.md`](docs/dev/spec/security/tool-boundary.md)）
 - `agents[].codex.workingDir`（`backend=codex` 时必填）：Codex 默认工作目录，传给 `--cd`
+- `daemon.commandRegistry.registration.enabled`（可选，默认 `true`）：设为 `false` 时不向 Discord apply slash command 注册计划，本地 command dispatch 保持 fail-closed
+- `daemon.commandRegistry.registration.applyTimeoutMs`（可选，默认 `30000`）：slash command 注册 apply 超时
+- `daemon.commandRegistry.aliases.singleAgent.enabled`（可选，默认 `true`）：控制裸 `/new` single-agent slash alias；稳定 `/codex-new` / `/claudecode-new` 不受影响
+- `daemon.commandRegistry.aliases.legacy.replyMode`（可选，默认 `true`）：控制 legacy `/reply-mode` 是否注册；稳定 `/discord-reply-mode` 不受影响
+- `daemon.commandRegistry.textPrefixes.newSession`（可选，默认 `true`）：控制 `@bot /new` 文本前缀；不影响 slash command
 - `bindings[].platformName` / `agentName`（必填）：把命名 platform bot 绑定到命名 agent
 - `bindings[].match.discord.channelIds`（必填）：该 binding 匹配的 Discord channel/thread id 列表
 - `codex.bin`（可选，默认 `codex`）：Codex CLI 可执行路径
@@ -182,12 +210,12 @@ agent-nexus
 ### 5. 使用
 
 - `@bot <prompt>`：发起一轮 CC 对话；同 `(channelId, userId)` 后续消息复用活跃 session
-- `@bot /new`：清当前 (channel, user) 的内存 session，回复 `[new session ready]`
-- `@bot /new <prompt>`：清 + 立即用 `<prompt>` 起新一轮
+- `@bot /new`：清当前 (channel, user) 的内存 session，回复 `[new session ready]`；可用 `daemon.commandRegistry.textPrefixes.newSession=false` 禁用
+- `@bot /new <prompt>`：清 + 立即用 `<prompt>` 起新一轮；同样受 `textPrefixes.newSession` 控制
 - `/claudecode-new` / `/codex-new`：按绑定到当前频道的 agent owner 清当前会话，回复 `[new session ready]`；只有对应 backend 已配置且在该 Discord 注册 scope 有 binding 时才会出现
-- `/new`：仅在同一个 Discord 注册 scope 里只有一种 agent owner 时作为便捷 alias 出现
+- `/new`：仅在同一个 Discord 注册 scope 里只有一种 agent owner 且 `daemon.commandRegistry.aliases.singleAgent.enabled=true` 时作为便捷 alias 出现
 - `/discord-reply-mode mode:<mention|all>`：在 allowlist 内切换 Discord 消息触发模式
-- `/reply-mode mode:<mention|all>`：legacy alias；迁移期内等价于 `/discord-reply-mode`
+- `/reply-mode mode:<mention|all>`：legacy alias；`daemon.commandRegistry.aliases.legacy.replyMode=true` 时注册
 
 约束：
 

--- a/docs/dev/spec/command-registry.md
+++ b/docs/dev/spec/command-registry.md
@@ -205,6 +205,10 @@ alias 前置条件：
 
 scope 从 single-agent 变为 multi-agent 时，只移除 bare alias；stable name 保持不变。移除 alias 不影响 active stable command dispatch。
 
+`daemon.commandRegistry.aliases.singleAgent.enabled=false` 时，daemon planner
+不生成 single-agent bare alias。该配置只移除 bare alias；stable agent command name
+仍按 §Stable Names 注册。
+
 ## Legacy Names
 
 legacy name 是已经发布过、需要兼容迁移窗口的裸名。legacy name 必须显式写在 descriptor 的 `legacyNames`，同时列入 `CommandNamePolicy.historicalReservedBareNames`。
@@ -220,6 +224,10 @@ legacy name 是已经发布过、需要兼容迁移窗口的裸名。legacy name
 - `/discord-reply-mode` 是 stable name。
 - `/reply-mode` 在迁移窗口内作为 legacy alias 保留。
 - 移除 `/reply-mode` 是破坏性变更；移除后 `reply-mode` 仍保留在 historical reserved bare names，agent alias 不得复用。
+
+`daemon.commandRegistry.aliases.legacy.replyMode=false` 时，registration plan
+不包含 legacy `/reply-mode`，但 `reply-mode` 必须继续留在 `historicalReservedBareNames`，
+避免 agent bare alias 复用历史名字。
 
 ## Registration Scope
 
@@ -325,6 +333,16 @@ CommandRegistrationResult =
 
 daemon 启动或重启时必须重新构建 plan 并 apply；远端 command 可能仍存在，但本地 active map 只有 apply 成功后才恢复。激活成功前该 scope dispatch fail-closed 是预期行为。
 
+运行期配置由 `config-routing.md` 的 `daemon.commandRegistry.registration` 拥有：
+
+- `enabled=false` 时，daemon 不调用 platform registration port，也不从未 apply 的远端状态激活新的 reverse map。
+- `applyTimeoutMs` 超时等同 registration failure，必须记录 `command_registration_failed` 并保留旧 active map。
+- `retry.maxAttempts` / `retry.backoffMs` 只重试 remote apply failure；retry 期间不得部分激活 active map。
+
+`applyTimeoutMs` 不能取消已经发出的 platform native request。运维同时调低 timeout 并提高
+`retry.maxAttempts` 时，远端可能收到重复的 bulk overwrite；本地仍必须只在 matching generation
+成功返回时激活 active map。
+
 平台 native API 如果不提供 all-or-nothing 语义，adapter 必须把任一 planned command 的失败表示为 `status:"failed"`；不得在 partial success 后要求 daemon 激活 next map。Discord adapter 必须使用能表达期望全集的提交方式，例如 bulk overwrite，而不是只增量 create/upsert。
 
 ## Dispatch
@@ -421,6 +439,7 @@ CommandDescriptor {
 | `command_name_collision` | 同 scope 内 command name 冲突 |
 | `command_name_reserved` | alias 或 stable name 命中保留规则 |
 | `command_registration_failed` | 远端注册失败或 partial apply |
+| `command_registration_disabled` | 配置关闭远端注册，daemon 未调用 registration port |
 | `command_activation_generation_mismatch` | registration result generation 与 next plan 不一致 |
 | `command_active_map_missing` | 收到 command event 但 scope 没有 active map |
 | `command_reverse_map_miss` | active map 中没有该 platform-visible name |

--- a/docs/dev/spec/config-routing.md
+++ b/docs/dev/spec/config-routing.md
@@ -13,6 +13,7 @@ related:
   - dev/spec/security/secrets
 contracts:
   - AgentNexusConfig
+  - DaemonRuntimeConfig
   - PlatformConfig
   - AgentConfig
   - PlatformAuthConfig
@@ -39,12 +40,58 @@ AgentNexusConfig {
     platforms: PlatformConfig[]       // 必填，非空
     agents: AgentConfig[]             // 必填，非空
     bindings: PlatformBinding[]       // 必填，非空
+    daemon: DaemonRuntimeConfig?      // daemon-owned operational config
     log: LogConfig?                   // 现有 log 配置，缺省仍为 info
     ui: DaemonConfig?                 // 现有 daemon/ui 配置
 }
 ```
 
 顶层不再使用 `discord`、`agent`、`claudeCode`、`codex` 作为主配置入口。loader 看到这些 legacy 顶层字段时必须按 §Legacy 配置迁移 报错，不得悄悄混用。
+
+## DaemonRuntimeConfig
+
+`daemon` 承载 daemon 拥有的运行期控制面配置。字段由 `@agent-nexus/daemon`
+owner parser 校验并提供默认值；CLI 只能读取、持久化默认模板并把解析结果传给 daemon owner
+实现，不得在 CLI 内重新解释命名策略或 dispatch 语义。
+
+```text
+DaemonRuntimeConfig {
+    commandRegistry: DaemonCommandRegistryConfig
+}
+
+DaemonCommandRegistryConfig {
+    registration: {
+        enabled: boolean              // 缺省 true
+        applyTimeoutMs: integer       // 缺省 30000，必须 > 0
+        retry: {
+            maxAttempts: integer      // 缺省 1，必须 >= 1
+            backoffMs: integer        // 缺省 0，必须 >= 0
+        }
+    }
+    aliases: {
+        singleAgent: {
+            enabled: boolean          // 缺省 true
+        }
+        legacy: {
+            replyMode: boolean        // 缺省 true
+        }
+    }
+    textPrefixes: {
+        newSession: boolean           // 缺省 true
+    }
+}
+```
+
+字段语义：
+
+| 字段 | 规则 |
+|---|---|
+| `daemon.commandRegistry.registration.enabled` | `false` 时不向远端 apply registration plan；由于没有持久化 active map，command dispatch 保持 fail-closed |
+| `daemon.commandRegistry.registration.applyTimeoutMs` | daemon 调用 platform `CommandRegistrationPort.applyCommandPlan` 的超时上限；timeout 等价 registration failure，保留旧 active map |
+| `daemon.commandRegistry.registration.retry.maxAttempts` / `backoffMs` | daemon 启动时 apply plan 的重试策略；只有 generation 匹配的成功结果能激活 active map |
+| `daemon.commandRegistry.aliases.singleAgent.enabled` | 控制 single-agent bare alias（如 `/new`）是否进入 plan；stable `/codex-new` / `/claudecode-new` 不受影响 |
+| `daemon.commandRegistry.aliases.legacy.replyMode` | 控制 legacy `/reply-mode` 是否进入 plan；`reply-mode` 仍保留为 historical reserved bare name |
+| `daemon.commandRegistry.textPrefixes.newSession` | 控制文本前缀 `@bot /new` / `@bot /new <prompt>`；不影响 slash command stable names |
 
 ## PlatformConfig
 

--- a/docs/ops/runbook.md
+++ b/docs/ops/runbook.md
@@ -62,7 +62,7 @@ agent-nexus
 
 首次运行会创建前两个文件的模板 / 空文件，但不会替你填真实 bot id、allowlist、working directory 或 token。
 
-`config.json` 变更后需要重启进程。`discord.json` 由 `/discord-reply-mode` 或 legacy `/reply-mode` 写入，通常不手动改。
+`config.json` 变更后需要重启进程。`daemon.commandRegistry.*` 控制 slash command 注册、alias 与 `@bot /new` 文本前缀；`discord.json` 由 `/discord-reply-mode` 或 legacy `/reply-mode` 写入，通常不手动改。
 
 ## 常见故障
 
@@ -74,8 +74,8 @@ agent-nexus
 | `cc_compat_probe_failed` | 先跑 `claude --version`；确认 Claude Code 已登录，且当前版本支持长驻 `stream-json` 与工具权限检查 |
 | `agent_compat_probe_failed` 且 `agentBackend=codex` | 先跑 `codex --version`；确认 Codex CLI 已登录；再跑 `scripts/verify-codex-agent.sh` 看 resume、错误或中断验证失败原因 |
 | Discord 里无响应 | 确认 `platforms[].auth.allowlist` 包含发送者 user id 或 role；确认当前频道命中某条 `bindings[].match.discord.channelIds`；默认模式下确认消息显式 @bot |
-| `/discord-reply-mode` / `/reply-mode` 不出现 | 开发时配置 `platforms[].testGuildId`，避免全局 slash command 缓存延迟；确认 bot 邀请包含 `applications.commands` scope |
-| `/codex-new` / `/claudecode-new` 不出现 | 确认对应 backend 的 agent 已配置，且当前 platform 至少有一条 binding 指向该 agent；裸 `/new` 只在同一注册 scope 只有一种 agent owner 时出现 |
+| `/discord-reply-mode` / `/reply-mode` 不出现 | 开发时配置 `platforms[].testGuildId`，避免全局 slash command 缓存延迟；确认 bot 邀请包含 `applications.commands` scope；确认 `daemon.commandRegistry.registration.enabled=true`；legacy `/reply-mode` 还要求 `daemon.commandRegistry.aliases.legacy.replyMode=true` |
+| `/codex-new` / `/claudecode-new` 不出现 | 确认对应 backend 的 agent 已配置，且当前 platform 至少有一条 binding 指向该 agent；裸 `/new` 只在同一注册 scope 只有一种 agent owner 且 `daemon.commandRegistry.aliases.singleAgent.enabled=true` 时出现 |
 | bot 回复自己或循环 | 检查 `platforms[].botUserId` 是否等于实际 bot user id；启动日志中不应出现 `discord_bot_user_id_mismatch` |
 
 ## 升级

--- a/docs/product/faq.md
+++ b/docs/product/faq.md
@@ -58,7 +58,7 @@ Codex CLI 当前没有 Claude Code 那种执行前工具审批。它的边界来
 
 ## 为什么看不到 `/new`？
 
-`/codex-new` 和 `/claudecode-new` 是稳定的 agent slash command 名称。每个 `-new` 命令只在对应 backend 已配置且在该 Discord 注册 scope 有 binding 时注册；只启用一个 backend 时只会看到对应的那一个。裸 `/new` 只在同一个 Discord 注册 scope 里只有一种 agent owner 时注册；如果同一个 scope 同时暴露 Codex 和 Claude Code，系统不会注册 `/new`，避免用户看不出会路由到哪个 backend。
+`/codex-new` 和 `/claudecode-new` 是稳定的 agent slash command 名称。每个 `-new` 命令只在对应 backend 已配置且在该 Discord 注册 scope 有 binding 时注册；只启用一个 backend 时只会看到对应的那一个。裸 `/new` 只在同一个 Discord 注册 scope 里只有一种 agent owner 且 `daemon.commandRegistry.aliases.singleAgent.enabled=true` 时注册；如果同一个 scope 同时暴露 Codex 和 Claude Code，系统不会注册 `/new`，避免用户看不出会路由到哪个 backend。
 
 ## 数据和密钥放在哪里？
 

--- a/docs/product/platforms/discord.md
+++ b/docs/product/platforms/discord.md
@@ -32,8 +32,8 @@ related:
 - portal 里 `Bot Token` 已生成并可用
 - `MESSAGE CONTENT INTENT` 已开启
 - 用 `@bot ping` 能收到响应
-- slash command 列表里能看到 `/discord-reply-mode`，迁移期内还会看到 legacy `/reply-mode`
-- slash command 列表里能看到已绑定 backend 对应的 `/claudecode-new` 或 `/codex-new`
+- slash command 列表里能看到 `/discord-reply-mode`；`daemon.commandRegistry.aliases.legacy.replyMode=true` 时还会看到 legacy `/reply-mode`
+- slash command 列表里能看到已绑定 backend 对应的 `/claudecode-new` 或 `/codex-new`；单 agent scope 且 `daemon.commandRegistry.aliases.singleAgent.enabled=true` 时还会看到裸 `/new`
 
 ## 参考
 

--- a/docs/product/user-guide.md
+++ b/docs/product/user-guide.md
@@ -92,6 +92,29 @@ npm install -g packages/cli/agent-nexus-cli-*.tgz
       }
     }
   ],
+  "daemon": {
+    "commandRegistry": {
+      "registration": {
+        "enabled": true,
+        "applyTimeoutMs": 30000,
+        "retry": {
+          "maxAttempts": 1,
+          "backoffMs": 0
+        }
+      },
+      "aliases": {
+        "singleAgent": {
+          "enabled": true
+        },
+        "legacy": {
+          "replyMode": true
+        }
+      },
+      "textPrefixes": {
+        "newSession": true
+      }
+    }
+  },
   "ui": {
     "toolMessages": "append"
   },
@@ -133,6 +156,12 @@ chmod 600 ~/.agent-nexus/config.json
 | `bindings[].platformName` | 是 | 引用 `platforms[].name` |
 | `bindings[].agentName` | 是 | 引用 `agents[].name` |
 | `bindings[].match.discord.channelIds` | 是 | 该 binding 匹配的 Discord channel/thread id 列表 |
+| `daemon.commandRegistry.registration.enabled` | 否 | 默认 `true`；设为 `false` 时不 apply 远端 slash command 注册计划，本地 command dispatch 保持 fail-closed |
+| `daemon.commandRegistry.registration.applyTimeoutMs` | 否 | 默认 `30000`；注册计划 apply 超时毫秒数 |
+| `daemon.commandRegistry.registration.retry.maxAttempts` / `backoffMs` | 否 | 默认 `1` / `0`；启动时注册计划 apply 的重试策略 |
+| `daemon.commandRegistry.aliases.singleAgent.enabled` | 否 | 默认 `true`；控制裸 `/new` single-agent slash alias，不影响 `/codex-new` / `/claudecode-new` |
+| `daemon.commandRegistry.aliases.legacy.replyMode` | 否 | 默认 `true`；控制 legacy `/reply-mode` 是否注册，不影响 `/discord-reply-mode` |
+| `daemon.commandRegistry.textPrefixes.newSession` | 否 | 默认 `true`；控制 `@bot /new` 文本前缀，不影响 slash command |
 | `ui.toolMessages` | 否 | 默认 `append`；工具调用追加为独立消息并在结果到达时编辑该工具消息。设为 `compact` 可回到旧式紧凑显示 |
 | `log.level` | 否 | `trace` / `debug` / `info` / `warn` / `error` / `fatal`，默认 `info` |
 
@@ -266,7 +295,7 @@ agent-nexus
 /codex-new       # 配置并绑定 Codex backend 时出现
 ```
 
-`/claudecode-new` 和 `/codex-new` 是 agent slash command 的稳定名称，按当前频道 binding 路由到对应 backend。每个 `-new` 命令只在对应 backend 已配置且在该 Discord 注册 scope 有 binding 时注册；只启用一个 backend 时只会看到对应的那一个。`/new` 只有在同一个 Discord 注册 scope 里只有一种 agent owner 时才会作为 slash command alias 出现；多 backend 共用同一个 scope 时不会注册裸 `/new`，避免歧义。`@bot /new <prompt>` 仍是文本前缀形式，可以在重置后立即带 prompt 开新一轮。
+`/claudecode-new` 和 `/codex-new` 是 agent slash command 的稳定名称，按当前频道 binding 路由到对应 backend。每个 `-new` 命令只在对应 backend 已配置且在该 Discord 注册 scope 有 binding 时注册；只启用一个 backend 时只会看到对应的那一个。`/new` 只有在同一个 Discord 注册 scope 里只有一种 agent owner 且 `daemon.commandRegistry.aliases.singleAgent.enabled=true` 时才会作为 slash command alias 出现；多 backend 共用同一个 scope 时不会注册裸 `/new`，避免歧义。`@bot /new <prompt>` 是文本前缀形式，可以在重置后立即带 prompt 开新一轮；可用 `daemon.commandRegistry.textPrefixes.newSession=false` 禁用。
 
 切换触发模式：
 
@@ -277,7 +306,7 @@ agent-nexus
 /reply-mode mode:all
 ```
 
-`/discord-reply-mode` 是稳定名称；`/reply-mode` 是迁移期 legacy alias。
+`/discord-reply-mode` 是稳定名称；`/reply-mode` 是迁移期 legacy alias，可用 `daemon.commandRegistry.aliases.legacy.replyMode=false` 停止注册。
 
 `all` 模式只影响消息触发条件，不绕过 `allowedUserIds`。不在 allowlist 里的用户仍不能驱动 bot。
 

--- a/packages/cli/src/command-registry.test.ts
+++ b/packages/cli/src/command-registry.test.ts
@@ -73,6 +73,20 @@ function baseConfig(overrides: Partial<AgentNexusConfig> = {}): AgentNexusConfig
         match: { discord: { channelIds: ['C1'] } },
       },
     ],
+    daemon: {
+      commandRegistry: {
+        registration: {
+          enabled: true,
+          applyTimeoutMs: 30000,
+          retry: { maxAttempts: 1, backoffMs: 0 },
+        },
+        aliases: {
+          singleAgent: { enabled: true },
+          legacy: { replyMode: true },
+        },
+        textPrefixes: { newSession: true },
+      },
+    },
     ui: { toolMessages: 'append' },
     log: { level: 'info' },
     ...overrides,
@@ -202,6 +216,60 @@ describe('buildCliCommandRegistrationPlan', () => {
       kind: 'guild',
       guildId: 'GUILD123',
     });
+  });
+
+  it('daemon config can disable the bare single-agent /new alias without removing stable names', () => {
+    const plan = buildCliCommandRegistrationPlan({
+      config: baseConfig({
+        daemon: {
+          ...baseConfig().daemon,
+          commandRegistry: {
+            ...baseConfig().daemon.commandRegistry,
+            aliases: {
+              ...baseConfig().daemon.commandRegistry.aliases,
+              singleAgent: { enabled: false },
+            },
+          },
+        },
+      }),
+      platformName: 'discord-main',
+      capabilities,
+      generation: 'g-alias-off',
+    });
+
+    expect(commandKeys(plan)).toEqual([
+      'discord-reply-mode:platform:discord:reply-mode:stable',
+      'codex-new:agent:codex:new:stable',
+      'reply-mode:platform:discord:reply-mode:legacy',
+    ]);
+    expect(plan.reverseMap.entries).not.toHaveProperty('new');
+  });
+
+  it('daemon config can disable legacy /reply-mode while keeping the stable replacement', () => {
+    const plan = buildCliCommandRegistrationPlan({
+      config: baseConfig({
+        daemon: {
+          ...baseConfig().daemon,
+          commandRegistry: {
+            ...baseConfig().daemon.commandRegistry,
+            aliases: {
+              ...baseConfig().daemon.commandRegistry.aliases,
+              legacy: { replyMode: false },
+            },
+          },
+        },
+      }),
+      platformName: 'discord-main',
+      capabilities,
+      generation: 'g-legacy-off',
+    });
+
+    expect(commandKeys(plan)).toEqual([
+      'discord-reply-mode:platform:discord:reply-mode:stable',
+      'codex-new:agent:codex:new:stable',
+      'new:agent:codex:new:single-agent-alias',
+    ]);
+    expect(plan.reverseMap.entries).not.toHaveProperty('reply-mode');
   });
 
   it('fails clearly when the requested platform is absent', () => {

--- a/packages/cli/src/command-registry.ts
+++ b/packages/cli/src/command-registry.ts
@@ -97,5 +97,9 @@ export function buildCliCommandRegistrationPlan(
     policy: DEFAULT_COMMAND_NAME_POLICY,
     agentOwnersInScope: agentOwnersForPlatform(input.config, platform.name),
     generation: input.generation,
+    singleAgentAliasesEnabled:
+      input.config.daemon.commandRegistry.aliases.singleAgent.enabled,
+    legacyReplyModeEnabled:
+      input.config.daemon.commandRegistry.aliases.legacy.replyMode,
   });
 }

--- a/packages/cli/src/config.test.ts
+++ b/packages/cli/src/config.test.ts
@@ -120,6 +120,9 @@ describe('config loader', () => {
     expect(configText).toMatch(/"channelIds"/);
     expect(configText).toMatch(/"auth"/);
     expect(configText).toMatch(/"allowlist"/);
+    expect(configText).toMatch(/"daemon"/);
+    expect(configText).toMatch(/"commandRegistry"/);
+    expect(configText).toMatch(/"applyTimeoutMs": 30000/);
     expect(configText).not.toMatch(/"agent"\s*:/);
     expect(
       Object.prototype.hasOwnProperty.call(JSON.parse(configText), 'discord'),
@@ -175,7 +178,80 @@ describe('config loader', () => {
       },
     ]);
     expect(cfg.ui.toolMessages).toBe('compact');
+    expect(cfg.daemon.commandRegistry.registration.enabled).toBe(true);
+    expect(cfg.daemon.commandRegistry.registration.applyTimeoutMs).toBe(30000);
+    expect(cfg.daemon.commandRegistry.aliases.singleAgent.enabled).toBe(true);
+    expect(cfg.daemon.commandRegistry.aliases.legacy.replyMode).toBe(true);
+    expect(cfg.daemon.commandRegistry.textPrefixes.newSession).toBe(true);
     expect(cfg.log.level).toBe('debug');
+  });
+
+  it('loadConfig 会把缺失的 daemon.commandRegistry 默认配置补回 config.json', async () => {
+    const path = join(tmp, '.agent-nexus', 'config.json');
+    await writeFile(path, JSON.stringify(validConfig()));
+
+    const cfg = await loadConfig();
+    const persisted = JSON.parse(await readFile(path, 'utf8')) as Record<string, unknown>;
+
+    expect(cfg.daemon.commandRegistry.registration.applyTimeoutMs).toBe(30000);
+    expect(persisted).toMatchObject({
+      daemon: {
+        commandRegistry: {
+          registration: {
+            enabled: true,
+            applyTimeoutMs: 30000,
+            retry: {
+              maxAttempts: 1,
+              backoffMs: 0,
+            },
+          },
+          aliases: {
+            singleAgent: { enabled: true },
+            legacy: { replyMode: true },
+          },
+          textPrefixes: { newSession: true },
+        },
+      },
+    });
+  });
+
+  it('loadConfig 解析显式 daemon.commandRegistry 配置', async () => {
+    await writeFile(
+      join(tmp, '.agent-nexus', 'config.json'),
+      JSON.stringify(
+        validConfig({
+          daemon: {
+            commandRegistry: {
+              registration: {
+                enabled: false,
+                applyTimeoutMs: 5000,
+                retry: { maxAttempts: 2, backoffMs: 10 },
+              },
+              aliases: {
+                singleAgent: { enabled: false },
+                legacy: { replyMode: false },
+              },
+              textPrefixes: { newSession: false },
+            },
+          },
+        }),
+      ),
+    );
+
+    const cfg = await loadConfig();
+
+    expect(cfg.daemon.commandRegistry).toEqual({
+      registration: {
+        enabled: false,
+        applyTimeoutMs: 5000,
+        retry: { maxAttempts: 2, backoffMs: 10 },
+      },
+      aliases: {
+        singleAgent: { enabled: false },
+        legacy: { replyMode: false },
+      },
+      textPrefixes: { newSession: false },
+    });
   });
 
   it('legacy 顶层字段被清晰拒绝，不做自动迁移', async () => {

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -19,9 +19,12 @@ import {
   CodexConfigError,
 } from '@agent-nexus/agent-codex';
 import {
+  DEFAULT_DAEMON_RUNTIME_CONFIG,
   parseDaemonConfig,
+  parseDaemonRuntimeConfig,
   parsePlatformAuthConfig,
   type DaemonConfig,
+  type DaemonRuntimeConfig,
   type PlatformAuthConfig,
   DaemonConfigError,
 } from '@agent-nexus/daemon';
@@ -58,6 +61,7 @@ export interface AgentNexusConfig {
   platforms: PlatformConfig[];
   agents: AgentConfig[];
   bindings: BindingConfig[];
+  daemon: DaemonRuntimeConfig;
   ui: DaemonConfig;
   log: {
     level: LogLevel;
@@ -184,6 +188,29 @@ const DEFAULT_CONFIG_TEMPLATE = `\
       }
     }
   ],
+  "daemon": {
+    "commandRegistry": {
+      "registration": {
+        "enabled": true,
+        "applyTimeoutMs": 30000,
+        "retry": {
+          "maxAttempts": 1,
+          "backoffMs": 0
+        }
+      },
+      "aliases": {
+        "singleAgent": {
+          "enabled": true
+        },
+        "legacy": {
+          "replyMode": true
+        }
+      },
+      "textPrefixes": {
+        "newSession": true
+      }
+    }
+  },
   "log": {
     "_levelComment": "allowed: trace, debug, info, warn, error, fatal",
     "level": "info"
@@ -231,6 +258,44 @@ function assertNoUnknownKeys(
       throw new ConfigError(`未知字段 ${path}.${key}`);
     }
   }
+}
+
+function cloneDefaultDaemonConfig(): DaemonRuntimeConfig {
+  return JSON.parse(JSON.stringify(DEFAULT_DAEMON_RUNTIME_CONFIG)) as DaemonRuntimeConfig;
+}
+
+function mergeMissingObjectFields(
+  target: Record<string, unknown>,
+  defaults: Record<string, unknown>,
+): boolean {
+  let changed = false;
+  for (const [key, defaultValue] of Object.entries(defaults)) {
+    if (!(key in target)) {
+      target[key] = defaultValue;
+      changed = true;
+      continue;
+    }
+    if (isRecord(target[key]) && isRecord(defaultValue)) {
+      changed = mergeMissingObjectFields(
+        target[key] as Record<string, unknown>,
+        defaultValue,
+      ) || changed;
+    }
+  }
+  return changed;
+}
+
+function applyTemplateDefaultsIfMissing(
+  parsed: Record<string, unknown>,
+): boolean {
+  return mergeMissingObjectFields(parsed, {
+    daemon: cloneDefaultDaemonConfig(),
+  });
+}
+
+async function persistConfig(path: string, parsed: Record<string, unknown>): Promise<void> {
+  await writeFile(path, `${JSON.stringify(parsed, null, 2)}\n`);
+  await chmod(path, 0o600);
 }
 
 async function createFileIfMissing(
@@ -512,7 +577,8 @@ export async function loadConfig(): Promise<AgentNexusConfig> {
     throw new ConfigError(`${path} 顶层必须是对象`);
   }
   rejectLegacyTopLevel(path, parsed);
-  assertNoUnknownKeys(parsed, ['platforms', 'agents', 'bindings', 'log', 'ui'], path);
+  assertNoUnknownKeys(parsed, ['platforms', 'agents', 'bindings', 'daemon', 'log', 'ui'], path);
+  const templateDefaultsChanged = applyTemplateDefaultsIfMissing(parsed);
 
   const platformsRaw = assertArray(parsed, 'platforms', path);
   const agentsRaw = assertArray(parsed, 'agents', path);
@@ -555,8 +621,10 @@ export async function loadConfig(): Promise<AgentNexusConfig> {
   assertAgentReferences(bindings, agents);
 
   let ui: DaemonConfig;
+  let daemon: DaemonRuntimeConfig;
   try {
     ui = parseDaemonConfig(parsed['ui']);
+    daemon = parseDaemonRuntimeConfig(parsed['daemon']);
   } catch (err) {
     if (err instanceof DaemonConfigError) {
       throw new ConfigError(`${path} ${err.message}`);
@@ -564,10 +632,20 @@ export async function loadConfig(): Promise<AgentNexusConfig> {
     throw err;
   }
 
+  if (templateDefaultsChanged) {
+    try {
+      await persistConfig(path, parsed);
+    } catch {
+      // Parsed defaults are already applied in memory; a read-only config file
+      // must not make an otherwise valid legacy config fail to start.
+    }
+  }
+
   return {
     platforms,
     agents,
     bindings,
+    daemon,
     ui,
     log: parseLog(parsed['log']),
   };

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -134,6 +134,7 @@ async function main(): Promise<void> {
       capabilities: DISCORD_CAPABILITIES,
       generation: `${platformConfig.name}:${Date.now()}`,
     });
+    const commandRegistrationConfig = config.daemon.commandRegistry.registration;
     const platform = createDiscordPlatform({
       token,
       botUserId: platformConfig.botUserId,
@@ -149,6 +150,9 @@ async function main(): Promise<void> {
             port,
             logger,
             activatedAt: new Date(),
+            enabled: commandRegistrationConfig.enabled,
+            timeoutMs: commandRegistrationConfig.applyTimeoutMs,
+            retry: commandRegistrationConfig.retry,
           }),
       },
     });
@@ -166,6 +170,9 @@ async function main(): Promise<void> {
         sessionStore,
         toolMessages: {
           mode: config.ui.toolMessages,
+        },
+        textPrefixes: {
+          newSession: config.daemon.commandRegistry.textPrefixes.newSession,
         },
       }),
     );

--- a/packages/daemon/src/command-registry.test.ts
+++ b/packages/daemon/src/command-registry.test.ts
@@ -173,9 +173,63 @@ describe('buildCommandRegistrationPlan', () => {
     ]);
     expect(multi.reverseMap.entries['new']).toBeUndefined();
   });
+
+  it('can disable single-agent alias generation while keeping stable names', () => {
+    const plan = buildCommandRegistrationPlan({
+      descriptors: [agentCommand('codex', 'new')],
+      scope,
+      capabilities: caps,
+      policy: DEFAULT_COMMAND_NAME_POLICY,
+      agentOwnersInScope: ['codex'],
+      generation: 'g1',
+      singleAgentAliasesEnabled: false,
+    });
+
+    expect(plan.commands.map((command) => command.commandName)).toEqual([
+      'codex-new',
+    ]);
+    expect(plan.reverseMap.entries).not.toHaveProperty('new');
+  });
 });
 
 describe('ActiveCommandRegistry', () => {
+  it('does not call the registration port or activate a map when registration is disabled', async () => {
+    const plan = buildCommandRegistrationPlan({
+      descriptors: [agentCommand('codex', 'new')],
+      scope,
+      capabilities: caps,
+      policy: DEFAULT_COMMAND_NAME_POLICY,
+      agentOwnersInScope: ['codex'],
+      generation: 'g-disabled',
+    });
+    const registry = new ActiveCommandRegistry();
+    const logger = { error: vi.fn(), warn: vi.fn() };
+    const port = { applyCommandPlan: vi.fn(async () => ({ status: 'applied' as const, generation: 'g-disabled' })) };
+
+    const result = await registry.applyRegistrationPlan(plan, {
+      enabled: false,
+      logger,
+      port,
+      activatedAt: new Date(0),
+    });
+
+    expect(result).toEqual({
+      status: 'failed',
+      error: {
+        code: 'command_registration_disabled',
+        message: 'command registration disabled by config',
+      },
+    });
+    expect(port.applyCommandPlan).not.toHaveBeenCalled();
+    expect(() => registry.resolve(scope, 'codex-new')).toThrow(
+      CommandRegistryError,
+    );
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ generation: 'g-disabled' }),
+      'command_registration_disabled',
+    );
+  });
+
   it('fails closed when a command name misses the active reverse map', () => {
     const plan = buildCommandRegistrationPlan({
       descriptors: [agentCommand('codex', 'new')],
@@ -315,6 +369,89 @@ describe('ActiveCommandRegistry', () => {
       }),
       'command_activation_generation_mismatch',
     );
+  });
+
+  it('treats registration timeout as failure and preserves the previous active map', async () => {
+    const initial = buildCommandRegistrationPlan({
+      descriptors: [agentCommand('codex', 'new')],
+      scope,
+      capabilities: caps,
+      policy: DEFAULT_COMMAND_NAME_POLICY,
+      agentOwnersInScope: ['codex'],
+      generation: 'g1',
+    });
+    const next = buildCommandRegistrationPlan({
+      descriptors: [agentCommand('claudecode', 'new')],
+      scope,
+      capabilities: caps,
+      policy: DEFAULT_COMMAND_NAME_POLICY,
+      agentOwnersInScope: ['claudecode'],
+      generation: 'g2',
+    });
+    const registry = new ActiveCommandRegistry();
+    registry.activate(initial, new Date(0));
+    const logger = { error: vi.fn() };
+
+    const result = await registry.applyRegistrationPlan(next, {
+      logger,
+      port: { applyCommandPlan: vi.fn(() => new Promise(() => {})) },
+      activatedAt: new Date(1),
+      timeoutMs: 1,
+    });
+
+    expect(result).toMatchObject({
+      status: 'failed',
+      error: { code: 'command_registration_failed' },
+    });
+    expect(registry.resolve(scope, 'codex-new')).toMatchObject({
+      canonicalId: 'agent:codex:new',
+    });
+    expect(() => registry.resolve(scope, 'claudecode-new')).toThrow(
+      CommandRegistryError,
+    );
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        generation: 'g2',
+        error: {
+          code: 'command_registration_failed',
+          message: 'command registration timed out',
+        },
+      }),
+      'command_registration_failed',
+    );
+  });
+
+  it('retries remote registration failures before activating the matching generation', async () => {
+    const plan = buildCommandRegistrationPlan({
+      descriptors: [agentCommand('codex', 'new')],
+      scope,
+      capabilities: caps,
+      policy: DEFAULT_COMMAND_NAME_POLICY,
+      agentOwnersInScope: ['codex'],
+      generation: 'g1',
+    });
+    const registry = new ActiveCommandRegistry();
+    const logger = { error: vi.fn() };
+    const applyCommandPlan = vi
+      .fn<CommandRegistrationPort['applyCommandPlan']>()
+      .mockResolvedValueOnce({
+        status: 'failed',
+        error: { code: 'command_registration_failed', message: 'remote failed' },
+      })
+      .mockResolvedValueOnce({ status: 'applied', generation: 'g1' });
+
+    const result = await registry.applyRegistrationPlan(plan, {
+      logger,
+      port: { applyCommandPlan },
+      activatedAt: new Date(1),
+      retry: { maxAttempts: 2, backoffMs: 0 },
+    });
+
+    expect(result).toEqual({ status: 'applied', generation: 'g1' });
+    expect(applyCommandPlan).toHaveBeenCalledTimes(2);
+    expect(registry.resolve(scope, 'codex-new')).toMatchObject({
+      canonicalId: 'agent:codex:new',
+    });
   });
 });
 

--- a/packages/daemon/src/command-registry.ts
+++ b/packages/daemon/src/command-registry.ts
@@ -54,16 +54,25 @@ export interface BuildCommandRegistrationPlanInput {
   policy: CommandNamePolicy;
   agentOwnersInScope: readonly string[];
   generation: string;
+  singleAgentAliasesEnabled?: boolean;
+  legacyReplyModeEnabled?: boolean;
 }
 
 export interface CommandRegistryLogger {
   error(obj: Record<string, unknown>, msg: string): void;
+  warn?(obj: Record<string, unknown>, msg: string): void;
 }
 
 export interface ApplyRegistrationPlanOptions {
   port: CommandRegistrationPort;
   activatedAt: Date;
   logger?: CommandRegistryLogger;
+  enabled?: boolean;
+  timeoutMs?: number;
+  retry?: {
+    maxAttempts: number;
+    backoffMs: number;
+  };
 }
 
 interface ParsedCanonicalId {
@@ -371,6 +380,12 @@ export function buildCommandRegistrationPlan(
 
   for (const descriptor of applicable) {
     for (const legacy of descriptor.legacyNames) {
+      if (
+        legacy.name === 'reply-mode' &&
+        input.legacyReplyModeEnabled === false
+      ) {
+        continue;
+      }
       if (!input.policy.historicalReservedBareNames.includes(legacy.name)) {
         throw new CommandRegistryError(
           'command_name_reserved',
@@ -394,6 +409,7 @@ export function buildCommandRegistrationPlan(
 
   for (const descriptor of applicable) {
     if (descriptor.owner.type !== 'agent') continue;
+    if (input.singleAgentAliasesEnabled === false) continue;
     const owners = agentOwnersByLocalName.get(descriptor.localName);
     if (!owners || owners.size !== 1) continue;
 
@@ -439,6 +455,45 @@ function safeRegistrationError(
   };
 }
 
+function sleep(ms: number): Promise<void> {
+  if (ms <= 0) return Promise.resolve();
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function applyPortWithTimeout(
+  port: CommandRegistrationPort,
+  plan: CommandRegistrationPlan,
+  timeoutMs: number | undefined,
+): Promise<CommandRegistrationResult> {
+  const portResult = port.applyCommandPlan(plan).catch((err: unknown) => ({
+    status: 'failed' as const,
+    error: {
+      code: 'command_registration_failed' as const,
+      message: 'command registration port threw',
+      cause: err,
+    },
+  }));
+  if (timeoutMs === undefined) return portResult;
+
+  let timer: NodeJS.Timeout | undefined;
+  const timeoutResult = new Promise<CommandRegistrationResult>((resolve) => {
+    timer = setTimeout(() => {
+      resolve({
+        status: 'failed',
+        error: {
+          code: 'command_registration_failed',
+          message: 'command registration timed out',
+        },
+      });
+    }, timeoutMs);
+  });
+  try {
+    return await Promise.race([portResult, timeoutResult]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
 export class ActiveCommandRegistry {
   private readonly activeMaps = new Map<string, ActiveCommandMap>();
 
@@ -457,18 +512,43 @@ export class ActiveCommandRegistry {
   ): Promise<CommandRegistrationResult> {
     // Caller owns the per-scope single-in-flight guarantee from the spec.
     // This method validates the returned generation for the one plan it applied.
-    let result: CommandRegistrationResult;
-    try {
-      result = await options.port.applyCommandPlan(plan);
-    } catch (err) {
-      result = {
+    if (options.enabled === false) {
+      options.logger?.warn?.(
+        {
+          platformName: plan.scope.platformName,
+          scope: plan.scope.nativeScope,
+          generation: plan.generation,
+        },
+        'command_registration_disabled',
+      );
+      return {
         status: 'failed',
         error: {
-          code: 'command_registration_failed',
-          message: 'command registration port threw',
-          cause: err,
+          code: 'command_registration_disabled',
+          message: 'command registration disabled by config',
         },
       };
+    }
+
+    const retry = options.retry ?? { maxAttempts: 1, backoffMs: 0 };
+    let result: CommandRegistrationResult = {
+      status: 'failed',
+      error: {
+        code: 'command_registration_failed',
+        message: 'command registration not attempted',
+      },
+    };
+
+    for (let attempt = 1; attempt <= retry.maxAttempts; attempt += 1) {
+      result = await applyPortWithTimeout(
+        options.port,
+        plan,
+        options.timeoutMs,
+      );
+      if (result.status === 'applied') break;
+      if (attempt < retry.maxAttempts) {
+        await sleep(retry.backoffMs);
+      }
     }
 
     if (result.status === 'failed') {

--- a/packages/daemon/src/config.test.ts
+++ b/packages/daemon/src/config.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import {
   DaemonConfigError,
+  DEFAULT_DAEMON_RUNTIME_CONFIG,
   parseDaemonConfig,
+  parseDaemonRuntimeConfig,
   parsePlatformAuthConfig,
 } from './config.js';
 
@@ -22,6 +24,67 @@ describe('daemon config', () => {
     expect(() => parseDaemonConfig({ toolMessages: 'hidden' })).toThrow(
       /ui\.toolMessages/,
     );
+  });
+});
+
+describe('daemon runtime config', () => {
+  it('缺省 commandRegistry 配置保持兼容默认值', () => {
+    expect(parseDaemonRuntimeConfig(undefined)).toEqual(
+      DEFAULT_DAEMON_RUNTIME_CONFIG,
+    );
+    expect(parseDaemonRuntimeConfig({})).toEqual(DEFAULT_DAEMON_RUNTIME_CONFIG);
+  });
+
+  it('解析 commandRegistry 显式配置并补齐未写字段', () => {
+    expect(
+      parseDaemonRuntimeConfig({
+        commandRegistry: {
+          registration: {
+            enabled: false,
+            applyTimeoutMs: 5000,
+            retry: { maxAttempts: 3 },
+          },
+          aliases: {
+            singleAgent: { enabled: false },
+            legacy: { replyMode: false },
+          },
+          textPrefixes: { newSession: false },
+        },
+      }),
+    ).toEqual({
+      commandRegistry: {
+        registration: {
+          enabled: false,
+          applyTimeoutMs: 5000,
+          retry: { maxAttempts: 3, backoffMs: 0 },
+        },
+        aliases: {
+          singleAgent: { enabled: false },
+          legacy: { replyMode: false },
+        },
+        textPrefixes: { newSession: false },
+      },
+    });
+  });
+
+  it('commandRegistry 数值和未知字段 fail-closed', () => {
+    expect(() => parseDaemonRuntimeConfig(5)).toThrow(/字段 daemon 必须是对象/);
+
+    expect(() =>
+      parseDaemonRuntimeConfig({
+        commandRegistry: {
+          registration: { applyTimeoutMs: 0 },
+        },
+      }),
+    ).toThrow(/daemon\.commandRegistry\.registration\.applyTimeoutMs/);
+
+    expect(() =>
+      parseDaemonRuntimeConfig({
+        commandRegistry: {
+          aliases: { singleAgent: { enabled: true, mode: 'auto' } },
+        },
+      }),
+    ).toThrow(/daemon\.commandRegistry\.aliases\.singleAgent\.mode/);
   });
 });
 

--- a/packages/daemon/src/config.ts
+++ b/packages/daemon/src/config.ts
@@ -5,6 +5,58 @@ export interface DaemonConfig {
   toolMessages: ToolMessageMode;
 }
 
+export interface DaemonRegistrationRetryConfig {
+  maxAttempts: number;
+  backoffMs: number;
+}
+
+export interface DaemonCommandRegistryConfig {
+  registration: {
+    enabled: boolean;
+    applyTimeoutMs: number;
+    retry: DaemonRegistrationRetryConfig;
+  };
+  aliases: {
+    singleAgent: {
+      enabled: boolean;
+    };
+    legacy: {
+      replyMode: boolean;
+    };
+  };
+  textPrefixes: {
+    newSession: boolean;
+  };
+}
+
+export interface DaemonRuntimeConfig {
+  commandRegistry: DaemonCommandRegistryConfig;
+}
+
+export const DEFAULT_DAEMON_RUNTIME_CONFIG: DaemonRuntimeConfig = {
+  commandRegistry: {
+    registration: {
+      enabled: true,
+      applyTimeoutMs: 30000,
+      retry: {
+        maxAttempts: 1,
+        backoffMs: 0,
+      },
+    },
+    aliases: {
+      singleAgent: {
+        enabled: true,
+      },
+      legacy: {
+        replyMode: true,
+      },
+    },
+    textPrefixes: {
+      newSession: true,
+    },
+  },
+};
+
 export interface AllowlistConfig {
   userIds: string[];
   roleIds: string[];
@@ -71,6 +123,21 @@ function parseBoolean(
   if (value === undefined) return defaultValue;
   if (typeof value !== 'boolean') {
     throw new DaemonConfigError(`字段 ${path}.${key} 必须是布尔值`);
+  }
+  return value;
+}
+
+function parseInteger(
+  raw: Record<string, unknown>,
+  key: string,
+  path: string,
+  defaultValue: number,
+  min: number,
+): number {
+  const value = raw[key];
+  if (value === undefined) return defaultValue;
+  if (!Number.isInteger(value) || value < min) {
+    throw new DaemonConfigError(`字段 ${path}.${key} 必须是 >= ${min} 的整数`);
   }
   return value;
 }
@@ -152,5 +219,152 @@ export function parseDaemonConfig(raw: unknown): DaemonConfig {
   }
   return {
     toolMessages: (toolMessagesRaw as ToolMessageMode | undefined) ?? 'append',
+  };
+}
+
+export function parseDaemonRuntimeConfig(raw: unknown): DaemonRuntimeConfig {
+  const path = 'daemon';
+  if (raw !== undefined && !isRecord(raw)) {
+    throw new DaemonConfigError(`字段 ${path} 必须是对象`);
+  }
+  const daemon = (raw ?? {}) as Record<string, unknown>;
+  assertNoUnknownKeys(daemon, ['commandRegistry'], path);
+
+  const commandRegistryPath = `${path}.commandRegistry`;
+  const commandRegistry = isRecord(daemon['commandRegistry'])
+    ? daemon['commandRegistry']
+    : {};
+  if (
+    daemon['commandRegistry'] !== undefined &&
+    !isRecord(daemon['commandRegistry'])
+  ) {
+    throw new DaemonConfigError(`字段 ${commandRegistryPath} 必须是对象`);
+  }
+  assertNoUnknownKeys(
+    commandRegistry,
+    ['registration', 'aliases', 'textPrefixes'],
+    commandRegistryPath,
+  );
+
+  const registrationPath = `${commandRegistryPath}.registration`;
+  const registration = isRecord(commandRegistry['registration'])
+    ? commandRegistry['registration']
+    : {};
+  if (
+    commandRegistry['registration'] !== undefined &&
+    !isRecord(commandRegistry['registration'])
+  ) {
+    throw new DaemonConfigError(`字段 ${registrationPath} 必须是对象`);
+  }
+  assertNoUnknownKeys(
+    registration,
+    ['enabled', 'applyTimeoutMs', 'retry'],
+    registrationPath,
+  );
+
+  const retryPath = `${registrationPath}.retry`;
+  const retry = isRecord(registration['retry']) ? registration['retry'] : {};
+  if (registration['retry'] !== undefined && !isRecord(registration['retry'])) {
+    throw new DaemonConfigError(`字段 ${retryPath} 必须是对象`);
+  }
+  assertNoUnknownKeys(retry, ['maxAttempts', 'backoffMs'], retryPath);
+
+  const aliasesPath = `${commandRegistryPath}.aliases`;
+  const aliases = isRecord(commandRegistry['aliases'])
+    ? commandRegistry['aliases']
+    : {};
+  if (commandRegistry['aliases'] !== undefined && !isRecord(commandRegistry['aliases'])) {
+    throw new DaemonConfigError(`字段 ${aliasesPath} 必须是对象`);
+  }
+  assertNoUnknownKeys(aliases, ['singleAgent', 'legacy'], aliasesPath);
+
+  const singleAgentPath = `${aliasesPath}.singleAgent`;
+  const singleAgent = isRecord(aliases['singleAgent'])
+    ? aliases['singleAgent']
+    : {};
+  if (aliases['singleAgent'] !== undefined && !isRecord(aliases['singleAgent'])) {
+    throw new DaemonConfigError(`字段 ${singleAgentPath} 必须是对象`);
+  }
+  assertNoUnknownKeys(singleAgent, ['enabled'], singleAgentPath);
+
+  const legacyPath = `${aliasesPath}.legacy`;
+  const legacy = isRecord(aliases['legacy']) ? aliases['legacy'] : {};
+  if (aliases['legacy'] !== undefined && !isRecord(aliases['legacy'])) {
+    throw new DaemonConfigError(`字段 ${legacyPath} 必须是对象`);
+  }
+  assertNoUnknownKeys(legacy, ['replyMode'], legacyPath);
+
+  const textPrefixesPath = `${commandRegistryPath}.textPrefixes`;
+  const textPrefixes = isRecord(commandRegistry['textPrefixes'])
+    ? commandRegistry['textPrefixes']
+    : {};
+  if (
+    commandRegistry['textPrefixes'] !== undefined &&
+    !isRecord(commandRegistry['textPrefixes'])
+  ) {
+    throw new DaemonConfigError(`字段 ${textPrefixesPath} 必须是对象`);
+  }
+  assertNoUnknownKeys(textPrefixes, ['newSession'], textPrefixesPath);
+
+  return {
+    commandRegistry: {
+      registration: {
+        enabled: parseBoolean(
+          registration,
+          'enabled',
+          registrationPath,
+          DEFAULT_DAEMON_RUNTIME_CONFIG.commandRegistry.registration.enabled,
+        ),
+        applyTimeoutMs: parseInteger(
+          registration,
+          'applyTimeoutMs',
+          registrationPath,
+          DEFAULT_DAEMON_RUNTIME_CONFIG.commandRegistry.registration.applyTimeoutMs,
+          1,
+        ),
+        retry: {
+          maxAttempts: parseInteger(
+            retry,
+            'maxAttempts',
+            retryPath,
+            DEFAULT_DAEMON_RUNTIME_CONFIG.commandRegistry.registration.retry.maxAttempts,
+            1,
+          ),
+          backoffMs: parseInteger(
+            retry,
+            'backoffMs',
+            retryPath,
+            DEFAULT_DAEMON_RUNTIME_CONFIG.commandRegistry.registration.retry.backoffMs,
+            0,
+          ),
+        },
+      },
+      aliases: {
+        singleAgent: {
+          enabled: parseBoolean(
+            singleAgent,
+            'enabled',
+            singleAgentPath,
+            DEFAULT_DAEMON_RUNTIME_CONFIG.commandRegistry.aliases.singleAgent.enabled,
+          ),
+        },
+        legacy: {
+          replyMode: parseBoolean(
+            legacy,
+            'replyMode',
+            legacyPath,
+            DEFAULT_DAEMON_RUNTIME_CONFIG.commandRegistry.aliases.legacy.replyMode,
+          ),
+        },
+      },
+      textPrefixes: {
+        newSession: parseBoolean(
+          textPrefixes,
+          'newSession',
+          textPrefixesPath,
+          DEFAULT_DAEMON_RUNTIME_CONFIG.commandRegistry.textPrefixes.newSession,
+        ),
+      },
+    },
   };
 }

--- a/packages/daemon/src/engine.test.ts
+++ b/packages/daemon/src/engine.test.ts
@@ -495,6 +495,36 @@ describe('Engine', () => {
     expect(out.text).toBe('[new session ready]');
   });
 
+  it('textPrefixes.newSession=false 时 /new 文本按普通 prompt 转给 agent', async () => {
+    const platform = makePlatform();
+    const agent = makeAgent();
+    const store = new SessionStore();
+    const engine = new Engine({
+      platform,
+      agent: agent.runtime,
+      logger: SILENT_LOGGER,
+      sessionStore: store,
+      defaultSessionConfig: DEFAULT_CFG,
+      textPrefixes: { newSession: false },
+    });
+
+    await engine.start();
+    const dispatchHandler = (platform.start as ReturnType<typeof vi.fn>).mock.calls[0]![0] as EventHandler;
+
+    agent.queueEvents([
+      ev('session_started', { agentSessionId: 'sid-new' }),
+      ev('text_final', { text: 'answer' }),
+      ev('turn_finished', { reason: 'stop', turnSequence: 1 }),
+    ]);
+
+    await dispatchHandler(makeEvent('/new'));
+
+    expect(platform.send).toHaveBeenCalledTimes(1);
+    expect(agent.startSession).toHaveBeenCalledTimes(1);
+    expect(agent.sendInput).toHaveBeenCalledTimes(1);
+    expect((agent.sendInput.mock.calls[0]![1] as AgentInput).text).toBe('/new');
+  });
+
   it('同 SessionKey 并发：第二条 dispatch 必须串行在第一条之后，看到首轮 agentSessionId 作 resume', async () => {
     // race regression：两条来自同一频道+同一用户的 @mention 几乎同时到达。
     // 期望：第二条 startSession 的 config.resumeFromAgentSessionId === 首轮的 agentSessionId。

--- a/packages/daemon/src/engine.ts
+++ b/packages/daemon/src/engine.ts
@@ -57,6 +57,9 @@ export interface EngineDeps {
   toolMessages?: {
     mode?: ToolMessageMode;
   };
+  textPrefixes?: {
+    newSession?: boolean;
+  };
 }
 
 const DEFAULT_STREAM_EDIT_THROTTLE_MS = 1500;
@@ -119,6 +122,7 @@ export class Engine {
   private readonly streamEditThrottleMs: number;
   private readonly typingRefreshMs: number;
   private readonly toolMessageMode: ToolMessageMode;
+  private readonly newSessionTextPrefixEnabled: boolean;
   private readonly agentSessions = new Map<string, ActiveAgentSession>();
   /**
    * Per-SessionKey 串行队列：同 key 的 dispatch 必须按到达序排队执行，
@@ -169,6 +173,7 @@ export class Engine {
     this.typingRefreshMs =
       deps.streaming?.typingRefreshMs ?? DEFAULT_TYPING_REFRESH_MS;
     this.toolMessageMode = deps.toolMessages?.mode ?? 'append';
+    this.newSessionTextPrefixEnabled = deps.textPrefixes?.newSession ?? true;
   }
 
   async start(): Promise<void> {
@@ -438,7 +443,10 @@ export class Engine {
       const rawText = event.text ?? '';
       const trimmed = rawText.trim();
       let prompt: string;
-      if (trimmed === '/new' || trimmed.startsWith('/new ')) {
+      if (
+        this.newSessionTextPrefixEnabled &&
+        (trimmed === '/new' || trimmed.startsWith('/new '))
+      ) {
         this.stopActiveSession(sessionKeyStr, event.traceId);
         this.sessionStore.delete(event.sessionKey);
         const remainder = trimmed === '/new' ? '' : trimmed.slice(5).trim();

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -27,11 +27,16 @@ export {
   type DispatchCommandEventInput,
 } from './command-dispatch.js';
 export {
+  DEFAULT_DAEMON_RUNTIME_CONFIG,
   parseDaemonConfig,
+  parseDaemonRuntimeConfig,
   parsePlatformAuthConfig,
   DaemonConfigError,
   type AllowlistConfig,
+  type DaemonCommandRegistryConfig,
   type DaemonConfig,
+  type DaemonRegistrationRetryConfig,
+  type DaemonRuntimeConfig,
   type PlatformAuthConfig,
   type ToolMessageMode,
 } from './config.js';

--- a/packages/platform/discord/src/index.test.ts
+++ b/packages/platform/discord/src/index.test.ts
@@ -288,6 +288,72 @@ describe('command registry integration', () => {
       },
     });
   });
+
+  it('registration plan 未包含 legacy /reply-mode 时把它作为普通 command 事件交给 daemon', async () => {
+    const plan = {
+      scope: {
+        platformName: 'discord-main',
+        platformType: 'discord' as const,
+        nativeScope: { kind: 'global' as const },
+      },
+      commands: [],
+      reverseMap: {
+        entries: {
+          'discord-reply-mode': {
+            canonicalId: 'platform:discord:reply-mode',
+            aliasKind: 'stable' as const,
+            owner: { type: 'platform' as const, platformType: 'discord' },
+            handlerKey: 'reply-mode',
+          },
+        },
+      },
+      generation: 'g-no-legacy',
+    };
+    const platform = createDiscordPlatform({
+      token: 'test-token',
+      botUserId: BOT_ID,
+      logger: makeLogger(),
+      statePath: '/tmp/agent-nexus-discord-state-test.json',
+      allowedUserIds: ALLOWED,
+      commandRegistration: {
+        plan,
+        apply: vi.fn(async () => ({ status: 'applied' as const, generation: 'g-no-legacy' })),
+      },
+    });
+    const handler = vi.fn(async () => undefined);
+    const deferReply = vi.fn(async () => undefined);
+    const deleteReply = vi.fn(async () => undefined);
+    const reply = vi.fn(async () => undefined);
+
+    await platform.start(handler);
+    const interactionCreate = registeredHandler('interactionCreate');
+    await interactionCreate({
+      id: 'i-legacy-off',
+      commandName: 'reply-mode',
+      channelId: 'C1',
+      guildId: 'G-dev',
+      createdAt: new Date(123),
+      user: { id: OTHER_ID, username: 'alice', bot: false },
+      member: { roles: { cache: new Map() } },
+      options: { data: [], getString: vi.fn(() => null) },
+      deferReply,
+      deleteReply,
+      editReply: vi.fn(async () => undefined),
+      reply,
+      isChatInputCommand: () => true,
+    });
+
+    expect(reply).not.toHaveBeenCalled();
+    expect(deferReply).toHaveBeenCalledWith({ ephemeral: true });
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(deleteReply).toHaveBeenCalledTimes(1);
+    expect(handler.mock.calls[0]![0]).toMatchObject({
+      command: {
+        name: 'reply-mode',
+        registrationScope: plan.scope,
+      },
+    });
+  });
 });
 
 function makeTextChannel(overrides: {

--- a/packages/platform/discord/src/index.ts
+++ b/packages/platform/discord/src/index.ts
@@ -252,6 +252,23 @@ function commandScope(testGuildId?: string): CommandRegistrationScope {
   };
 }
 
+function replyModeCommandNames(
+  commandRegistration: DiscordCommandRegistration | undefined,
+): Set<string> {
+  if (!commandRegistration) {
+    return new Set(['reply-mode', 'discord-reply-mode']);
+  }
+  const names = new Set<string>();
+  for (const [name, route] of Object.entries(
+    commandRegistration.plan.reverseMap.entries,
+  )) {
+    if (route.canonicalId === discordReplyModeCommandDescriptor.canonicalId) {
+      names.add(name);
+    }
+  }
+  return names;
+}
+
 function commandEventFromInteraction(
   interaction: ChatInputCommandInteraction,
   scope: CommandRegistrationScope,
@@ -447,6 +464,7 @@ export function createDiscordPlatform(opts: DiscordPlatformOptions): PlatformAda
   let stopped = false;
   // 启动时从 state 文件读，缺省 'mention'。运行时由 /reply-mode 切换更新。
   let replyMode: ReplyMode = 'mention';
+  const replyModeNames = replyModeCommandNames(commandRegistration);
   const editLocks = new WeakMap<MessageRef, Promise<void>>();
 
   const runSerializedEdit = async (
@@ -531,10 +549,7 @@ export function createDiscordPlatform(opts: DiscordPlatformOptions): PlatformAda
 
       client.on('interactionCreate', async (interaction: Interaction) => {
         if (!interaction.isChatInputCommand()) return;
-        if (
-          interaction.commandName !== 'reply-mode' &&
-          interaction.commandName !== 'discord-reply-mode'
-        ) {
+        if (!replyModeNames.has(interaction.commandName)) {
           if (!(await deferCommandInteraction(interaction, logger))) return;
           const event = commandEventFromInteraction(
             interaction,

--- a/packages/protocol/src/command.ts
+++ b/packages/protocol/src/command.ts
@@ -86,6 +86,7 @@ export interface CommandRegistrationPlan {
 
 export type CommandRegistrationErrorCode =
   | 'command_registration_failed'
+  | 'command_registration_disabled'
   | 'command_activation_generation_mismatch';
 
 export interface CommandRegistrationError {


### PR DESCRIPTION
## Summary

- Add persisted `daemon.commandRegistry` config defaults and parsing under `~/.agent-nexus/config.json`.
- Wire registration enablement, timeout/retry, single-agent alias, legacy `/reply-mode`, and text-prefix `/new` controls through daemon-owned behavior.
- Update command registry/config specs, product docs, runbook, and focused regression tests.

## Verification

- `COREPACK_HOME=/cache/corepack corepack pnpm exec tsc --noEmit --pretty false`
- `COREPACK_HOME=/cache/corepack corepack pnpm test`
- `git diff --check`
- Independent Claude review/rereview: no blocker or important findings after fixes.

## Notes

- Base branch is `feature/slash-command-registry-main`.
- Pre-existing untracked package-level `AGENTS.md` / `CLAUDE.md` files are intentionally excluded.