### PR TITLE
feat(command-registry): add config hot reload slash command

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ agent-nexus
 - `/claudecode-stop` / `/codex-stop`：按绑定到当前频道的 agent owner 路由给对应 agent package；具体停止语义由该 agent runtime 决定
 - `/new` / `/stop`：仅在同一个 Discord 注册 scope 里只有一种 agent owner 且 `daemon.commandRegistry.aliases.singleAgent.enabled=true` 时作为便捷 alias 出现
 - `/nexus-kill`：daemon 直接终止当前 RoutingSession，并清除 resume 记录
+- `/nexus-reload-config`：daemon 重新加载 `config.json` 并热应用 bindings / auth / ui / textPrefixes；解析失败保留旧配置并返回错误，其余字段变更需重启生效
 - `/discord-reply-mode mode:<mention|all>`：在 allowlist 内切换 Discord 消息触发模式
 - `/reply-mode mode:<mention|all>`：legacy alias；`daemon.commandRegistry.aliases.legacy.replyMode=true` 时注册
 

--- a/docs/dev/spec/command-registry.md
+++ b/docs/dev/spec/command-registry.md
@@ -412,8 +412,11 @@ Agent command 的远端可见性是 registration scope 粒度，binding 是 chan
 | Descriptor | Stable name |
 |---|---|
 | `daemon:kill` | `nexus-kill` |
+| `daemon:reload-config` | `nexus-reload-config` |
 
 `kill` 的语义是 daemon 直接终止当前 `(platformName, channelId, userId)` 的 RoutingSession，并清除 daemon 持久化的 opaque agent conversation ref。它不经过 agent command route；若存在活跃 runtime handle，daemon 只调用通用 cleanup/close 入口释放资源，不解释 agent 内部 conversation 语义。
+
+`reload-config` 的语义是重新加载并应用 `config.json`。daemon 不拥有配置加载：handler 只调用组装层注入的 config reloader，并把 reloader 返回的结果文本作为 ephemeral command response 返回触发者；reloader 未注入时按 `command_handler_missing` fail-closed。热生效字段范围与失败 rollback 语义由 [`config-routing.md` §配置热重载](config-routing.md#配置热重载) 拥有。
 
 不得把 Claude Code 或 Codex 自身 TTY slash commands 直接透传为首批 agent-nexus slash command。后端 CLI 私有命令若要暴露，必须先补对应 backend contract 和安全边界。
 
@@ -490,6 +493,7 @@ P3-P5 必须覆盖：
 - agent command descriptor 来自 agent package 内声明配置文件，并进入对应 package 构建产物。
 - `/stop` 在 single-agent scope 作为 agent alias 路由到当前 backend，并以 agent command envelope 转发；daemon 不校验 agent 私有 handler、不映射为 runtime interrupt。
 - `/nexus-kill` 作为 daemon command 终止当前 RoutingSession 并清除 opaque agent conversation ref。
+- `/nexus-reload-config` 把注入的 config reloader 结果作为 ephemeral response 返回；reload 失败保留旧配置并把错误返回触发者。
 - `/discord-reply-mode` 与 `/reply-mode` 都路由到 `platform:discord:reply-mode`。
 - Claude Code / Codex descriptors 不 import platform package 或 platform naming utility。
 

--- a/docs/dev/spec/config-routing.md
+++ b/docs/dev/spec/config-routing.md
@@ -2,7 +2,7 @@
 title: Spec：配置与路由契约
 type: spec
 status: active
-summary: platforms[] / agents[] / bindings 的配置 schema、owner 校验边界、路由匹配语义与迁移规则
+summary: platforms[] / agents[] / bindings 的配置 schema、owner 校验边界、路由匹配语义、热重载与迁移规则
 tags: [spec, config, routing, platform, agent]
 related:
   - dev/adr/0015-multi-platform-agent-config
@@ -330,6 +330,28 @@ platformName + platformType + channelId + initiatorUserId
 迁移策略为 **清晰错误**：loader 拒绝 legacy 形态，错误消息说明需要改为 `platforms[]` / `agents[]`，
 并给出最小字段路径清单。可在用户文档中提供人工迁移示例或后续迁移命令，但 loader 不做自动迁移，也不得在内存里把 legacy 配置偷偷当新配置启动。
 
+## 配置热重载
+
+`/nexus-reload-config` daemon command 触发对 `config.json` 的全量重新加载（descriptor 与 dispatch 契约见 [`command-registry.md` §Agent Session Commands](command-registry.md#agent-session-commands)）。reload 由组装层注入 daemon 的 config reloader 执行；daemon 不读取配置文件。
+
+加载与校验语义与启动时 loader 完全一致。在此之上 reloader 增加两条运行态约束，违反任一条按失败处理：
+
+- `bindings[].agentName` 必须命中当前进程内运行中的 agent 实例 name。
+- 每个运行中 engine 的 `platformName` 必须仍存在于新配置 `platforms[]`。
+
+失败语义（rollback）：
+
+- 任何 parse / 校验 / 运行态约束失败 → 整次 reload 放弃，当前生效配置保持不变。
+- 错误信息必须返回给触发者（ephemeral command response），不得只落日志。
+
+成功语义：
+
+- 应用 all-or-nothing：先验证所有 engine 目标，再统一替换；不得出现部分 engine 用新配置、部分用旧配置。
+- 热生效字段：`bindings[]`（routing table）、`platforms[].auth`、`ui.toolMessages`、`daemon.commandRegistry.textPrefixes`。
+- 仅重启生效字段：`platforms[]` 其余字段、`agents[]`、`log`、`daemon.commandRegistry` 其余字段。这些 section 有变化时，成功响应必须提示重启后才生效。
+
+并发 reload 不做序列化保证：手动触发场景下后完成者生效。
+
 ## Secret 规则
 
 - platform 配置只接受 `tokenRef`，不接受 token 明文。
@@ -372,6 +394,13 @@ session 隔离合约测试必须覆盖：
 
 1. 两个 Discord platform 实例的同 channel/user 不共享 session key。
 2. route decision 后续 auth、idempotency、session 队列与出站发送沿用同一个 `platformName`。
+
+配置热重载合约测试必须覆盖：
+
+1. 配置 parse / 校验失败时不应用任何改动，错误信息进入 command response。
+2. 成功 reload 后 routing table、auth、ui、textPrefixes 替换生效。
+3. binding 引用未运行的 agent、或新配置缺失运行中 engine 的 platform 时按失败处理。
+4. 仅重启生效 section 有变化时，成功响应包含重启提示。
 
 ## 反模式
 

--- a/docs/dev/spec/config-routing.md
+++ b/docs/dev/spec/config-routing.md
@@ -334,10 +334,11 @@ platformName + platformType + channelId + initiatorUserId
 
 `/nexus-reload-config` daemon command 触发对 `config.json` 的全量重新加载（descriptor 与 dispatch 契约见 [`command-registry.md` §Agent Session Commands](command-registry.md#agent-session-commands)）。reload 由组装层注入 daemon 的 config reloader 执行；daemon 不读取配置文件。
 
-加载与校验语义与启动时 loader 完全一致。在此之上 reloader 增加两条运行态约束，违反任一条按失败处理：
+加载与校验语义与启动时 loader 完全一致。在此之上 reloader 增加三条运行态约束，违反任一条按失败处理：
 
 - `bindings[].agentName` 必须命中当前进程内运行中的 agent 实例 name。
 - 每个运行中 engine 的 `platformName` 必须仍存在于新配置 `platforms[]`。
+- 每个运行中 platform 由 `bindings[]` 派生的 agent owner 集合不得变化——slash command 注册集是启动时按 owner 集合生成的（见 [`command-registry.md` §Registration Plan](command-registry.md#registration-plan)），不在 reload 事务内；owner 集合变化会让已注册命令与路由失配。
 
 失败语义（rollback）：
 
@@ -348,9 +349,15 @@ platformName + platformType + channelId + initiatorUserId
 
 - 应用 all-or-nothing：先验证所有 engine 目标，再统一替换；不得出现部分 engine 用新配置、部分用旧配置。
 - 热生效字段：`bindings[]`（routing table）、`platforms[].auth`、`ui.toolMessages`、`daemon.commandRegistry.textPrefixes`。
+- `platforms[].auth` 的热应用以**重启等价**为准：成功 reload 后 daemon engine 鉴权（全维度 allowlist）与 platform adapter 内部授权数据（inbound guard、`/discord-reply-mode` 的 userIds 列表）必须与用新配置重启进程后一致；只换其一视为违反本 spec。
+- 已知限制（重启路径同样受限）：adapter 内部命令（`/discord-reply-mode`）的授权仅基于 `userIds` 维度；role / guild / channel 维度待 platform command 经 daemon dispatch 统一鉴权后覆盖。
+- `ui.toolMessages` 与 `textPrefixes` 在 turn 边界生效：进行中的 turn 沿用其开始时的值，不得中途混合渲染。
 - 仅重启生效字段：`platforms[]` 其余字段、`agents[]`、`log`、`daemon.commandRegistry` 其余字段。这些 section 有变化时，成功响应必须提示重启后才生效。
 
-并发 reload 不做序列化保证：手动触发场景下后完成者生效。
+并发与时序：
+
+- 并发 reload 不做序列化保证：手动触发场景下后完成者生效。
+- reload 只影响其后开始处理的事件；已通过 auth 检查、在 per-session 队列中等待的事件不重查。
 
 ## Secret 规则
 
@@ -400,7 +407,11 @@ session 隔离合约测试必须覆盖：
 1. 配置 parse / 校验失败时不应用任何改动，错误信息进入 command response。
 2. 成功 reload 后 routing table、auth、ui、textPrefixes 替换生效。
 3. binding 引用未运行的 agent、或新配置缺失运行中 engine 的 platform 时按失败处理。
-4. 仅重启生效 section 有变化时，成功响应包含重启提示。
+4. bindings 变更改变运行中 platform 的 agent owner 集合时按失败处理。
+5. auth 热替换后 platform adapter 内部命令（reply-mode）按新 `userIds` allowlist 判定（其余维度见上文已知限制）。
+6. reload 切到 role-only allowlist 后，chat 按 role 维度在 daemon 判定（adapter 不做 userIds 预筛）。
+7. turn 进行中切换 `ui.toolMessages` 不影响该 turn 的渲染模式。
+8. 仅重启生效 section 有变化时，成功响应包含重启提示。
 
 ## 反模式
 

--- a/docs/product/platforms/discord.md
+++ b/docs/product/platforms/discord.md
@@ -34,7 +34,7 @@ related:
 - 用 `@bot ping` 能收到响应
 - slash command 列表里能看到 `/discord-reply-mode`；`daemon.commandRegistry.aliases.legacy.replyMode=true` 时还会看到 legacy `/reply-mode`
 - slash command 列表里能看到已绑定 backend 对应的 `/claudecode-new` / `/claudecode-stop` 或 `/codex-new` / `/codex-stop`；单 agent scope 且 `daemon.commandRegistry.aliases.singleAgent.enabled=true` 时还会看到裸 `/new` 和 `/stop`
-- slash command 列表里能看到 daemon command `/nexus-kill`
+- slash command 列表里能看到 daemon command `/nexus-kill` 和 `/nexus-reload-config`
 
 ## 参考
 

--- a/docs/product/user-guide.md
+++ b/docs/product/user-guide.md
@@ -323,6 +323,14 @@ agent-nexus
 
 `all` 模式只影响消息触发条件，不绕过 `allowedUserIds`。不在 allowlist 里的用户仍不能驱动 bot。
 
+重载配置：
+
+```text
+/nexus-reload-config
+```
+
+`/nexus-reload-config` 是 daemon command，重新加载 `config.json` 并热应用 `bindings[]`、`platforms[].auth`、`ui.toolMessages` 和 `daemon.commandRegistry.textPrefixes`；解析或校验失败时保留当前生效配置，错误以 ephemeral 反馈返回调用方。`platforms[]` 其余字段、`agents[]`、`log` 等变更仍需重启进程生效，reload 成功反馈会带提示。完整语义见 [`config-routing.md` §配置热重载](../dev/spec/config-routing.md#配置热重载)。
+
 ## 工具与安全
 
 - 默认工具集是 `Read` / `Grep` / `Glob` / `Edit` / `Write`。

--- a/packages/cli/src/command-registry.test.ts
+++ b/packages/cli/src/command-registry.test.ts
@@ -137,6 +137,7 @@ describe('buildCliCommandRegistrationPlan', () => {
     });
     expect(commandKeys(plan)).toEqual([
       'nexus-kill:daemon:kill:stable',
+      'nexus-reload-config:daemon:reload-config:stable',
       'discord-reply-mode:platform:discord:reply-mode:stable',
       'codex-new:agent:codex:new:stable',
       'codex-stop:agent:codex:stop:stable',
@@ -178,6 +179,7 @@ describe('buildCliCommandRegistrationPlan', () => {
 
     expect(commandKeys(plan)).toEqual([
       'nexus-kill:daemon:kill:stable',
+      'nexus-reload-config:daemon:reload-config:stable',
       'discord-reply-mode:platform:discord:reply-mode:stable',
       'codex-new:agent:codex:new:stable',
       'codex-stop:agent:codex:stop:stable',
@@ -274,6 +276,7 @@ describe('buildCliCommandRegistrationPlan', () => {
 
     expect(commandKeys(plan)).toEqual([
       'nexus-kill:daemon:kill:stable',
+      'nexus-reload-config:daemon:reload-config:stable',
       'discord-reply-mode:platform:discord:reply-mode:stable',
       'codex-new:agent:codex:new:stable',
       'codex-stop:agent:codex:stop:stable',
@@ -305,6 +308,7 @@ describe('buildCliCommandRegistrationPlan', () => {
 
     expect(commandKeys(plan)).toEqual([
       'nexus-kill:daemon:kill:stable',
+      'nexus-reload-config:daemon:reload-config:stable',
       'discord-reply-mode:platform:discord:reply-mode:stable',
       'codex-new:agent:codex:new:stable',
       'codex-stop:agent:codex:stop:stable',

--- a/packages/cli/src/command-registry.ts
+++ b/packages/cli/src/command-registry.ts
@@ -61,7 +61,8 @@ function agentByName(config: AgentNexusConfig): Map<string, AgentConfig> {
   return new Map(config.agents.map((agent) => [agent.name, agent]));
 }
 
-function agentOwnersForPlatform(
+/** registration plan 与热重载共用：owner 集合派生逻辑必须同源，否则 reload 校验会和注册集漂移 */
+export function agentOwnersForPlatform(
   config: AgentNexusConfig,
   platformName: string,
 ): string[] {

--- a/packages/cli/src/config-reload.test.ts
+++ b/packages/cli/src/config-reload.test.ts
@@ -181,6 +181,36 @@ describe('createConfigReloader', () => {
     expect(target.applyRuntimeUpdate).not.toHaveBeenCalled();
   });
 
+  it('bindings 变更改变 platform 的 agent owner 集合时按失败处理且不应用', async () => {
+    const target = makeTarget('discord-main');
+    const initial = baseConfig({ agents: [codexAgent, claudeAgent] });
+    const next = baseConfig({
+      agents: [codexAgent, claudeAgent],
+      bindings: [
+        {
+          name: 'discord-main-claude',
+          platformName: 'discord-main',
+          agentName: 'claude-prod',
+          match: { discord: { channelIds: ['C1'] } },
+        },
+      ],
+    });
+
+    const reload = createConfigReloader({
+      initialConfig: initial,
+      load: async () => next,
+      targets: [target],
+      runningAgentNames: ['codex-dev', 'claude-prod'],
+      logger: SILENT_LOGGER,
+    });
+
+    const result = await reload();
+
+    expect(result.status).toBe('failed');
+    expect(result.message).toContain('agent owner');
+    expect(target.applyRuntimeUpdate).not.toHaveBeenCalled();
+  });
+
   it('新配置缺少运行中的 platform 时按失败处理且不应用', async () => {
     const target = makeTarget('discord-main');
     const next = baseConfig();

--- a/packages/cli/src/config-reload.test.ts
+++ b/packages/cli/src/config-reload.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createLogger, type EngineRuntimeUpdate } from '@agent-nexus/daemon';
+import { ConfigError, type AgentConfig, type AgentNexusConfig } from './config.js';
+import { createConfigReloader } from './config-reload.js';
+
+const SILENT_LOGGER = createLogger({ level: 'fatal', pretty: false });
+
+const codexAgent: AgentConfig = {
+  name: 'codex-dev',
+  backend: 'codex',
+  codex: {
+    bin: 'codex',
+    workingDir: '/codex',
+    sandbox: 'read-only',
+    addDirs: [],
+    loadUserConfig: false,
+    loadRules: false,
+  },
+};
+
+const claudeAgent: AgentConfig = {
+  name: 'claude-prod',
+  backend: 'claudecode',
+  claudeCode: {
+    bin: 'claude',
+    workingDir: '/claude',
+    allowedTools: ['Read'],
+    permissionLevel: 'default',
+  },
+};
+
+function baseConfig(overrides: Partial<AgentNexusConfig> = {}): AgentNexusConfig {
+  return {
+    platforms: [
+      {
+        name: 'discord-main',
+        type: 'discord',
+        botUserId: 'bot',
+        tokenRef: 'DISCORD_BOT_TOKEN',
+        statePath: '/state/discord-main.json',
+        publicChannelMode: 'thread',
+        auth: {
+          allowlist: {
+            userIds: ['U1'],
+            roleIds: [],
+            allowedGuildIds: ['G1'],
+            allowedChannelIds: [],
+            allowDM: true,
+            requireMentionOrSlash: true,
+          },
+        },
+      },
+    ],
+    agents: [codexAgent],
+    bindings: [
+      {
+        name: 'discord-main-codex',
+        platformName: 'discord-main',
+        agentName: 'codex-dev',
+        match: { discord: { channelIds: ['C1'] } },
+      },
+    ],
+    daemon: {
+      commandRegistry: {
+        registration: {
+          enabled: true,
+          applyTimeoutMs: 30000,
+          retry: { maxAttempts: 1, backoffMs: 0 },
+        },
+        aliases: {
+          singleAgent: { enabled: true },
+          legacy: { replyMode: true },
+        },
+        textPrefixes: { newSession: true },
+      },
+    },
+    ui: { toolMessages: 'append' },
+    log: { level: 'info' },
+    ...overrides,
+  };
+}
+
+function makeTarget(platformName: string): {
+  platformName: string;
+  applyRuntimeUpdate: ReturnType<typeof vi.fn>;
+} {
+  return { platformName, applyRuntimeUpdate: vi.fn() };
+}
+
+describe('createConfigReloader', () => {
+  it('load 抛 ConfigError 时返回 failed、错误进消息、不应用任何改动', async () => {
+    const target = makeTarget('discord-main');
+    const reload = createConfigReloader({
+      initialConfig: baseConfig(),
+      load: vi.fn(async () => {
+        throw new ConfigError('config.json 不是合法 JSON：Unexpected token');
+      }),
+      targets: [target],
+      runningAgentNames: ['codex-dev'],
+      logger: SILENT_LOGGER,
+    });
+
+    const result = await reload();
+
+    expect(result.status).toBe('failed');
+    expect(result.message).toContain('config.json 不是合法 JSON');
+    expect(result.message).toContain('previous config kept');
+    expect(target.applyRuntimeUpdate).not.toHaveBeenCalled();
+  });
+
+  it('成功 reload 把新 routing table / auth / ui / textPrefixes 应用到所有 target', async () => {
+    const target = makeTarget('discord-main');
+    const next = baseConfig({
+      bindings: [
+        {
+          name: 'discord-main-codex',
+          platformName: 'discord-main',
+          agentName: 'codex-dev',
+          match: { discord: { channelIds: ['C2'] } },
+        },
+      ],
+      ui: { toolMessages: 'compact' },
+    });
+    next.platforms[0]!.auth.allowlist.userIds = ['U2'];
+    next.daemon.commandRegistry.textPrefixes.newSession = false;
+
+    const reload = createConfigReloader({
+      initialConfig: baseConfig(),
+      load: async () => next,
+      targets: [target],
+      runningAgentNames: ['codex-dev'],
+      logger: SILENT_LOGGER,
+    });
+
+    const result = await reload();
+
+    expect(result.status).toBe('reloaded');
+    expect(result.message).not.toContain('restart required');
+    expect(target.applyRuntimeUpdate).toHaveBeenCalledTimes(1);
+    const update = target.applyRuntimeUpdate.mock.calls[0]![0] as EngineRuntimeUpdate;
+    expect(update.routingTable).toEqual([
+      {
+        bindingName: 'discord-main-codex',
+        platformName: 'discord-main',
+        platformType: 'discord',
+        agentName: 'codex-dev',
+        match: { discord: { channelIds: ['C2'] } },
+      },
+    ]);
+    expect(update.platformAuth.allowlist.userIds).toEqual(['U2']);
+    expect(update.toolMessageMode).toBe('compact');
+    expect(update.newSessionTextPrefix).toBe(false);
+  });
+
+  it('binding 引用未运行的 agent 时按失败处理且不应用', async () => {
+    const target = makeTarget('discord-main');
+    const next = baseConfig({
+      agents: [codexAgent, claudeAgent],
+      bindings: [
+        {
+          name: 'discord-main-claude',
+          platformName: 'discord-main',
+          agentName: 'claude-prod',
+          match: { discord: { channelIds: ['C1'] } },
+        },
+      ],
+    });
+
+    const reload = createConfigReloader({
+      initialConfig: baseConfig(),
+      load: async () => next,
+      targets: [target],
+      runningAgentNames: ['codex-dev'],
+      logger: SILENT_LOGGER,
+    });
+
+    const result = await reload();
+
+    expect(result.status).toBe('failed');
+    expect(result.message).toContain('claude-prod');
+    expect(target.applyRuntimeUpdate).not.toHaveBeenCalled();
+  });
+
+  it('新配置缺少运行中的 platform 时按失败处理且不应用', async () => {
+    const target = makeTarget('discord-main');
+    const next = baseConfig();
+    next.platforms[0]!.name = 'discord-side';
+    next.bindings[0]!.platformName = 'discord-side';
+
+    const reload = createConfigReloader({
+      initialConfig: baseConfig(),
+      load: async () => next,
+      targets: [target],
+      runningAgentNames: ['codex-dev'],
+      logger: SILENT_LOGGER,
+    });
+
+    const result = await reload();
+
+    expect(result.status).toBe('failed');
+    expect(result.message).toContain('discord-main');
+    expect(target.applyRuntimeUpdate).not.toHaveBeenCalled();
+  });
+
+  it('仅重启生效 section 变化时成功响应带重启提示', async () => {
+    const target = makeTarget('discord-main');
+    const next = baseConfig({
+      agents: [
+        {
+          ...codexAgent,
+          codex: { ...codexAgent.codex, workingDir: '/codex-v2' },
+        } as AgentConfig,
+      ],
+      log: { level: 'debug' },
+    });
+
+    const reload = createConfigReloader({
+      initialConfig: baseConfig(),
+      load: async () => next,
+      targets: [target],
+      runningAgentNames: ['codex-dev'],
+      logger: SILENT_LOGGER,
+    });
+
+    const result = await reload();
+
+    expect(result.status).toBe('reloaded');
+    expect(target.applyRuntimeUpdate).toHaveBeenCalledTimes(1);
+    expect(result.message).toContain('restart required');
+    expect(result.message).toContain('agents');
+    expect(result.message).toContain('log');
+  });
+});

--- a/packages/cli/src/config-reload.ts
+++ b/packages/cli/src/config-reload.ts
@@ -4,6 +4,7 @@ import type {
   EngineRuntimeUpdate,
   Logger,
 } from '@agent-nexus/daemon';
+import { agentOwnersForPlatform } from './command-registry.js';
 import { buildRoutingTable, type AgentNexusConfig } from './config.js';
 
 /** reload 时被热替换的 engine 目标；语义见 docs/dev/spec/config-routing.md §配置热重载 */
@@ -99,6 +100,20 @@ export function createConfigReloader(
     if (missingPlatforms.length > 0) {
       return failed(
         `新配置缺少运行中的 platform：${missingPlatforms.join(', ')}（platforms[] 变更需重启生效）`,
+      );
+    }
+
+    // slash command 注册集按启动时各 platform 的 agent owner 集合生成，
+    // 不在 reload 事务内；owner 集合变化会让已注册命令与路由失配，按失败处理
+    const ownerSet = (config: AgentNexusConfig, platformName: string) =>
+      [...agentOwnersForPlatform(config, platformName)].sort().join(',');
+    const ownerChangedPlatforms = opts.targets
+      .map((target) => target.platformName)
+      .filter((name) => ownerSet(current, name) !== ownerSet(next, name));
+    if (ownerChangedPlatforms.length > 0) {
+      return failed(
+        `bindings 变更改变了 platform 的 agent owner 集合：${ownerChangedPlatforms.join(', ')}；` +
+          'slash command 注册集不在 reload 事务内，需重启生效',
       );
     }
 

--- a/packages/cli/src/config-reload.ts
+++ b/packages/cli/src/config-reload.ts
@@ -1,0 +1,135 @@
+import type {
+  DaemonConfigReloader,
+  DaemonConfigReloadResult,
+  EngineRuntimeUpdate,
+  Logger,
+} from '@agent-nexus/daemon';
+import { buildRoutingTable, type AgentNexusConfig } from './config.js';
+
+/** reload 时被热替换的 engine 目标；语义见 docs/dev/spec/config-routing.md §配置热重载 */
+export interface ConfigReloadTarget {
+  platformName: string;
+  applyRuntimeUpdate(update: EngineRuntimeUpdate): void;
+}
+
+export interface CreateConfigReloaderOptions {
+  initialConfig: AgentNexusConfig;
+  load: () => Promise<AgentNexusConfig>;
+  /** call 时读取，允许调用方在 engine 逐个创建期间填充 */
+  targets: readonly ConfigReloadTarget[];
+  runningAgentNames: readonly string[];
+  logger: Logger;
+}
+
+function failed(reason: string): DaemonConfigReloadResult {
+  return {
+    status: 'failed',
+    message: `[config reload failed] previous config kept:\n${reason}`,
+  };
+}
+
+/** 仅重启生效 section 的变更检测；热生效字段（auth / textPrefixes）剔除后再比较 */
+function restartOnlyChanges(
+  prev: AgentNexusConfig,
+  next: AgentNexusConfig,
+): string[] {
+  const platformsSansAuth = (config: AgentNexusConfig) =>
+    config.platforms.map(({ auth: _auth, ...rest }) => rest);
+  const daemonSansTextPrefixes = (config: AgentNexusConfig) => ({
+    ...config.daemon,
+    commandRegistry: {
+      ...config.daemon.commandRegistry,
+      textPrefixes: undefined,
+    },
+  });
+  const sections: string[] = [];
+  if (
+    JSON.stringify(platformsSansAuth(prev)) !==
+    JSON.stringify(platformsSansAuth(next))
+  ) {
+    sections.push('platforms');
+  }
+  if (JSON.stringify(prev.agents) !== JSON.stringify(next.agents)) {
+    sections.push('agents');
+  }
+  if (
+    JSON.stringify(daemonSansTextPrefixes(prev)) !==
+    JSON.stringify(daemonSansTextPrefixes(next))
+  ) {
+    sections.push('daemon');
+  }
+  if (JSON.stringify(prev.log) !== JSON.stringify(next.log)) {
+    sections.push('log');
+  }
+  return sections;
+}
+
+export function createConfigReloader(
+  opts: CreateConfigReloaderOptions,
+): DaemonConfigReloader {
+  let current = opts.initialConfig;
+  return async (): Promise<DaemonConfigReloadResult> => {
+    let next: AgentNexusConfig;
+    try {
+      next = await opts.load();
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      opts.logger.error({ err }, 'config_reload_failed');
+      return failed(reason);
+    }
+
+    const running = new Set(opts.runningAgentNames);
+    const missingAgents = [
+      ...new Set(
+        next.bindings
+          .filter((binding) => !running.has(binding.agentName))
+          .map((binding) => binding.agentName),
+      ),
+    ];
+    if (missingAgents.length > 0) {
+      return failed(
+        `bindings 引用了未运行的 agent：${missingAgents.join(', ')}（agents[] 变更需重启生效）`,
+      );
+    }
+
+    const platformNames = new Set(next.platforms.map((platform) => platform.name));
+    const missingPlatforms = opts.targets
+      .filter((target) => !platformNames.has(target.platformName))
+      .map((target) => target.platformName);
+    if (missingPlatforms.length > 0) {
+      return failed(
+        `新配置缺少运行中的 platform：${missingPlatforms.join(', ')}（platforms[] 变更需重启生效）`,
+      );
+    }
+
+    const routingTable = buildRoutingTable(next);
+    const authByPlatform = new Map(
+      next.platforms.map((platform) => [platform.name, platform.auth]),
+    );
+    for (const target of opts.targets) {
+      const platformAuth = authByPlatform.get(target.platformName);
+      if (!platformAuth) continue; // missingPlatforms 已兜住；保留给类型收窄
+      target.applyRuntimeUpdate({
+        routingTable,
+        platformAuth,
+        toolMessageMode: next.ui.toolMessages,
+        newSessionTextPrefix: next.daemon.commandRegistry.textPrefixes.newSession,
+      });
+    }
+
+    const restartSections = restartOnlyChanges(current, next);
+    current = next;
+    opts.logger.info(
+      { targets: opts.targets.length, restartSections },
+      'config_reloaded',
+    );
+    const restartNote =
+      restartSections.length > 0
+        ? `\nrestart required for: ${restartSections.join(', ')}`
+        : '';
+    return {
+      status: 'reloaded',
+      message: `[config reloaded] applied: bindings, auth, ui, text prefixes${restartNote}`,
+    };
+  };
+}

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -26,6 +26,7 @@ import {
   type DaemonConfig,
   type DaemonRuntimeConfig,
   type PlatformAuthConfig,
+  type RoutingEntry,
   DaemonConfigError,
 } from '@agent-nexus/daemon';
 
@@ -649,6 +650,27 @@ export async function loadConfig(): Promise<AgentNexusConfig> {
     ui,
     log: parseLog(parsed['log']),
   };
+}
+
+export function buildRoutingTable(config: AgentNexusConfig): RoutingEntry[] {
+  const platformsByName = new Map(
+    config.platforms.map((platform) => [platform.name, platform]),
+  );
+  return config.bindings.map((binding) => {
+    const platform = platformsByName.get(binding.platformName);
+    if (!platform) {
+      throw new ConfigError(
+        `binding "${binding.name}" 引用了不存在的 platform "${binding.platformName}"`,
+      );
+    }
+    return {
+      bindingName: binding.name,
+      platformName: binding.platformName,
+      platformType: platform.type,
+      agentName: binding.agentName,
+      match: binding.match,
+    };
+  });
 }
 
 function assertValidSecretName(name: string): void {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -16,8 +16,13 @@ import {
 import { createAgentRegistry } from './agent.js';
 import { buildCliCommandRegistrationPlan } from './command-registry.js';
 import {
+  createConfigReloader,
+  type ConfigReloadTarget,
+} from './config-reload.js';
+import {
   ConfigError,
   SecretsPermissionError,
+  buildRoutingTable,
   loadConfig,
   loadSecret,
 } from './config.js';
@@ -63,24 +68,7 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  const platformsByName = new Map(
-    config.platforms.map((platform) => [platform.name, platform]),
-  );
-  const routingTable: RoutingEntry[] = config.bindings.map((binding) => {
-    const platform = platformsByName.get(binding.platformName);
-    if (!platform) {
-      throw new ConfigError(
-        `binding "${binding.name}" 引用了不存在的 platform "${binding.platformName}"`,
-      );
-    }
-    return {
-      bindingName: binding.name,
-      platformName: binding.platformName,
-      platformType: platform.type,
-      agentName: binding.agentName,
-      match: binding.match,
-    };
-  });
+  const routingTable: RoutingEntry[] = buildRoutingTable(config);
   logger.info(
     {
       platforms: config.platforms.map((platform) => platform.name),
@@ -93,6 +81,15 @@ async function main(): Promise<void> {
   const sessionStore = new SessionStore();
   const commandRegistry = new ActiveCommandRegistry();
   const engines: Engine[] = [];
+  // targets 在下面循环里随 engine 创建逐个填充；reloader 调用时才读取
+  const configReloadTargets: ConfigReloadTarget[] = [];
+  const configReloader = createConfigReloader({
+    initialConfig: config,
+    load: loadConfig,
+    targets: configReloadTargets,
+    runningAgentNames: agents.map((agent) => agent.agentName),
+    logger,
+  });
 
   for (const platformConfig of config.platforms) {
     logger.info(
@@ -159,28 +156,32 @@ async function main(): Promise<void> {
       },
     });
 
-    engines.push(
-      new Engine({
-        platform,
-        platformName: platformConfig.name,
-        platformType: platformConfig.type,
-        platformAuth: platformConfig.auth,
-        commandRegistry,
-        daemonCommandHandlerKeys: daemonCommandDescriptors.map(
-          (descriptor) => descriptor.handlerKey,
-        ),
-        agents,
-        routingTable,
-        logger,
-        sessionStore,
-        toolMessages: {
-          mode: config.ui.toolMessages,
-        },
-        textPrefixes: {
-          newSession: config.daemon.commandRegistry.textPrefixes.newSession,
-        },
-      }),
-    );
+    const engine = new Engine({
+      platform,
+      platformName: platformConfig.name,
+      platformType: platformConfig.type,
+      platformAuth: platformConfig.auth,
+      commandRegistry,
+      daemonCommandHandlerKeys: daemonCommandDescriptors.map(
+        (descriptor) => descriptor.handlerKey,
+      ),
+      configReloader,
+      agents,
+      routingTable,
+      logger,
+      sessionStore,
+      toolMessages: {
+        mode: config.ui.toolMessages,
+      },
+      textPrefixes: {
+        newSession: config.daemon.commandRegistry.textPrefixes.newSession,
+      },
+    });
+    engines.push(engine);
+    configReloadTargets.push({
+      platformName: platformConfig.name,
+      applyRuntimeUpdate: (update) => engine.applyRuntimeUpdate(update),
+    });
   }
 
   await Promise.all(engines.map((engine) => engine.start()));

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -180,7 +180,15 @@ async function main(): Promise<void> {
     engines.push(engine);
     configReloadTargets.push({
       platformName: platformConfig.name,
-      applyRuntimeUpdate: (update) => engine.applyRuntimeUpdate(update),
+      applyRuntimeUpdate: (update) => {
+        engine.applyRuntimeUpdate(update);
+        // adapter 内部命令（/discord-reply-mode）授权跟随热替换；
+        // chat 授权由 daemon platform auth 全维度判定（null = inbound guard 关闭，与启动语义一致）
+        platform.updateAuth({
+          allowedUserIds: update.platformAuth.allowlist.userIds,
+          inboundAllowedUserIds: null,
+        });
+      },
     });
   }
 

--- a/packages/daemon/src/command-descriptors.test.ts
+++ b/packages/daemon/src/command-descriptors.test.ts
@@ -14,6 +14,16 @@ describe('daemonCommandDescriptors', () => {
         },
         legacyNames: [],
       }),
+      expect.objectContaining({
+        canonicalId: 'daemon:reload-config',
+        owner: { type: 'daemon' },
+        localName: 'reload-config',
+        handlerKey: 'reload-config',
+        applicability: {
+          requiredCapabilities: ['slash-command-registration'],
+        },
+        legacyNames: [],
+      }),
     ]);
   });
 });

--- a/packages/daemon/src/command-descriptors.ts
+++ b/packages/daemon/src/command-descriptors.ts
@@ -13,4 +13,16 @@ export const daemonCommandDescriptors: readonly CommandDescriptor[] = [
     },
     legacyNames: [],
   },
+  {
+    canonicalId: 'daemon:reload-config',
+    owner: { type: 'daemon' },
+    localName: 'reload-config',
+    summary: 'Reload config.json and apply runtime-safe fields',
+    options: [],
+    handlerKey: 'reload-config',
+    applicability: {
+      requiredCapabilities: ['slash-command-registration'],
+    },
+    legacyNames: [],
+  },
 ];

--- a/packages/daemon/src/engine.test.ts
+++ b/packages/daemon/src/engine.test.ts
@@ -1895,6 +1895,141 @@ describe('Engine', () => {
     expect(codex.sendInput).toHaveBeenCalledTimes(1);
   });
 
+  it('applyRuntimeUpdate 切到 role-only allowlist 后按 role 维度判定', async () => {
+    const platform = makePlatform();
+    const codex = makeAgent();
+    const routingTable: RoutingEntry[] = [
+      {
+        bindingName: 'discord-main-codex',
+        platformName: 'discord-main',
+        platformType: 'discord',
+        agentName: 'codex-dev',
+        match: { discord: { channelIds: ['C1'] } },
+      },
+    ];
+    const engine = new Engine({
+      platform,
+      platformName: 'discord-main',
+      platformType: 'discord',
+      agents: [
+        {
+          agentName: 'codex-dev',
+          agentOwner: 'codex',
+          agent: codex.runtime,
+          defaultSessionConfig: DEFAULT_CFG,
+        },
+      ],
+      routingTable,
+      platformAuth: PLATFORM_AUTH_ALLOW_U1,
+      logger: SILENT_LOGGER,
+      sessionStore: new SessionStore(),
+    });
+
+    await engine.start();
+    const dispatchHandler = (platform.start as ReturnType<typeof vi.fn>).mock.calls[0]![0] as EventHandler;
+
+    engine.applyRuntimeUpdate({
+      routingTable,
+      platformAuth: {
+        allowlist: {
+          userIds: [],
+          roleIds: ['R1'],
+          allowedGuildIds: [],
+          allowedChannelIds: [],
+          allowDM: true,
+          requireMentionOrSlash: true,
+        },
+      },
+      toolMessageMode: 'append',
+      newSessionTextPrefix: true,
+    });
+
+    // 旧 userIds 用户、无 role：拒绝
+    await dispatchHandler(makeEvent('hello', { guildId: 'G1' }));
+    expect(codex.sendInput).not.toHaveBeenCalled();
+
+    codex.queueEvents([
+      ev('session_started', { agentSessionId: 'sid-1' }),
+      ev('text_final', { text: 'hi' }),
+      ev('turn_finished', { reason: 'stop', turnSequence: 1 }),
+    ]);
+    await dispatchHandler(
+      makeEvent('hello', {
+        guildId: 'G1',
+        initiatorRoleIds: ['R1'],
+        sessionKey: { platform: 'discord', channelId: 'C1', initiatorUserId: 'U9' },
+        initiator: { userId: 'U9', displayName: 'U9', isBot: false },
+      }),
+    );
+    expect(codex.sendInput).toHaveBeenCalledTimes(1);
+  });
+
+  it('turn 进行中 applyRuntimeUpdate 切换 toolMessages 不影响当前 turn 渲染', async () => {
+    const platform = makePlatform();
+    const codex = makeAgent();
+    const routingTable: RoutingEntry[] = [
+      {
+        bindingName: 'discord-main-codex',
+        platformName: 'discord-main',
+        platformType: 'discord',
+        agentName: 'codex-dev',
+        match: { discord: { channelIds: ['C1'] } },
+      },
+    ];
+    const engine = new Engine({
+      platform,
+      platformName: 'discord-main',
+      platformType: 'discord',
+      agents: [
+        {
+          agentName: 'codex-dev',
+          agentOwner: 'codex',
+          agent: codex.runtime,
+          defaultSessionConfig: DEFAULT_CFG,
+        },
+      ],
+      routingTable,
+      platformAuth: PLATFORM_AUTH_ALLOW_U1,
+      logger: SILENT_LOGGER,
+      sessionStore: new SessionStore(),
+      toolMessages: { mode: 'append' },
+    });
+
+    await engine.start();
+    const dispatchHandler = (platform.start as ReturnType<typeof vi.fn>).mock.calls[0]![0] as EventHandler;
+
+    codex.queueEventsAfter(
+      [
+        ev('session_started', { agentSessionId: 'sid-1' }),
+        ev('tool_call_started', {
+          callId: 'tc-1',
+          toolName: 'Bash',
+          inputSummary: 'ls',
+        }),
+        ev('turn_finished', { reason: 'stop', turnSequence: 1 }),
+      ],
+      40,
+    );
+    const dispatchPromise = dispatchHandler(makeEvent('hello'));
+    // turn 已开始（snapshot 应已取），事件 40ms 后才到——窗口内切 compact
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    engine.applyRuntimeUpdate({
+      routingTable,
+      platformAuth: PLATFORM_AUTH_ALLOW_U1,
+      toolMessageMode: 'compact',
+      newSessionTextPrefix: true,
+    });
+    await dispatchPromise;
+
+    // 当前 turn 仍按 append 渲染：tool message 独立发送、不补 [empty response]
+    expect(platform.send).toHaveBeenCalledTimes(1);
+    const texts = platform.send.mock.calls.map(
+      (call) => (call[1] as OutboundMessage).text,
+    );
+    expect(texts[0]).toContain('Bash');
+    expect(texts).not.toContain('[empty response]');
+  });
+
   it('applyRuntimeUpdate 关闭 newSession text prefix 后 /new 文本按普通 prompt 转发', async () => {
     const platform = makePlatform();
     const codex = makeAgent();

--- a/packages/daemon/src/engine.test.ts
+++ b/packages/daemon/src/engine.test.ts
@@ -346,6 +346,19 @@ const DAEMON_KILL_COMMAND: CommandDescriptor = {
   legacyNames: [],
 };
 
+const DAEMON_RELOAD_CONFIG_COMMAND: CommandDescriptor = {
+  canonicalId: 'daemon:reload-config',
+  owner: { type: 'daemon' },
+  localName: 'reload-config',
+  summary: 'Reload config.json and apply runtime-safe fields',
+  options: [],
+  handlerKey: 'reload-config',
+  applicability: {
+    requiredCapabilities: ['slash-command-registration'],
+  },
+  legacyNames: [],
+};
+
 function makeCommandEvent(
   commandName: string,
   overrides: Partial<NormalizedEvent> = {},
@@ -1611,6 +1624,327 @@ describe('Engine', () => {
     expect(platform.send).toHaveBeenCalledWith(
       expect.objectContaining({ platformName: 'discord-main' }),
       expect.objectContaining({ text: '[session killed]' }),
+    );
+  });
+
+  it('daemon /nexus-reload-config 把注入 reloader 的成功结果作为 ephemeral response 返回', async () => {
+    const platform = makePlatform({ supportsSlashCommands: true });
+    const codex = makeAgent();
+    const configReloader = vi.fn(async () => ({
+      status: 'reloaded' as const,
+      message: '[config reloaded] applied: bindings, auth, ui, text prefixes',
+    }));
+    const engine = new Engine({
+      platform,
+      platformName: 'discord-main',
+      platformType: 'discord',
+      agents: [
+        {
+          agentName: 'codex-dev',
+          agentOwner: 'codex',
+          agent: codex.runtime,
+          defaultSessionConfig: DEFAULT_CFG,
+        },
+      ],
+      routingTable: [
+        {
+          bindingName: 'discord-main-codex',
+          platformName: 'discord-main',
+          platformType: 'discord',
+          agentName: 'codex-dev',
+          match: { discord: { channelIds: ['C1'] } },
+        },
+      ],
+      platformAuth: PLATFORM_AUTH_ALLOW_U1,
+      commandRegistry: makeActiveRegistry([DAEMON_RELOAD_CONFIG_COMMAND]),
+      daemonCommandHandlerKeys: ['kill', 'reload-config'],
+      configReloader,
+      logger: SILENT_LOGGER,
+      sessionStore: new SessionStore(),
+    });
+
+    await engine.start();
+    const dispatchHandler = (platform.start as ReturnType<typeof vi.fn>).mock.calls[0]![0] as EventHandler;
+    const result = await dispatchHandler(makeCommandEvent('nexus-reload-config'));
+
+    expect(configReloader).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      commandResponse: {
+        text: '[config reloaded] applied: bindings, auth, ui, text prefixes',
+        ephemeral: true,
+      },
+    });
+    expect(platform.send).not.toHaveBeenCalled();
+  });
+
+  it('daemon /nexus-reload-config reloader 报失败时把错误文本返回触发者', async () => {
+    const platform = makePlatform({ supportsSlashCommands: true });
+    const codex = makeAgent();
+    const configReloader = vi.fn(async () => ({
+      status: 'failed' as const,
+      message: '[config reload failed] previous config kept:\nconfig.json 不是合法 JSON',
+    }));
+    const engine = new Engine({
+      platform,
+      platformName: 'discord-main',
+      platformType: 'discord',
+      agents: [
+        {
+          agentName: 'codex-dev',
+          agentOwner: 'codex',
+          agent: codex.runtime,
+          defaultSessionConfig: DEFAULT_CFG,
+        },
+      ],
+      routingTable: [
+        {
+          bindingName: 'discord-main-codex',
+          platformName: 'discord-main',
+          platformType: 'discord',
+          agentName: 'codex-dev',
+          match: { discord: { channelIds: ['C1'] } },
+        },
+      ],
+      platformAuth: PLATFORM_AUTH_ALLOW_U1,
+      commandRegistry: makeActiveRegistry([DAEMON_RELOAD_CONFIG_COMMAND]),
+      daemonCommandHandlerKeys: ['kill', 'reload-config'],
+      configReloader,
+      logger: SILENT_LOGGER,
+      sessionStore: new SessionStore(),
+    });
+
+    await engine.start();
+    const dispatchHandler = (platform.start as ReturnType<typeof vi.fn>).mock.calls[0]![0] as EventHandler;
+    const result = await dispatchHandler(makeCommandEvent('nexus-reload-config'));
+
+    expect(result).toEqual({
+      commandResponse: {
+        text: '[config reload failed] previous config kept:\nconfig.json 不是合法 JSON',
+        ephemeral: true,
+      },
+    });
+  });
+
+  it('daemon /nexus-reload-config reloader 抛错时返回通用失败反馈并记日志', async () => {
+    const platform = makePlatform({ supportsSlashCommands: true });
+    const codex = makeAgent();
+    const mockLogger = makeMockLogger();
+    const configReloader = vi.fn(async () => {
+      throw new Error('boom');
+    });
+    const engine = new Engine({
+      platform,
+      platformName: 'discord-main',
+      platformType: 'discord',
+      agents: [
+        {
+          agentName: 'codex-dev',
+          agentOwner: 'codex',
+          agent: codex.runtime,
+          defaultSessionConfig: DEFAULT_CFG,
+        },
+      ],
+      routingTable: [
+        {
+          bindingName: 'discord-main-codex',
+          platformName: 'discord-main',
+          platformType: 'discord',
+          agentName: 'codex-dev',
+          match: { discord: { channelIds: ['C1'] } },
+        },
+      ],
+      platformAuth: PLATFORM_AUTH_ALLOW_U1,
+      commandRegistry: makeActiveRegistry([DAEMON_RELOAD_CONFIG_COMMAND]),
+      daemonCommandHandlerKeys: ['kill', 'reload-config'],
+      configReloader,
+      logger: mockLogger,
+      sessionStore: new SessionStore(),
+    });
+
+    await engine.start();
+    const dispatchHandler = (platform.start as ReturnType<typeof vi.fn>).mock.calls[0]![0] as EventHandler;
+    const result = await dispatchHandler(makeCommandEvent('nexus-reload-config'));
+
+    expect(result).toEqual({
+      commandResponse: {
+        text: 'Command failed.',
+        ephemeral: true,
+      },
+    });
+    const errorCalls = (mockLogger.error as ReturnType<typeof vi.fn>).mock.calls;
+    expect(errorCalls.find(([, msg]) => msg === 'config_reload_failed')).toBeDefined();
+  });
+
+  it('daemon /nexus-reload-config 未注入 reloader 时返回未就绪反馈', async () => {
+    const platform = makePlatform({ supportsSlashCommands: true });
+    const codex = makeAgent();
+    const mockLogger = makeMockLogger();
+    const engine = new Engine({
+      platform,
+      platformName: 'discord-main',
+      platformType: 'discord',
+      agents: [
+        {
+          agentName: 'codex-dev',
+          agentOwner: 'codex',
+          agent: codex.runtime,
+          defaultSessionConfig: DEFAULT_CFG,
+        },
+      ],
+      routingTable: [
+        {
+          bindingName: 'discord-main-codex',
+          platformName: 'discord-main',
+          platformType: 'discord',
+          agentName: 'codex-dev',
+          match: { discord: { channelIds: ['C1'] } },
+        },
+      ],
+      platformAuth: PLATFORM_AUTH_ALLOW_U1,
+      commandRegistry: makeActiveRegistry([DAEMON_RELOAD_CONFIG_COMMAND]),
+      daemonCommandHandlerKeys: ['kill', 'reload-config'],
+      logger: mockLogger,
+      sessionStore: new SessionStore(),
+    });
+
+    await engine.start();
+    const dispatchHandler = (platform.start as ReturnType<typeof vi.fn>).mock.calls[0]![0] as EventHandler;
+    const result = await dispatchHandler(makeCommandEvent('nexus-reload-config'));
+
+    expect(result).toEqual({
+      commandResponse: {
+        text: 'Slash commands are not ready yet. Try again later.',
+        ephemeral: true,
+      },
+    });
+    const errorCalls = (mockLogger.error as ReturnType<typeof vi.fn>).mock.calls;
+    expect(errorCalls.find(([, msg]) => msg === 'command_handler_missing')).toBeDefined();
+  });
+
+  it('applyRuntimeUpdate 生效后按新 routing table 与 auth 处理后续事件', async () => {
+    const platform = makePlatform();
+    const codex = makeAgent();
+    const engine = new Engine({
+      platform,
+      platformName: 'discord-main',
+      platformType: 'discord',
+      agents: [
+        {
+          agentName: 'codex-dev',
+          agentOwner: 'codex',
+          agent: codex.runtime,
+          defaultSessionConfig: DEFAULT_CFG,
+        },
+      ],
+      routingTable: [
+        {
+          bindingName: 'discord-main-codex',
+          platformName: 'discord-main',
+          platformType: 'discord',
+          agentName: 'codex-dev',
+          match: { discord: { channelIds: ['C1'] } },
+        },
+      ],
+      platformAuth: PLATFORM_AUTH_ALLOW_U1,
+      logger: SILENT_LOGGER,
+      sessionStore: new SessionStore(),
+    });
+
+    await engine.start();
+    const dispatchHandler = (platform.start as ReturnType<typeof vi.fn>).mock.calls[0]![0] as EventHandler;
+
+    engine.applyRuntimeUpdate({
+      routingTable: [
+        {
+          bindingName: 'discord-main-codex-c2',
+          platformName: 'discord-main',
+          platformType: 'discord',
+          agentName: 'codex-dev',
+          match: { discord: { channelIds: ['C2'] } },
+        },
+      ],
+      platformAuth: {
+        allowlist: {
+          userIds: ['U2'],
+          roleIds: [],
+          allowedGuildIds: [],
+          allowedChannelIds: [],
+          allowDM: true,
+          requireMentionOrSlash: true,
+        },
+      },
+      toolMessageMode: 'append',
+      newSessionTextPrefix: true,
+    });
+
+    // 旧表里 C1 的 U1：新 auth 不再放行
+    await dispatchHandler(makeEvent('hello'));
+    expect(codex.sendInput).not.toHaveBeenCalled();
+
+    codex.queueEvents([
+      ev('session_started', { agentSessionId: 'sid-1' }),
+      ev('text_final', { text: 'hi' }),
+      ev('turn_finished', { reason: 'stop', turnSequence: 1 }),
+    ]);
+    await dispatchHandler(
+      makeEvent('hello', {
+        sessionKey: { platform: 'discord', channelId: 'C2', initiatorUserId: 'U2' },
+        initiator: { userId: 'U2', displayName: 'U2', isBot: false },
+      }),
+    );
+    expect(codex.sendInput).toHaveBeenCalledTimes(1);
+  });
+
+  it('applyRuntimeUpdate 关闭 newSession text prefix 后 /new 文本按普通 prompt 转发', async () => {
+    const platform = makePlatform();
+    const codex = makeAgent();
+    const routingTable: RoutingEntry[] = [
+      {
+        bindingName: 'discord-main-codex',
+        platformName: 'discord-main',
+        platformType: 'discord',
+        agentName: 'codex-dev',
+        match: { discord: { channelIds: ['C1'] } },
+      },
+    ];
+    const engine = new Engine({
+      platform,
+      platformName: 'discord-main',
+      platformType: 'discord',
+      agents: [
+        {
+          agentName: 'codex-dev',
+          agentOwner: 'codex',
+          agent: codex.runtime,
+          defaultSessionConfig: DEFAULT_CFG,
+        },
+      ],
+      routingTable,
+      platformAuth: PLATFORM_AUTH_ALLOW_U1,
+      logger: SILENT_LOGGER,
+      sessionStore: new SessionStore(),
+    });
+
+    await engine.start();
+    const dispatchHandler = (platform.start as ReturnType<typeof vi.fn>).mock.calls[0]![0] as EventHandler;
+
+    engine.applyRuntimeUpdate({
+      routingTable,
+      platformAuth: PLATFORM_AUTH_ALLOW_U1,
+      toolMessageMode: 'append',
+      newSessionTextPrefix: false,
+    });
+
+    codex.queueEvents([
+      ev('session_started', { agentSessionId: 'sid-1' }),
+      ev('text_final', { text: 'hi' }),
+      ev('turn_finished', { reason: 'stop', turnSequence: 1 }),
+    ]);
+    await dispatchHandler(makeEvent('/new'));
+
+    expect(codex.sendInput).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ text: '/new' }),
     );
   });
 

--- a/packages/daemon/src/engine.ts
+++ b/packages/daemon/src/engine.ts
@@ -757,6 +757,9 @@ export class Engine {
       }
 
       const platformCaps = this.platform.capabilities();
+      // turn 级 snapshot：reload 切换 toolMessages 只影响后续 turn，
+      // 避免同一 turn 内前后段按不同模式混合渲染
+      const toolMessageMode = this.toolMessageMode;
       let session: AgentSession | undefined;
       let buf = '';
       let sawDelta = false;
@@ -921,7 +924,7 @@ export class Engine {
       const finalizeReply = async (): Promise<void> => {
         cancelPendingEdit();
         if (
-          this.toolMessageMode === 'append' &&
+          toolMessageMode === 'append' &&
           toolMessages.size > 0 &&
           buf.length === 0
         ) {
@@ -1089,7 +1092,7 @@ export class Engine {
               e.payload.toolName,
               e.payload.inputSummary,
             );
-            if (this.toolMessageMode === 'append') {
+            if (toolMessageMode === 'append') {
               await splitAssistantMessageBeforeTool();
               await upsertToolMessage(
                 e.payload.callId,
@@ -1102,7 +1105,7 @@ export class Engine {
             return;
           }
           if (e.type === 'tool_call_progress') {
-            if (this.toolMessageMode === 'compact') {
+            if (toolMessageMode === 'compact') {
               await ensureToolVisible(`[tool: ${e.payload.callId}] running`);
             }
             return;
@@ -1119,7 +1122,7 @@ export class Engine {
               },
               'tool_result',
             );
-            if (this.toolMessageMode === 'compact') {
+            if (toolMessageMode === 'compact') {
               await ensureToolVisible(`[tool: ${e.payload.callId}] result`);
             }
             return;
@@ -1138,7 +1141,7 @@ export class Engine {
               },
               'tool_call_finished',
             );
-            if (this.toolMessageMode === 'compact') {
+            if (toolMessageMode === 'compact') {
               await ensureToolVisible(
                 `[tool: ${e.payload.toolName}] ${e.payload.status}`,
               );

--- a/packages/daemon/src/engine.ts
+++ b/packages/daemon/src/engine.ts
@@ -41,6 +41,20 @@ export interface EngineAgent {
   >;
 }
 
+/** config reloader 由组装层注入；语义见 docs/dev/spec/config-routing.md §配置热重载 */
+export type DaemonConfigReloadResult =
+  | { status: 'reloaded'; message: string }
+  | { status: 'failed'; message: string };
+
+export type DaemonConfigReloader = () => Promise<DaemonConfigReloadResult>;
+
+export interface EngineRuntimeUpdate {
+  routingTable: readonly RoutingEntry[];
+  platformAuth: PlatformAuthConfig;
+  toolMessageMode: ToolMessageMode;
+  newSessionTextPrefix: boolean;
+}
+
 export interface EngineDeps {
   platform: PlatformAdapter;
   platformName?: string;
@@ -52,6 +66,7 @@ export interface EngineDeps {
   commandRegistry?: ActiveCommandRegistry;
   platformCommandHandlerKeys?: readonly string[];
   daemonCommandHandlerKeys?: readonly string[];
+  configReloader?: DaemonConfigReloader;
   logger: Logger;
   sessionStore: SessionStore;
   /** 每轮 sessionId 由 Engine 生成；resumeFromAgentSessionId 由 store 决定 */
@@ -124,18 +139,20 @@ export class Engine {
   private readonly platform: PlatformAdapter;
   private readonly platformName: string;
   private readonly platformType: 'discord';
-  private readonly platformAuth?: PlatformAuthConfig;
+  // applyRuntimeUpdate 热替换的四个字段；其余 deps 启动后不可变
+  private platformAuth?: PlatformAuthConfig;
+  private routingTable?: readonly RoutingEntry[];
+  private toolMessageMode: ToolMessageMode;
+  private newSessionTextPrefixEnabled: boolean;
   private readonly commandRegistry?: ActiveCommandRegistry;
   private readonly platformCommandHandlerKeys: readonly string[];
   private readonly daemonCommandHandlerKeys: readonly string[];
+  private readonly configReloader?: DaemonConfigReloader;
   private readonly agents: Map<string, EngineAgent>;
-  private readonly routingTable?: readonly RoutingEntry[];
   private readonly logger: Logger;
   private readonly sessionStore: SessionStore;
   private readonly streamEditThrottleMs: number;
   private readonly typingRefreshMs: number;
-  private readonly toolMessageMode: ToolMessageMode;
-  private readonly newSessionTextPrefixEnabled: boolean;
   private readonly agentSessions = new Map<string, ActiveAgentSession>();
   /**
    * Per-SessionKey 串行队列：同 key 的 dispatch 必须按到达序排队执行，
@@ -164,6 +181,7 @@ export class Engine {
     this.commandRegistry = deps.commandRegistry;
     this.platformCommandHandlerKeys = deps.platformCommandHandlerKeys ?? [];
     this.daemonCommandHandlerKeys = deps.daemonCommandHandlerKeys ?? [];
+    this.configReloader = deps.configReloader;
     this.routingTable = deps.routingTable;
     this.agents = new Map();
     if (deps.agents) {
@@ -191,6 +209,14 @@ export class Engine {
 
   async start(): Promise<void> {
     await this.platform.start(this.dispatch.bind(this));
+  }
+
+  /** 热替换运行期可安全更新的配置字段；语义见 docs/dev/spec/config-routing.md §配置热重载 */
+  applyRuntimeUpdate(update: EngineRuntimeUpdate): void {
+    this.routingTable = update.routingTable;
+    this.platformAuth = update.platformAuth;
+    this.toolMessageMode = update.toolMessageMode;
+    this.newSessionTextPrefixEnabled = update.newSessionTextPrefix;
   }
 
   async stop(): Promise<void> {
@@ -551,6 +577,9 @@ export class Engine {
     event: NormalizedEvent,
     decision: Extract<CommandDispatchDecision, { ownerType: 'daemon' }>,
   ): Promise<void | EventHandlerResult> {
+    if (decision.handlerKey === 'reload-config' && this.configReloader) {
+      return this.handleReloadConfigCommand(event, decision);
+    }
     if (decision.handlerKey !== 'kill') {
       this.logger.error(
         {
@@ -581,6 +610,41 @@ export class Engine {
         ? '[session killed]'
         : '[no active session]',
     );
+  }
+
+  private async handleReloadConfigCommand(
+    event: NormalizedEvent,
+    decision: Extract<CommandDispatchDecision, { ownerType: 'daemon' }>,
+  ): Promise<EventHandlerResult> {
+    if (!this.configReloader) {
+      return this.commandResponse(COMMAND_NOT_READY_TEXT);
+    }
+    let result: DaemonConfigReloadResult;
+    try {
+      result = await this.configReloader();
+    } catch (err) {
+      this.logger.error(
+        {
+          traceId: event.traceId,
+          platformName: this.platformName,
+          commandName: decision.commandName,
+          canonicalId: decision.canonicalId,
+          err,
+        },
+        'config_reload_failed',
+      );
+      return this.commandResponse(COMMAND_FAILED_TEXT);
+    }
+    this.logger.info(
+      {
+        traceId: event.traceId,
+        platformName: this.platformName,
+        commandName: decision.commandName,
+        status: result.status,
+      },
+      'config_reload_result',
+    );
+    return this.commandResponse(result.message);
   }
 
   private route(event: NormalizedEvent):

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -1,6 +1,13 @@
 export { createLogger, type Logger, type CreateLoggerOptions } from './logger.js';
 export { checkPlatformAuth, type AuthDecision } from './auth.js';
-export { Engine, type EngineAgent, type EngineDeps } from './engine.js';
+export {
+  Engine,
+  type DaemonConfigReloader,
+  type DaemonConfigReloadResult,
+  type EngineAgent,
+  type EngineDeps,
+  type EngineRuntimeUpdate,
+} from './engine.js';
 export {
   RouteError,
   selectRoute,

--- a/packages/platform/discord/src/index.test.ts
+++ b/packages/platform/discord/src/index.test.ts
@@ -444,6 +444,86 @@ describe('command registry integration', () => {
     });
   });
 
+  it('updateAuth 热替换后 reply-mode 授权立即按新 allowlist 判定', async () => {
+    const logger = makeLogger();
+    const platform = createDiscordPlatform({
+      token: 'test-token',
+      botUserId: BOT_ID,
+      logger,
+      statePath: '/tmp/agent-nexus-missing-dir/reply-mode-auth.json',
+      allowedUserIds: ['U-old'],
+      commandRegistration: {
+        plan: {
+          scope: {
+            platformName: 'discord-main',
+            platformType: 'discord' as const,
+            nativeScope: { kind: 'global' as const },
+          },
+          commands: [],
+          reverseMap: {
+            entries: {
+              'discord-reply-mode': {
+                canonicalId: 'platform:discord:reply-mode',
+                aliasKind: 'stable' as const,
+                owner: { type: 'platform' as const, platformType: 'discord' },
+                handlerKey: 'reply-mode',
+              },
+            },
+          },
+          generation: 'g-auth-update',
+        },
+        apply: vi.fn(async () => ({
+          status: 'applied' as const,
+          generation: 'g-auth-update',
+        })),
+      },
+    });
+
+    await platform.start(vi.fn());
+    const interactionCreate = registeredHandler('interactionCreate');
+    const makeReplyModeInteraction = (
+      userId: string,
+      reply: ReturnType<typeof vi.fn>,
+    ) => ({
+      id: `i-auth-${userId}`,
+      commandName: 'discord-reply-mode',
+      channelId: 'C1',
+      guildId: 'G-dev',
+      createdAt: new Date(123),
+      user: { id: userId, username: 'u', bot: false },
+      member: { roles: { cache: new Map() } },
+      options: { data: [], getString: vi.fn(() => null) },
+      reply,
+      isChatInputCommand: () => true,
+    });
+
+    const replyBefore = vi.fn(async () => undefined);
+    await interactionCreate(makeReplyModeInteraction('U-new', replyBefore));
+    expect(replyBefore).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining('Permission denied'),
+      }),
+    );
+
+    platform.updateAuth({ allowedUserIds: ['U-new'], inboundAllowedUserIds: null });
+
+    const replyAfter = vi.fn(async () => undefined);
+    await interactionCreate(makeReplyModeInteraction('U-new', replyAfter));
+    expect(replyAfter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining('current reply mode'),
+      }),
+    );
+
+    const replyRemoved = vi.fn(async () => undefined);
+    await interactionCreate(makeReplyModeInteraction('U-old', replyRemoved));
+    expect(replyRemoved).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining('Permission denied'),
+      }),
+    );
+  });
+
   it('stable /discord-reply-mode 内部失败时仍回复 ephemeral 错误，避免 Discord 显示未响应', async () => {
     const logger = makeLogger();
     const platform = createDiscordPlatform({
@@ -1246,6 +1326,58 @@ describe('parseInbound: 用户白名单（fail-closed）', () => {
     expect(
       parseInbound(makeMsg({ content: 's', authorId: BOT_ID }), BOT_ID, [BOT_ID]),
     ).toEqual({ kind: 'drop', reason: 'noise' });
+  });
+});
+
+describe('createDiscordPlatform: inboundAllowedUserIds 接线', () => {
+  it('显式传 null 时 chat 不做 adapter guard，事件交给 daemon 判定', async () => {
+    const logger = makeLogger();
+    const platform = createDiscordPlatform({
+      token: 'test-token',
+      botUserId: BOT_ID,
+      logger,
+      statePath: '/tmp/agent-nexus-missing-dir/inbound-null-guard.json',
+      allowedUserIds: ['U-only'],
+      inboundAllowedUserIds: null,
+    });
+    const handler = vi.fn(async () => undefined);
+    await platform.start(handler);
+    const messageCreate = registeredHandler('messageCreate');
+
+    await messageCreate(
+      makeMsg({ content: `<@${BOT_ID}> hi`, authorId: 'U-stranger' }),
+    );
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    // updateAuth 传 null 同语义：guard 保持关闭
+    platform.updateAuth({ allowedUserIds: ['U-other'], inboundAllowedUserIds: null });
+    await messageCreate(
+      makeMsg({ content: `<@${BOT_ID}> hi again`, authorId: 'U-stranger-2', id: 'm-2' }),
+    );
+    expect(handler).toHaveBeenCalledTimes(2);
+  });
+
+  it('缺省（undefined）时沿用 allowedUserIds 做 chat guard', async () => {
+    const logger = makeLogger();
+    const platform = createDiscordPlatform({
+      token: 'test-token',
+      botUserId: BOT_ID,
+      logger,
+      statePath: '/tmp/agent-nexus-missing-dir/inbound-default-guard.json',
+      allowedUserIds: ['U-only'],
+    });
+    const handler = vi.fn(async () => undefined);
+    await platform.start(handler);
+    const messageCreate = registeredHandler('messageCreate');
+
+    await messageCreate(
+      makeMsg({ content: `<@${BOT_ID}> hi`, authorId: 'U-stranger' }),
+    );
+    expect(handler).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'U-stranger' }),
+      'discord_inbound_unauthorized',
+    );
   });
 });
 

--- a/packages/platform/discord/src/index.ts
+++ b/packages/platform/discord/src/index.ts
@@ -98,6 +98,16 @@ export interface DiscordPlatformOptions {
   commandRegistration?: DiscordCommandRegistration;
 }
 
+/** 配置热重载时替换 adapter 内部授权数据；字段语义同 DiscordPlatformOptions 同名字段 */
+export interface DiscordAuthUpdate {
+  allowedUserIds: readonly string[];
+  inboundAllowedUserIds?: readonly string[] | null;
+}
+
+export interface DiscordPlatformAdapter extends PlatformAdapter {
+  updateAuth(update: DiscordAuthUpdate): void;
+}
+
 /**
  * 单切片字符预算（UTF-16 code unit）。Discord 文档说 message content 上限 "2000
  * characters" 但没明指口径（code point / UTF-16 / grapheme 都可能），保守按最严的
@@ -466,17 +476,22 @@ export function parseInbound(
   return { kind: 'event', event };
 }
 
-export function createDiscordPlatform(opts: DiscordPlatformOptions): PlatformAdapter {
+export function createDiscordPlatform(opts: DiscordPlatformOptions): DiscordPlatformAdapter {
   const {
     token,
     botUserId,
     logger,
     statePath,
-    allowedUserIds,
     testGuildId,
     commandRegistration,
   } = opts;
-  const inboundAllowedUserIds = opts.inboundAllowedUserIds ?? allowedUserIds;
+  // 可被 updateAuth 热替换；reply-mode ctx 与 inbound guard 每次调用时读取。
+  // null 必须保留（语义：chat guard 交给 daemon platform auth）——不能用 ?? 吞掉
+  let allowedUserIds = opts.allowedUserIds;
+  let inboundAllowedUserIds =
+    opts.inboundAllowedUserIds === undefined
+      ? opts.allowedUserIds
+      : opts.inboundAllowedUserIds;
 
   const client = new Client({
     intents: [
@@ -516,6 +531,22 @@ export function createDiscordPlatform(opts: DiscordPlatformOptions): PlatformAda
 
     capabilities(): CapabilitySet {
       return DISCORD_CAPABILITIES;
+    },
+
+    updateAuth(update: DiscordAuthUpdate): void {
+      allowedUserIds = update.allowedUserIds;
+      // 与构造时同语义：undefined → 复用 allowedUserIds；null → chat guard 交给 daemon
+      inboundAllowedUserIds =
+        update.inboundAllowedUserIds === undefined
+          ? update.allowedUserIds
+          : update.inboundAllowedUserIds;
+      logger.info(
+        {
+          allowedUserCount: allowedUserIds.length,
+          inboundGuardEnabled: inboundAllowedUserIds !== null,
+        },
+        'discord_auth_updated',
+      );
     },
 
     async start(handler: EventHandler): Promise<void> {


### PR DESCRIPTION
&gt; **Stacked PR**：base=`feature/slash-command-registry-main`（discord 错误回复 PR #142 已合入 base）。合并顺序：registry PR → 本 PR，均 squash merge。

## Summary

改配置（binding 路由、auth allowlist、UI 行为）此前必须重启 daemon 进程才能生效，小改动的代价不成比例。

本 PR 新增 daemon slash command `/nexus-reload-config`，用户手动触发后重新加载 `~/.agent-nexus/config.json`：
- 解析 / 校验失败：整次放弃，旧配置保持生效（从未被替换），错误以 ephemeral 回复返回触发者
- 成功：all-or-nothing 热应用 `bindings[]`（路由表）、`platforms[].auth`、`ui.toolMessages`、`textPrefixes` 到所有 engine 与 platform adapter
- `agents[]`、`platforms[]` 其余字段、`log` 不可热应用，有变化时成功反馈附「需重启」提示
- 架构上 daemon 不读配置文件：Engine 只持有 CLI 注入的 reloader 回调与 `applyRuntimeUpdate()` 热替换入口

第二个 commit 来自 3 轮 GAN 对抗 review（codex reviewer），把热生效语义钉在「reload 后状态 == 用新配置重启」基准上：
- bindings 派生的 agent owner 集合变化时拒绝 reload（slash command 注册集不在 reload 事务内，否则命令面板与路由失配）
- Discord adapter 闭包持有的 allowlist 随 reload 热替换；顺带修复 base 分支 `??` 吞 `null` 导致 role-only 配置的 chat 在启动路径就被 adapter 预筛拦死的问题
- `toolMessages` 模式改为 turn 级 snapshot，进行中的 turn 不会中途混合渲染

## Why

运维场景里最常改的就是 allowlist 和 channel binding，这两类恰好可以安全热应用；不可热应用的部分诚实报「需重启」而不是假装生效。

ADR: N/A（在 [ADR-0017 slash command registry](docs/dev/adr/0017-slash-command-registry.md) 架构内的功能扩展，无新架构决策）
Spec: [docs/dev/spec/config-routing.md §配置热重载](docs/dev/spec/config-routing.md)（本 PR 新增，语义 owner）+ [docs/dev/spec/command-registry.md](docs/dev/spec/command-registry.md) daemon command 表

## Test plan

- [x] Tests: engine 7 条（reload 命令四态、applyRuntimeUpdate 路由 / auth / role-only / mid-turn）、config-reload 6 条（parse 失败回退、热应用、三条运行态约束、重启提示）、discord adapter 3 条（updateAuth、inbound null 接线）
- [x] `npx vitest run` — 29 文件 / 428 测试全过
- [x] `corepack pnpm -r typecheck` — 6/6 通过
- [ ] Manual: 未跑真实 Discord（需要真实 bot token；语义由合约测试覆盖，spec 合约测试清单同步更新）

## Review notes

- Independent agent review: GAN 对抗 review 3 轮（codex gpt-5 reviewer）：4 条主 issue（3 blocker + 1 important）全部收敛，reviewer 第 3 轮主动判定无需继续；review log 在容器 `/tmp/adversarial-review-1781075067-31102/`
- Deep review: 同上（多轮对抗 review 即深度 review 留痕）

## Out of scope

- `/discord-reply-mode` 的 role / guild / channel 维度鉴权——重启路径同等受限（已记入 spec 已知限制），正确修法是 platform command 经 daemon dispatch 统一鉴权的架构迁移
- 把远端 slash command 重注册纳入 reload 事务（owner 集合变化场景当前 fail-closed 拒绝）
- `log.level` 热应用
