### PR TITLE
fix(platform-discord): reply ephemeral error when slash command handler throws

### DIFF
--- a/packages/platform/discord/src/index.test.ts
+++ b/packages/platform/discord/src/index.test.ts
@@ -443,6 +443,67 @@ describe('command registry integration', () => {
       },
     });
   });
+
+  it('stable /discord-reply-mode 内部失败时仍回复 ephemeral 错误，避免 Discord 显示未响应', async () => {
+    const logger = makeLogger();
+    const platform = createDiscordPlatform({
+      token: 'test-token',
+      botUserId: BOT_ID,
+      logger,
+      statePath: '/tmp/agent-nexus-missing-dir/reply-mode.json',
+      allowedUserIds: ALLOWED,
+      commandRegistration: {
+        plan: {
+          scope: {
+            platformName: 'discord-main',
+            platformType: 'discord' as const,
+            nativeScope: { kind: 'global' as const },
+          },
+          commands: [],
+          reverseMap: {
+            entries: {
+              'discord-reply-mode': {
+                canonicalId: 'platform:discord:reply-mode',
+                aliasKind: 'stable' as const,
+                owner: { type: 'platform' as const, platformType: 'discord' },
+                handlerKey: 'reply-mode',
+              },
+            },
+          },
+          generation: 'g-stable-reply-mode',
+        },
+        apply: vi.fn(async () => ({
+          status: 'applied' as const,
+          generation: 'g-stable-reply-mode',
+        })),
+      },
+    });
+    const reply = vi.fn(async () => undefined);
+
+    await platform.start(vi.fn());
+    const interactionCreate = registeredHandler('interactionCreate');
+    await interactionCreate({
+      id: 'i-stable-reply-mode-fail',
+      commandName: 'discord-reply-mode',
+      channelId: 'C1',
+      guildId: 'G-dev',
+      createdAt: new Date(123),
+      user: { id: OTHER_ID, username: 'alice', bot: false },
+      member: { roles: { cache: new Map() } },
+      options: { data: [], getString: vi.fn(() => 'all') },
+      reply,
+      isChatInputCommand: () => true,
+    });
+
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({ commandName: 'discord-reply-mode' }),
+      'discord_interaction_handler_error',
+    );
+    expect(reply).toHaveBeenCalledWith({
+      content: 'Command failed. Try again later.',
+      ephemeral: true,
+    });
+  });
 });
 
 function makeTextChannel(overrides: {

--- a/packages/platform/discord/src/index.ts
+++ b/packages/platform/discord/src/index.ts
@@ -620,6 +620,17 @@ export function createDiscordPlatform(opts: DiscordPlatformOptions): PlatformAda
             { err, commandName: interaction.commandName },
             'discord_interaction_handler_error',
           );
+          try {
+            await interaction.reply({
+              content: 'Command failed. Try again later.',
+              ephemeral: true,
+            });
+          } catch (replyErr) {
+            logger.error(
+              { err: replyErr, commandName: interaction.commandName },
+              'discord_interaction_error_reply_failed',
+            );
+          }
         }
       });
 


### PR DESCRIPTION
> **Stacked PR**：base=`feature/slash-command-registry-main`（slash command registry 功能分支）。请先合 registry PR，再 squash merge 本 PR。

## Summary

Discord slash command 进入 adapter 的 interaction handler 后，如果内部处理抛错，此前只记一条 error 日志、不回复用户。Discord 端的表现是「应用程序没有响应」，触发命令的人完全不知道发生了什么。

本 PR：
- interaction handler 抛错时补发一条仅调用方可见（ephemeral）的错误回复
- 错误回复本身再失败时降级为 `discord_interaction_error_reply_failed` 日志，不再上抛

## Why

用户可见的失败必须有反馈，不能静默吞掉——这与 command registry spec 里 dispatch 失败路径全部给用户可见反馈的原则一致。

ADR: N/A（单一行为修补，无架构决策）
Spec: N/A（不改契约字段；错误反馈原则已由 docs/dev/spec/command-registry.md §错误与日志 覆盖）

## Test plan

- [x] Tests: `packages/platform/discord/src/index.test.ts` 新增 case——handler 抛错时断言 ephemeral 错误回复 + `discord_interaction_handler_error` 日志
- [x] `npx vitest run` — 全仓通过
- [x] `corepack pnpm -r typecheck` — 6/6 通过
- [ ] Manual: 未跑真实 Discord（需要真实 bot；行为由 adapter 集成测试覆盖）

## Review notes

- Independent agent review: 待触发（draft 状态，按 code-review.md 流程走）
- Deep review: N/A（2 文件、72 行新增，未达深度 review 触发条件）

## Out of scope

- interaction 已 defer 后的错误回复路径（已有 `markDeferredCommandFailed` 覆盖）
