### PR TITLE
ci(pr): guard MCP pull request creation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
           node-version: 20
           cache: pnpm
 
+      - run: node scripts/validate-pr-metadata.mjs --self-test
+
       - run: pnpm install --frozen-lockfile
 
       - run: pnpm build

--- a/.github/workflows/pr-metadata.yml
+++ b/.github/workflows/pr-metadata.yml
@@ -1,7 +1,7 @@
 name: PR Metadata
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - edited
@@ -13,76 +13,13 @@ jobs:
   pr-metadata:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: read
     steps:
-      - name: Validate PR title and body
-        uses: actions/github-script@v7
+      - uses: actions/checkout@v6
         with:
-          script: |
-            const pr = context.payload.pull_request;
-            if (!pr) {
-              core.setFailed("This workflow must run on pull_request events.");
-              return;
-            }
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 1
 
-            const errors = [];
-            const body = pr.body || "";
-
-            const titlePattern = /^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([a-z0-9._-]+\))?!?: .+/;
-            if (!titlePattern.test(pr.title)) {
-              errors.push("PR title must follow Conventional Commits, for example: ci(pr): validate pull request metadata");
-            }
-
-            const requiredSections = [
-              "## Summary",
-              "## Why",
-              "ADR:",
-              "Spec:",
-              "## Test plan",
-              "## Review notes",
-              "## Out of scope",
-            ];
-
-            for (const section of requiredSections) {
-              if (!body.includes(section)) {
-                errors.push(`PR body is missing required template field: ${section}`);
-              }
-            }
-
-            const placeholderPatterns = [
-              /<背景和当前问题[^>]*>/,
-              /<改了什么[^>]*>/,
-              /<为什么要做[^>]*>/,
-              /<链接或 N\/A[^>]*>/,
-              /<测试文件[^>]*>/,
-              /<命令>/,
-              /<真实平台[^>]*>/,
-              /<review log[^>]*>/,
-              /<触发条件[^>]*>/,
-              /<本 PR 明确不做[^>]*>/,
-            ];
-
-            for (const pattern of placeholderPatterns) {
-              if (pattern.test(body)) {
-                errors.push(`PR body still contains template placeholder matching ${pattern}`);
-              }
-            }
-
-            if (!/^- \[[ xX]\] .+/m.test(body)) {
-              errors.push("PR body must include at least one checklist item in the test plan.");
-            }
-
-            const requiredReviewFields = [
-              /^- Independent agent review:\s*\S.+/im,
-              /^- Deep review:\s*\S.+/im,
-            ];
-
-            for (const pattern of requiredReviewFields) {
-              if (!pattern.test(body)) {
-                errors.push(`PR body is missing a filled review field matching ${pattern}`);
-              }
-            }
-
-            if (errors.length > 0) {
-              core.setFailed(["PR metadata validation failed:", ...errors.map((error) => `- ${error}`)].join("\n"));
-            }
+      - name: Validate PR title and body
+        run: node scripts/validate-pr-metadata.mjs --event-path "$GITHUB_EVENT_PATH"

--- a/docs/dev/process/code-review.md
+++ b/docs/dev/process/code-review.md
@@ -30,6 +30,53 @@ related:
 
 PR 描述模板见 [`../standards/code-review.md` §PR 描述合格条件](../standards/code-review.md#pr-描述合格条件)。
 
+## PR metadata 同步校验
+
+GitHub ruleset + `pr-metadata` workflow 是 merge 门禁；它们不能保证 agent 在创建 PR 的那一刻同步感知失败，因为 GitHub Actions 是异步的。支持 PreToolUse hook 的 harness 应在 MCP 创建 PR 前运行仓库脚本：
+
+```bash
+node scripts/validate-pr-metadata.mjs --hook
+```
+
+脚本从 stdin 读取 hook JSON；仅命中 GitHub MCP `create_pull_request` / `update_pull_request` 类工具时校验 `tool_input.title` / `tool_input.body`，其他工具直接放行。校验失败时 exit 2 并在 stderr 输出缺失项，agent 不应继续创建或改坏 PR。
+
+本地 hook 配置不入库。Claude Code 示例：
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "mcp__codex_apps__github._create_pull_request",
+        "hooks": [
+          { "type": "command", "command": "node scripts/validate-pr-metadata.mjs --hook" }
+        ]
+      },
+      {
+        "matcher": "mcp__github__create_pull_request",
+        "hooks": [
+          { "type": "command", "command": "node scripts/validate-pr-metadata.mjs --hook" }
+        ]
+      },
+      {
+        "matcher": "mcp__codex_apps__github._update_pull_request",
+        "hooks": [
+          { "type": "command", "command": "node scripts/validate-pr-metadata.mjs --hook" }
+        ]
+      },
+      {
+        "matcher": "mcp__github__update_pull_request",
+        "hooks": [
+          { "type": "command", "command": "node scripts/validate-pr-metadata.mjs --hook" }
+        ]
+      }
+    ]
+  }
+}
+```
+
+若 harness 的 matcher 不能精确匹配 MCP tool name，可以把该脚本挂到所有 PreToolUse；脚本会自行判断非 PR metadata 写入工具并放行。
+
 ## 作者自查时机
 
 开 PR 前按 [`../standards/code-review.md` §自查清单合格条件](../standards/code-review.md#自查清单合格条件) 走一遍，每项打勾。任一项未达合格不开 PR。

--- a/docs/dev/process/skill-setup.md
+++ b/docs/dev/process/skill-setup.md
@@ -69,6 +69,15 @@ ln -sfn "../../skills/<name>" ".claude/skills/<name>"
 
 规则本身以 `docs/dev/process/` 下的权威源为准，skill 只是执行器。
 
+## Hook setup
+
+Hook 配置同样属于本地 harness 配置，不入库。clone 后除 skill 挂接外，支持 PreToolUse 的 harness 应按对应流程挂接仓库守卫脚本：
+
+- 文档读取防污染：`scripts/pretool-read-guard`，配置见 [`docs-read.md` §pretool-read-guard hook](docs-read.md#pretool-read-guard-hook)
+- PR metadata 同步校验：`node scripts/validate-pr-metadata.mjs --hook`，配置见 [`code-review.md` §PR metadata 同步校验](code-review.md#pr-metadata-同步校验)
+
+这两类 hook 的目的不同：前者避免 agent 读取非权威文档后污染决策，后者避免 agent 通过 MCP 创建不符合模板的 PR 后只把 URL 丢给用户。
+
 ## 未挂接的后果
 
 ⚠️ **未挂接 → 协作 skill 静默不触发 → 协作产出格式漂移**。

--- a/scripts/validate-pr-metadata.mjs
+++ b/scripts/validate-pr-metadata.mjs
@@ -1,0 +1,325 @@
+#!/usr/bin/env node
+
+const titlePattern =
+  /^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([a-z0-9._-]+\))?!?: .+/;
+
+const requiredSections = [
+  '## Summary',
+  '## Why',
+  'ADR:',
+  'Spec:',
+  '## Test plan',
+  '## Review notes',
+  '## Out of scope',
+];
+
+const placeholderPatterns = [
+  /<背景和当前问题[^>]*>/,
+  /<改了什么[^>]*>/,
+  /<为什么要做[^>]*>/,
+  /<链接或 N\/A[^>]*>/,
+  /<测试文件[^>]*>/,
+  /<命令>/,
+  /<真实平台[^>]*>/,
+  /<review log[^>]*>/,
+  /<触发条件[^>]*>/,
+  /<本 PR 明确不做[^>]*>/,
+];
+
+const requiredReviewFields = [
+  /^- Independent agent review:\s*\S.+/im,
+  /^- Deep review:\s*\S.+/im,
+];
+
+function validatePrTitle(title) {
+  const normalizedTitle = typeof title === 'string' ? title : '';
+  if (titlePattern.test(normalizedTitle)) {
+    return [];
+  }
+
+  return [
+    'PR title must follow Conventional Commits, for example: ci(pr): validate pull request metadata',
+  ];
+}
+
+function validatePrBody(body) {
+  const errors = [];
+  const normalizedBody = typeof body === 'string' ? body : '';
+
+  for (const section of requiredSections) {
+    if (!normalizedBody.includes(section)) {
+      errors.push(`PR body is missing required template field: ${section}`);
+    }
+  }
+
+  for (const pattern of placeholderPatterns) {
+    if (pattern.test(normalizedBody)) {
+      errors.push(`PR body still contains template placeholder matching ${pattern}`);
+    }
+  }
+
+  if (!/^- \[[ xX]\] .+/m.test(normalizedBody)) {
+    errors.push('PR body must include at least one checklist item in the test plan.');
+  }
+
+  for (const pattern of requiredReviewFields) {
+    if (!pattern.test(normalizedBody)) {
+      errors.push(`PR body is missing a filled review field matching ${pattern}`);
+    }
+  }
+
+  return errors;
+}
+
+function validatePrMetadata({ title, body }) {
+  return [...validatePrTitle(title), ...validatePrBody(body)];
+}
+
+function hasOwn(object, key) {
+  return Object.prototype.hasOwnProperty.call(object, key);
+}
+
+function validatePrMetadataUpdate(toolInput) {
+  const errors = [];
+
+  if (hasOwn(toolInput, 'title')) {
+    errors.push(...validatePrTitle(toolInput.title));
+  }
+
+  if (hasOwn(toolInput, 'body')) {
+    errors.push(...validatePrBody(toolInput.body));
+  }
+
+  return errors;
+}
+
+function printErrors(errors) {
+  console.error(['PR metadata validation failed:', ...errors.map((error) => `- ${error}`)].join('\n'));
+}
+
+function usage() {
+  console.error(`Usage:
+  scripts/validate-pr-metadata.mjs --event-path <github-event-json>
+  scripts/validate-pr-metadata.mjs --hook
+  scripts/validate-pr-metadata.mjs --title <title> --body-file <markdown>
+  scripts/validate-pr-metadata.mjs --self-test`);
+}
+
+function readStdin() {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', (chunk) => {
+      data += chunk;
+    });
+    process.stdin.on('end', () => resolve(data));
+    process.stdin.on('error', reject);
+  });
+}
+
+function getArgValue(flag) {
+  const index = process.argv.indexOf(flag);
+  if (index === -1) {
+    return undefined;
+  }
+  return process.argv[index + 1];
+}
+
+function isCreatePullRequestTool(toolName) {
+  return (
+    toolName === 'mcp__codex_apps__github._create_pull_request' ||
+    toolName === 'mcp__github__.create_pull_request' ||
+    toolName === 'mcp__github__create_pull_request' ||
+    (toolName.includes('github') && toolName.includes('create_pull_request'))
+  );
+}
+
+function isUpdatePullRequestTool(toolName) {
+  return (
+    toolName === 'mcp__codex_apps__github._update_pull_request' ||
+    toolName === 'mcp__github__.update_pull_request' ||
+    toolName === 'mcp__github__update_pull_request' ||
+    (toolName.includes('github') && toolName.includes('update_pull_request'))
+  );
+}
+
+async function runHookMode() {
+  const inputText = await readStdin();
+  let input;
+  try {
+    input = JSON.parse(inputText || '{}');
+  } catch (error) {
+    console.error(
+      `[validate-pr-metadata] invalid hook JSON: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return 2;
+  }
+
+  const toolName = input.tool_name || '';
+
+  if (!isCreatePullRequestTool(toolName) && !isUpdatePullRequestTool(toolName)) {
+    return 0;
+  }
+
+  const toolInput = input.tool_input || {};
+  const errors = isCreatePullRequestTool(toolName)
+    ? validatePrMetadata({ title: toolInput.title, body: toolInput.body })
+    : validatePrMetadataUpdate(toolInput);
+  if (errors.length > 0) {
+    console.error(`[validate-pr-metadata] blocked ${toolName}`);
+    printErrors(errors);
+    return 2;
+  }
+
+  return 0;
+}
+
+async function runEventPathMode(eventPath) {
+  const { readFile } = await import('node:fs/promises');
+  const event = JSON.parse(await readFile(eventPath, 'utf8'));
+  const pr = event.pull_request;
+
+  if (!pr) {
+    console.error('This validator must run on pull_request events.');
+    return 2;
+  }
+
+  const errors = validatePrMetadata({ title: pr.title, body: pr.body || '' });
+  if (errors.length > 0) {
+    printErrors(errors);
+    return 2;
+  }
+
+  return 0;
+}
+
+async function runTitleBodyMode(title, bodyFile) {
+  const { readFile } = await import('node:fs/promises');
+  const body = await readFile(bodyFile, 'utf8');
+  const errors = validatePrMetadata({ title, body });
+  if (errors.length > 0) {
+    printErrors(errors);
+    return 2;
+  }
+
+  return 0;
+}
+
+function sampleBody() {
+  return `## Summary
+
+Adds PR metadata validation.
+
+本 PR：
+- Adds validation.
+
+## Why
+
+Keep PR descriptions complete.
+
+ADR: N/A - repository metadata check only.
+Spec: N/A - no runtime contract change.
+
+## Test plan
+
+- [x] Tests: self-test.
+- [x] \`node scripts/validate-pr-metadata.mjs --self-test\` - passed.
+
+## Review notes
+
+- Independent agent review: N/A - self-test fixture.
+- Deep review: N/A - no architecture change.
+
+## Out of scope
+
+- Merge automation.
+`;
+}
+
+async function runSelfTest() {
+  const validErrors = validatePrMetadata({
+    title: 'ci(pr): validate pull request metadata',
+    body: sampleBody(),
+  });
+  if (validErrors.length > 0) {
+    throw new Error(`valid fixture failed: ${validErrors.join('; ')}`);
+  }
+
+  const invalidErrors = validatePrMetadata({
+    title: 'bad title',
+    body: '## Summary\n\n<背景和当前问题，1-2 段>',
+  });
+  if (invalidErrors.length === 0) {
+    throw new Error('invalid fixture unexpectedly passed');
+  }
+
+  const nonPrTool = {
+    tool_name: 'Read',
+    tool_input: { file_path: 'AGENTS.md' },
+  };
+  const createPrTool = {
+    tool_name: 'mcp__codex_apps__github._create_pull_request',
+    tool_input: {
+      title: 'bad title',
+      body: '## Summary\n\n<背景和当前问题，1-2 段>',
+    },
+  };
+  const updatePrTool = {
+    tool_name: 'mcp__codex_apps__github._update_pull_request',
+    tool_input: {
+      title: 'bad title',
+    },
+  };
+
+  if (!isCreatePullRequestTool(createPrTool.tool_name)) {
+    throw new Error('known MCP create PR tool was not recognized');
+  }
+
+  if (!isUpdatePullRequestTool(updatePrTool.tool_name)) {
+    throw new Error('known MCP update PR tool was not recognized');
+  }
+
+  if (validatePrMetadataUpdate(updatePrTool.tool_input).length === 0) {
+    throw new Error('invalid update PR fixture unexpectedly passed');
+  }
+
+  if (isCreatePullRequestTool(nonPrTool.tool_name)) {
+    throw new Error('non-PR tool was incorrectly recognized');
+  }
+
+  console.log('validate-pr-metadata self-test ok');
+  return 0;
+}
+
+async function main() {
+  if (process.argv.includes('--self-test')) {
+    return runSelfTest();
+  }
+
+  if (process.argv.includes('--hook')) {
+    return runHookMode();
+  }
+
+  const eventPath = getArgValue('--event-path');
+  if (eventPath) {
+    return runEventPathMode(eventPath);
+  }
+
+  const title = getArgValue('--title');
+  const bodyFile = getArgValue('--body-file');
+  if (title && bodyFile) {
+    return runTitleBodyMode(title, bodyFile);
+  }
+
+  usage();
+  return 1;
+}
+
+main()
+  .then((code) => {
+    process.exitCode = code;
+  })
+  .catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = process.argv.includes('--hook') ? 2 : 1;
+  });


### PR DESCRIPTION
## Summary

当前 `pr-metadata` 只作为异步 GitHub Actions / ruleset 门禁存在，agent 通过 MCP 创建 PR 时可能只看到“PR 创建成功”，不知道 title/body 后续会被 metadata check 拒绝。这个 PR 把 metadata 校验逻辑抽成脚本，让 Actions 和本地 PreToolUse hook 复用同一套规则。

本 PR：
- 新增 `scripts/validate-pr-metadata.mjs`，支持 `--event-path`、`--hook`、`--title/--body-file` 和 `--self-test`。
- 将 `pr-metadata` workflow 改为调用脚本，并使用 `pull_request_target` + checkout default branch，避免 PR head 篡改 validator。
- 在 CI 中加入 `node scripts/validate-pr-metadata.mjs --self-test`。
- 更新 code-review 和 setup 文档，给出 MCP create/update PR 的 PreToolUse hook 配置。

## Why

ruleset 负责防止坏 PR merge，但不能让 agent 在 MCP 创建 PR 的同步路径里感知模板错误。PreToolUse hook 负责在 `create_pull_request` / `update_pull_request` 调用前 fail closed，避免 agent 创建或改坏 PR 后只把 URL 交给用户。

ADR: N/A - 这是既有 PR 流程和 CI 守卫的实现细化，不改变架构决策。
Spec: N/A - 不改变运行时接口、协议字段或 daemon/platform/agent 契约。

## Test plan

- [x] Tests: `scripts/validate-pr-metadata.mjs --self-test` 覆盖合法/非法 PR、create/update MCP tool 识别。
- [x] `node --check scripts/validate-pr-metadata.mjs && node scripts/validate-pr-metadata.mjs --self-test` - passed。
- [x] Hook/event fixture test - passed：`--title/--body-file`、`--event-path`、非 PR tool 放行、create PR 失败、update PR 失败、坏 JSON exit 2。
- [x] `git diff --check` - passed。
- [x] `COREPACK_HOME=/tmp/corepack-test corepack pnpm test` - passed, 22 test files / 337 tests。
- [ ] Manual: 合入后确认本地 harness 已挂 `node scripts/validate-pr-metadata.mjs --hook`，并用一个坏 PR body 的 MCP create/update 调用验证会被 hook 阻止。

## Review notes

- Independent agent review: completed via local `claude -p`; findings addressed. Fixed update PR bypass, hook exception fail-open, and added CI self-test. Reviewer also confirmed `pull_request_target` + checkout default branch avoids PR head tampering with the validator.
- Deep review: pending - this PR changes 5 files and more than 200 lines, so it is intentionally draft until deep review is completed.

## Out of scope

- Polling GitHub checks after PR creation; this PR only handles pre-tool synchronous metadata validation.
- Replacing GitHub ruleset / required checks; ruleset remains the final merge gate.
- Committing local `.claude/settings.json`; it was updated in this workspace only because harness configs are gitignored.