### PR TITLE
fix(command-registry): narrow daemon integer config

### DIFF
--- a/packages/daemon/src/config.ts
+++ b/packages/daemon/src/config.ts
@@ -136,7 +136,7 @@ function parseInteger(
 ): number {
   const value = raw[key];
   if (value === undefined) return defaultValue;
-  if (!Number.isInteger(value) || value < min) {
+  if (typeof value !== 'number' || !Number.isInteger(value) || value < min) {
     throw new DaemonConfigError(`字段 ${path}.${key} 必须是 >= ${min} 的整数`);
   }
   return value;


### PR DESCRIPTION
## Summary

- Fix CI build failure in `parseInteger` by narrowing unknown config values to `number` before integer/range checks.

## Verification

Reproduced the full `.github/workflows/ci.yml` locally on `feature/slash-command-registry-main@8c7227b5`, then reran after the fix:

- `CI=true COREPACK_HOME=/cache/corepack corepack pnpm install --frozen-lockfile`
- `CI=true COREPACK_HOME=/cache/corepack corepack pnpm build`
- `CI=true COREPACK_HOME=/cache/corepack corepack pnpm test`
- `CI=true COREPACK_HOME=/cache/corepack corepack pnpm pack:cli`
- packed CLI smoke test from `ci.yml`
- `git diff --check`

## Note

I will not merge this PR until GitHub CI has actually completed successfully.