### PR TITLE
docs(packages): 添加 package 局部 agent 规则入口

### DIFF
--- a/packages/agent/claudecode/AGENTS.md
+++ b/packages/agent/claudecode/AGENTS.md
@@ -1,0 +1,28 @@
+# packages/agent/claudecode
+
+本文件叠加仓库根目录 `AGENTS.md`。这里只写 Claude Code backend package 的局部导航与开发约束；架构、契约、决策事实仍以 `docs/dev/` 下 owner 文档为准。
+
+## 本包职责
+
+- 实现 `@agent-nexus/agent-claudecode`，把 Claude Code CLI 适配为 `AgentRuntime`。
+- 入口在 `src/index.ts`；配置解析、自检、usage 归一化分别看同目录相关模块与测试。
+- 本包只服务 Claude Code backend，不承载 daemon、platform 或 CLI 拼装逻辑。
+
+## 先看哪里
+
+- Agent runtime 契约：[`../../../docs/dev/spec/agent-runtime.md`](../../../docs/dev/spec/agent-runtime.md)
+- Claude Code CLI 契约：[`../../../docs/dev/spec/agent-backends/claude-code-cli.md`](../../../docs/dev/spec/agent-backends/claude-code-cli.md)
+- 配置与路由契约：[`../../../docs/dev/spec/config-routing.md`](../../../docs/dev/spec/config-routing.md)
+- import 方向：[`../../../docs/dev/architecture/dependencies.md`](../../../docs/dev/architecture/dependencies.md)
+
+## 本地命令
+
+- `corepack pnpm --filter @agent-nexus/agent-claudecode test`
+- `corepack pnpm --filter @agent-nexus/agent-claudecode typecheck`
+- `corepack pnpm --filter @agent-nexus/agent-claudecode build`
+
+## 修改约束
+
+- 改 `AgentRuntime`、事件字段、配置字段或 Claude Code CLI 调用语义时，先改对应 spec，再改测试和实现。
+- 不在本文件复述字段表、默认值、错误码；需要说明时 link 到 owner 文档。
+- 不 import 其他 agent 或 platform package；共享抽象只能来自 `@agent-nexus/daemon` 和 `@agent-nexus/protocol`。

--- a/packages/agent/claudecode/CLAUDE.md
+++ b/packages/agent/claudecode/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/packages/agent/codex/AGENTS.md
+++ b/packages/agent/codex/AGENTS.md
@@ -1,0 +1,29 @@
+# packages/agent/codex
+
+本文件叠加仓库根目录 `AGENTS.md`。这里只写 Codex backend package 的局部导航与开发约束；架构、契约、决策事实仍以 `docs/dev/` 下 owner 文档为准。
+
+## 本包职责
+
+- 实现 `@agent-nexus/agent-codex`，把 Codex CLI 适配为 `AgentRuntime`。
+- 入口在 `src/index.ts`；配置解析、自检与 e2e verify 逻辑分别看同目录相关模块与测试。
+- 本包只服务 Codex backend，不承载 daemon、platform 或 CLI 拼装逻辑。
+
+## 先看哪里
+
+- Agent runtime 契约：[`../../../docs/dev/spec/agent-runtime.md`](../../../docs/dev/spec/agent-runtime.md)
+- Codex CLI 契约：[`../../../docs/dev/spec/agent-backends/codex-cli.md`](../../../docs/dev/spec/agent-backends/codex-cli.md)
+- 配置与路由契约：[`../../../docs/dev/spec/config-routing.md`](../../../docs/dev/spec/config-routing.md)
+- 工具边界：[`../../../docs/dev/spec/security/tool-boundary.md`](../../../docs/dev/spec/security/tool-boundary.md)
+- import 方向：[`../../../docs/dev/architecture/dependencies.md`](../../../docs/dev/architecture/dependencies.md)
+
+## 本地命令
+
+- `corepack pnpm --filter @agent-nexus/agent-codex test`
+- `corepack pnpm --filter @agent-nexus/agent-codex typecheck`
+- `corepack pnpm --filter @agent-nexus/agent-codex build`
+
+## 修改约束
+
+- 改 `AgentRuntime`、事件字段、配置字段、sandbox/approval 语义或 Codex CLI 调用语义时，先改对应 spec，再改测试和实现。
+- 不在本文件复述字段表、默认值、错误码；需要说明时 link 到 owner 文档。
+- 不 import 其他 agent 或 platform package；共享抽象只能来自 `@agent-nexus/daemon` 和 `@agent-nexus/protocol`。

--- a/packages/agent/codex/CLAUDE.md
+++ b/packages/agent/codex/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -1,0 +1,30 @@
+# packages/cli
+
+本文件叠加仓库根目录 `AGENTS.md`。这里只写 CLI package 的局部导航与开发约束；架构、契约、决策事实仍以 `docs/dev/` 下 owner 文档为准。
+
+## 本包职责
+
+- 实现 `@agent-nexus/cli` 与 `agent-nexus` 可执行入口。
+- 入口在 `src/index.ts`；agent 选择与配置解析看 `src/agent.ts`、`src/config.ts` 及对应测试。
+- CLI 是拼装层：读取配置、创建 daemon、注册启用的 platform / agent，并处理进程入口行为。
+
+## 先看哪里
+
+- 配置与路由契约：[`../../docs/dev/spec/config-routing.md`](../../docs/dev/spec/config-routing.md)
+- 消息流：[`../../docs/dev/spec/message-flow.md`](../../docs/dev/spec/message-flow.md)
+- import 方向与 CLI 职责：[`../../docs/dev/architecture/dependencies.md`](../../docs/dev/architecture/dependencies.md)
+- Agent runtime 契约：[`../../docs/dev/spec/agent-runtime.md`](../../docs/dev/spec/agent-runtime.md)
+- Platform adapter 契约：[`../../docs/dev/spec/platform-adapter.md`](../../docs/dev/spec/platform-adapter.md)
+
+## 本地命令
+
+- `corepack pnpm --filter @agent-nexus/cli test`
+- `corepack pnpm --filter @agent-nexus/cli typecheck`
+- `corepack pnpm --filter @agent-nexus/cli build`
+- `corepack pnpm --filter @agent-nexus/cli dev`
+
+## 修改约束
+
+- 改配置 schema、backend/platform 选择、路由匹配或 CLI 对外行为时，先改对应 spec，再改测试和实现。
+- CLI 可以 import daemon、platform、agent、protocol；其他 package 不应 import CLI。
+- 不把业务逻辑下沉到 CLI；能归属 daemon、agent 或 platform 的行为放回 owner package。

--- a/packages/cli/CLAUDE.md
+++ b/packages/cli/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/packages/daemon/AGENTS.md
+++ b/packages/daemon/AGENTS.md
@@ -1,0 +1,29 @@
+# packages/daemon
+
+本文件叠加仓库根目录 `AGENTS.md`。这里只写 daemon package 的局部导航与开发约束；架构、契约、决策事实仍以 `docs/dev/` 下 owner 文档为准。
+
+## 本包职责
+
+- 实现 `@agent-nexus/daemon`，作为 platform 与 agent 之间的中枢。
+- 入口在 `src/index.ts`；engine、auth、config、router、session store 看同目录模块与测试。
+- daemon 只依赖 protocol 与准入的基础库，不感知具体 agent / platform 实现。
+
+## 先看哪里
+
+- 消息流：[`../../docs/dev/spec/message-flow.md`](../../docs/dev/spec/message-flow.md)
+- 配置与路由契约：[`../../docs/dev/spec/config-routing.md`](../../docs/dev/spec/config-routing.md)
+- 会话模型：[`../../docs/dev/architecture/session-model.md`](../../docs/dev/architecture/session-model.md)
+- 身份与 allowlist：[`../../docs/dev/spec/security/auth.md`](../../docs/dev/spec/security/auth.md)
+- import 方向：[`../../docs/dev/architecture/dependencies.md`](../../docs/dev/architecture/dependencies.md)
+
+## 本地命令
+
+- `corepack pnpm --filter @agent-nexus/daemon test`
+- `corepack pnpm --filter @agent-nexus/daemon typecheck`
+- `corepack pnpm --filter @agent-nexus/daemon build`
+
+## 修改约束
+
+- 改路由、session、auth、engine 事件流或持久化语义时，先改对应 spec / architecture，再改测试和实现。
+- 不 import `@agent-nexus/agent-*` 或 `@agent-nexus/platform-*`。
+- 不把具体 backend 或具体 IM 平台的特殊行为写进 daemon；通过 protocol / runtime / adapter 契约表达。

--- a/packages/daemon/CLAUDE.md
+++ b/packages/daemon/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/packages/platform/discord/AGENTS.md
+++ b/packages/platform/discord/AGENTS.md
@@ -1,0 +1,29 @@
+# packages/platform/discord
+
+本文件叠加仓库根目录 `AGENTS.md`。这里只写 Discord platform package 的局部导航与开发约束；架构、契约、决策事实仍以 `docs/dev/` 下 owner 文档为准。
+
+## 本包职责
+
+- 实现 `@agent-nexus/platform-discord`，把 Discord 事件和发送能力适配到 `PlatformAdapter`。
+- 入口在 `src/index.ts`；命令、回复模式、状态和配置看同目录模块与测试。
+- 本包只服务 Discord platform，不承载 daemon、agent 或 CLI 拼装逻辑。
+
+## 先看哪里
+
+- Platform adapter 契约：[`../../../docs/dev/spec/platform-adapter.md`](../../../docs/dev/spec/platform-adapter.md)
+- 归一化消息协议：[`../../../docs/dev/spec/message-protocol.md`](../../../docs/dev/spec/message-protocol.md)
+- 配置与路由契约：[`../../../docs/dev/spec/config-routing.md`](../../../docs/dev/spec/config-routing.md)
+- 身份与 allowlist：[`../../../docs/dev/spec/security/auth.md`](../../../docs/dev/spec/security/auth.md)
+- import 方向：[`../../../docs/dev/architecture/dependencies.md`](../../../docs/dev/architecture/dependencies.md)
+
+## 本地命令
+
+- `corepack pnpm --filter @agent-nexus/platform-discord typecheck`
+- `corepack pnpm --filter @agent-nexus/platform-discord build`
+- `corepack pnpm test -- packages/platform/discord`
+
+## 修改约束
+
+- 改 Discord 事件映射、发送能力、配置字段或用户可见交互语义时，先改对应 spec，再改测试和实现。
+- 不在本文件复述 Discord 字段映射表；需要说明时 link 到 owner 文档。
+- 不 import 其他 platform 或 agent package；共享抽象只能来自 `@agent-nexus/daemon` 和 `@agent-nexus/protocol`。

--- a/packages/platform/discord/CLAUDE.md
+++ b/packages/platform/discord/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/packages/protocol/AGENTS.md
+++ b/packages/protocol/AGENTS.md
@@ -1,0 +1,29 @@
+# packages/protocol
+
+本文件叠加仓库根目录 `AGENTS.md`。这里只写 protocol package 的局部导航与开发约束；架构、契约、决策事实仍以 `docs/dev/` 下 owner 文档为准。
+
+## 本包职责
+
+- 实现 `@agent-nexus/protocol`，承载跨 package 共享的类型与接口契约。
+- 入口在 `src/index.ts`；agent 事件、session key 等类型看同目录模块与测试。
+- protocol 是 leaf package，不应引入运行时业务依赖。
+
+## 先看哪里
+
+- Agent runtime 契约：[`../../docs/dev/spec/agent-runtime.md`](../../docs/dev/spec/agent-runtime.md)
+- Platform adapter 契约：[`../../docs/dev/spec/platform-adapter.md`](../../docs/dev/spec/platform-adapter.md)
+- 归一化消息协议：[`../../docs/dev/spec/message-protocol.md`](../../docs/dev/spec/message-protocol.md)
+- 配置与路由契约：[`../../docs/dev/spec/config-routing.md`](../../docs/dev/spec/config-routing.md)
+- import 方向：[`../../docs/dev/architecture/dependencies.md`](../../docs/dev/architecture/dependencies.md)
+
+## 本地命令
+
+- `corepack pnpm --filter @agent-nexus/protocol typecheck`
+- `corepack pnpm --filter @agent-nexus/protocol build`
+- `corepack pnpm test -- packages/protocol`
+
+## 修改约束
+
+- 改任何 exported 类型、事件 union、session key 或公共接口时，先改对应 spec，再改测试和实现。
+- 不引入 daemon、agent、platform 或 CLI 依赖；protocol 必须保持 leaf。
+- 不把具体 backend / platform 实现细节写进通用类型，除非对应 spec 已明确收敛为跨实现契约。

--- a/packages/protocol/CLAUDE.md
+++ b/packages/protocol/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Summary

为各 package 增加局部 agent 规则入口，让 agent 在 package 子目录内工作时能直接看到对应职责、常用命令、相关 owner 文档和局部约束，同时不重复定义仓库级事实。

本 PR：
- 为 agent、CLI、daemon、Discord platform、protocol package 增加 `AGENTS.md`。
- 增加对应 `CLAUDE.md`，让 Claude Code 读取同一份局部 package 指引。
- 架构、spec、决策事实仍链接到既有 `docs/dev/` owner 文档，不在 package 局部文件里重述。

## Why

仓库已经有根目录协作规则和 owner 文档，但 package 局部会话需要更短的入口来定位该 package 的 spec、命令和 import 边界。这次只是文档导航入口，不改变运行时行为。

ADR: N/A - 仅新增局部文档入口，不引入新的架构决策。
Spec: N/A - 不改变 runtime contract、public API、message field、persistence schema 或 adapter 行为。

## Test plan

- [x] Tests: 未新增测试文件；本 PR 是 docs-only package 导航入口，使用既有全量测试做回归覆盖。
- [x] `git diff --check origin/main...HEAD` - passed。
- [x] `corepack pnpm test` - 22 个 test files passed，337 个 tests passed。
- [x] Manual: 未跑；本 PR 只新增 Markdown 入口，不影响 runtime、CLI、platform 或外部用户路径。

## Review notes

- Independent agent review: Pending；先开 draft PR，后续把独立 reviewer 输出挂到 PR 线程并逐条回应后再进入合并。
- Deep review: Required before merge；本 PR 跨 3+ 文件，按流程需要深度 review，当前 pending。

## Out of scope

- 修改运行时行为。
- 修改 `docs/dev/` owner 文档，或在 package 局部文件里重新定义 owner 文档事实。
- 为生产代码新增或修改测试。
