### PR TITLE
ci(pr): validate pull request metadata

### DIFF
--- a/.github/workflows/pr-metadata.yml
+++ b/.github/workflows/pr-metadata.yml
@@ -1,0 +1,88 @@
+name: PR Metadata
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+      - ready_for_review
+
+jobs:
+  pr-metadata:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Validate PR title and body
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            if (!pr) {
+              core.setFailed("This workflow must run on pull_request events.");
+              return;
+            }
+
+            const errors = [];
+            const body = pr.body || "";
+
+            const titlePattern = /^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([a-z0-9._-]+\))?!?: .+/;
+            if (!titlePattern.test(pr.title)) {
+              errors.push("PR title must follow Conventional Commits, for example: ci(pr): validate pull request metadata");
+            }
+
+            const requiredSections = [
+              "## Summary",
+              "## Why",
+              "ADR:",
+              "Spec:",
+              "## Test plan",
+              "## Review notes",
+              "## Out of scope",
+            ];
+
+            for (const section of requiredSections) {
+              if (!body.includes(section)) {
+                errors.push(`PR body is missing required template field: ${section}`);
+              }
+            }
+
+            const placeholderPatterns = [
+              /<背景和当前问题[^>]*>/,
+              /<改了什么[^>]*>/,
+              /<为什么要做[^>]*>/,
+              /<链接或 N\/A[^>]*>/,
+              /<测试文件[^>]*>/,
+              /<命令>/,
+              /<真实平台[^>]*>/,
+              /<review log[^>]*>/,
+              /<触发条件[^>]*>/,
+              /<本 PR 明确不做[^>]*>/,
+            ];
+
+            for (const pattern of placeholderPatterns) {
+              if (pattern.test(body)) {
+                errors.push(`PR body still contains template placeholder matching ${pattern}`);
+              }
+            }
+
+            if (!/^- \[[ xX]\] .+/m.test(body)) {
+              errors.push("PR body must include at least one checklist item in the test plan.");
+            }
+
+            const requiredReviewFields = [
+              /^- Independent agent review:\s*\S.+/im,
+              /^- Deep review:\s*\S.+/im,
+            ];
+
+            for (const pattern of requiredReviewFields) {
+              if (!pattern.test(body)) {
+                errors.push(`PR body is missing a filled review field matching ${pattern}`);
+              }
+            }
+
+            if (errors.length > 0) {
+              core.setFailed(["PR metadata validation failed:", ...errors.map((error) => `- ${error}`)].join("\n"));
+            }


### PR DESCRIPTION
## Summary

当前 PR 描述依赖作者手动遵守模板，容易出现标题不符合 Conventional Commits、模板占位符未替换、ADR/spec/test/review 字段缺失等问题。这个 PR 增加一个专门的 PR metadata check，后续可以把它加入仓库 ruleset 的 required checks。

本 PR：
- 新增 `.github/workflows/pr-metadata.yml`。
- 校验 PR 标题是否符合 Conventional Commits。
- 校验 PR 正文是否包含模板必填章节、ADR/spec/test/review 字段。
- 阻止模板占位符原样留在 PR 描述里。

## Why

这是把“必须按 process 和模板写 PR”从人工约定推进到 GitHub Actions 门禁。合入后，需要在仓库 ruleset 里把 `pr-metadata` 加入 required status checks，才会真正阻断 merge。

ADR: N/A - 只新增仓库 CI 元数据检查，不改变架构决策。
Spec: N/A - 不改变运行时接口、协议字段或外部契约。

## Test plan

- [x] Tests: 用本地 Node mock 执行 workflow 内嵌脚本，覆盖合法 PR 通过、非法 PR 失败两条路径。
- [x] `git diff --check -- .github/workflows/pr-metadata.yml` - passed。
- [x] `node <<'NODE' ... NODE` - metadata mock ok。
- [ ] Manual: 合入后打开一个故意不符合模板的 PR，确认 `pr-metadata` check 失败；本 PR 新增的 pull_request workflow 在进入 base branch 前不能作为既有 required check 保护自己。

## Review notes

- Independent agent review: attempted via local `claude -p` using the project `claude-review` flow, but the CLI produced no output and was stopped after hanging; this draft PR should not be merged until an independent review is completed.
- Deep review: N/A - 单一 GitHub Actions workflow，未跨 3+ 文件，未改变架构或运行时契约。

## Out of scope

- 直接更新仓库 ruleset；合入后需要在 GitHub 设置中把 `pr-metadata` 加到所有 branch 的 required checks。
- 修改 PR 模板或 process 文档。
- 合并或修改之前的 feature 分支 PR。