### PR TITLE
docs(testing): 定义 Discord E2E 测试方案

### DIFF
--- a/docs/dev/testing/discord-e2e.md
+++ b/docs/dev/testing/discord-e2e.md
@@ -45,7 +45,7 @@ Harness qualification 只能证明测试工具自身可用，不能替代 Discor
 
 ## Fake Discord 边界
 
-Fake Discord 实现 `PlatformAdapter`，不 mock `discord.js Client`，也不走真实网络。它的职责是模拟平台边界，而不是复刻 Discord SDK。
+Fake Discord 实现 `PlatformAdapter`，不 mock `discord.js Client`，也不走真实网络。它的职责是模拟平台边界，而不是复刻 Discord SDK。接口契约以 [`../spec/platform-adapter.md`](../spec/platform-adapter.md) 为准；下表只列 fake 实现必须覆盖的测试子集。
 
 Fake adapter 必备能力：
 
@@ -69,14 +69,13 @@ Fake adapter 不负责：
 
 ## 输入事件
 
-E2E case 注入的是 `NormalizedEvent`，不是 raw gateway JSON。Discord raw payload 到 `NormalizedEvent` 的映射由 platform adapter 合约测试负责。
+E2E case 注入的是 `NormalizedEvent`，不是 raw gateway JSON。Discord raw payload 到 `NormalizedEvent` 的映射由 platform adapter 合约测试负责。字段契约以 [`../spec/message-protocol.md`](../spec/message-protocol.md) 为准。
 
 事件工厂使用固定测试 ID：
 
 | 字段 | 示例 |
 |---|---|
 | `platform` | `discord` |
-| `platformName` | 由 Engine 注入，例如 `discord-main` |
 | `channelId` | `C-e2e-main` |
 | `initiatorUserId` | `U-e2e-owner` |
 | `guildId` | `G-e2e` |
@@ -84,6 +83,8 @@ E2E case 注入的是 `NormalizedEvent`，不是 raw gateway JSON。Discord raw 
 | `traceId` | 每次运行可唯一，但必须写入 transcript |
 
 测试事件不得包含真实 username、真实频道名、真实 token、真实附件 URL。raw payload 只允许放最小空对象或脱敏后的 fixture 引用。
+
+`platformName` 不由测试事件预填。E2E 应断言 daemon routing 后的完整 `SessionKey` 含配置实例名，例如 `discord-main`，从而覆盖 routing 注入路径。
 
 ## Runner
 
@@ -181,15 +182,16 @@ E2E 禁止用固定 sleep 等待业务结果。harness 提供显式等待：
 | Case | 目的 | 关键断言 |
 |---|---|---|
 | `happy-path` | 合法 Discord 消息触发真实 agent 并回送 Discord | route 命中；auth 通过；agent 收到输入；至少一条 outbound；traceId 串联 |
-| `auth-denied` | 非 allowlist 用户不触发 agent | `auth_denied`；无 agent session；无 outbound；无幂等记录 |
+| `auth-denied` | 非 allowlist 用户不触发 agent | `auth_denied`；无 agent session；无 agent outbound；无幂等记录 |
 | `idempotency-replay` | Discord at-least-once 重放只处理一次 | 同 `(sessionKey, messageId)` 第二次不触发 agent；记录命中日志 |
-| `long-output-slicing` | 长回复在 Discord outbound 中按平台能力切片 | `MessageRef.messageIds.length > 1`；切片顺序稳定；拼接等于脱敏后原文 |
+| `long-output-slicing` | 长回复切片归属清晰后，证明默认 E2E 不产生 fake-only 通过 | 不由 fake adapter 复刻 Discord `buildSlices`；最终断言随 platform-adapter owner 对切片归属的修正确定 |
 | `redaction` | agent 输出敏感模式时发到 Discord 前已脱敏 | outbound 不含原始 secret / 绝对路径；transcript 也不含原文 |
 
 当前代码缺口影响：
 
 - `idempotency-replay` 必须按 spec 的 `(sessionKey, messageId)` 语义实现；当前仅有 `eventId` 内存 dedup，不足以作为最终通过证据。
 - `redaction` 必须等 daemon redaction layer 落地后才可通过；当前直接发送 agent 文本，不能声明通过。
+- `long-output-slicing` 必须先澄清切片归属；当前实现的切片在真实 Discord adapter 内，默认 fake-adapter E2E 不能通过复刻该逻辑来声明生产切片通过。
 - 若 session/idempotency 存储仍是内存实现，E2E 可以用 tmpdir state，但不能声称已覆盖 SQLite 持久化。
 
 ## 真实 Agent 选择
@@ -212,7 +214,7 @@ case 断言不能依赖完整 LLM 文本逐字一致。需要确定输出时，p
 版本控制内 fixture：
 
 - Discord raw gateway fixture 继续放 `testdata/discord/events/`，供 adapter 合约测试使用。
-- agent transcript fixture 继续放 owner backend 的 testdata 或 `testdata/cc-cli/transcripts/`，供 replay / integration 使用。
+- agent transcript fixture 继续放 owner backend 的 testdata；现有 Claude Code transcript 归 [`fixtures.md`](fixtures.md) 定义的 `testdata/cc-cli/transcripts/`，新增 Codex transcript 不在本文重新命名。
 - E2E seed case 配置可以放 `tests/e2e/discord/cases/`，只写脱敏输入和断言，不写运行产物。
 
 运行产物：

--- a/docs/dev/testing/discord-e2e.md
+++ b/docs/dev/testing/discord-e2e.md
@@ -1,0 +1,263 @@
+---
+title: Discord E2E 测试方案
+type: testing
+status: active
+summary: Discord 端到端测试的 fake platform 边界、runner、transcript、seed case 与真实 Discord smoke 分层
+tags: [testing, discord, strategy, fixtures, pipeline]
+related:
+  - dev/testing/strategy
+  - dev/testing/fixtures
+  - dev/spec/message-flow
+  - dev/spec/platform-adapter
+  - dev/spec/agent-runtime
+  - dev/spec/security/auth
+  - dev/spec/infra/idempotency
+  - dev/spec/security/redaction
+---
+
+# Discord E2E 测试方案
+
+本文件定义 Discord 端到端测试用什么证据证明行为正确。接口字段、消息流顺序、权限、幂等、脱敏的契约分别由相关 spec 拥有；本文只规定测试 harness、runner、fixture、transcript 与 seed case 的证据模型。
+
+## 目标行为
+
+Discord E2E 要证明一条用户输入能穿过完整运行链路，并在 Discord 侧产生可断言的出站结果：
+
+```text
+Fake Discord input
+  -> PlatformAdapter handler
+  -> daemon routing / auth / idempotency / session / output handling
+  -> real AgentRuntime
+  -> Fake Discord outbound capture
+```
+
+默认 E2E 不连接真实 Discord gateway，不读取真实 Discord token，不依赖真实 guild 或频道状态。真实 Discord 只作为单独的 smoke 证据。
+
+## 分层
+
+| 层 | 目的 | Discord 边界 | Agent 边界 | 是否作为最终 E2E 证据 |
+|---|---|---|---|---|
+| Harness qualification | 验证 fake Discord、同步等待、transcript、断言工具自身可靠 | fake `PlatformAdapter` | scripted agent 或 transcript replay | 否 |
+| Discord E2E | 验证完整 daemon + agent + platform boundary 链路 | fake `PlatformAdapter` | 真实 `AgentRuntime` 子进程 | 是 |
+| Real Discord smoke | 验证真实 token、gateway、slash command、REST 基线 | 真实 Discord adapter | 可用最小 agent | 否，诊断用 |
+
+Harness qualification 只能证明测试工具自身可用，不能替代 Discord E2E。Discord E2E 的 agent 边界必须使用真实 runtime；若本机缺少认证或 CLI，case 只能标记为环境前提缺失，不能记为通过。
+
+## Fake Discord 边界
+
+Fake Discord 实现 `PlatformAdapter`，不 mock `discord.js Client`，也不走真实网络。它的职责是模拟平台边界，而不是复刻 Discord SDK。
+
+Fake adapter 必备能力：
+
+| 能力 | 证据 |
+|---|---|
+| `start(handler)` | 保存 daemon 提供的 handler；未 start 前拒绝注入 |
+| `inject(event)` | 将测试构造的 `NormalizedEvent` 投递给 handler |
+| `send(sessionKey, message)` | 记录出站文本、traceId、sessionKey，返回确定性的 `MessageRef` |
+| `edit(messageRef, message)` | 记录 edit，保持 `MessageRef.messageIds` 语义 |
+| `setTyping` / `clearTyping` | 记录 typing 生命周期 |
+| capability | 每个 case 可配置 `supportsEdit`、`supportsTypingIndicator`、`maxTextLength` 等 |
+
+Fake adapter 不负责：
+
+- 解析真实 gateway payload。
+- 验证 `discord.js` 登录、重连、REST rate limit。
+- 注册 slash command。
+- 证明真实 Discord REST request 的字段。
+
+这些由 `@agent-nexus/platform-discord` 的合约测试和可选 smoke 证明。
+
+## 输入事件
+
+E2E case 注入的是 `NormalizedEvent`，不是 raw gateway JSON。Discord raw payload 到 `NormalizedEvent` 的映射由 platform adapter 合约测试负责。
+
+事件工厂使用固定测试 ID：
+
+| 字段 | 示例 |
+|---|---|
+| `platform` | `discord` |
+| `platformName` | 由 Engine 注入，例如 `discord-main` |
+| `channelId` | `C-e2e-main` |
+| `initiatorUserId` | `U-e2e-owner` |
+| `guildId` | `G-e2e` |
+| `messageId` / `eventId` | 每 case 稳定生成 |
+| `traceId` | 每次运行可唯一，但必须写入 transcript |
+
+测试事件不得包含真实 username、真实频道名、真实 token、真实附件 URL。raw payload 只允许放最小空对象或脱敏后的 fixture 引用。
+
+## Runner
+
+目标 runner 命令：
+
+```bash
+corepack pnpm test:e2e:discord -- --case happy-path
+corepack pnpm test:e2e:discord -- --tag seed
+corepack pnpm test:e2e:discord -- --all
+```
+
+runner 行为：
+
+- 单命令、无交互。
+- 默认创建 tmpdir workingDir、tmpdir state、tmpdir transcript 输出目录。
+- 默认不读取 `~/.agent-nexus/config.json` 或 Discord secret。
+- 默认使用 fake Discord platform。
+- agent backend 通过显式参数或环境变量选择；第一实现优先 Codex backend，因为它已有真实 CLI verify 工具。
+- 环境前提缺失时，输出结构化 skip，不把 skip 算作 pass。
+- 失败时保留 artifact 路径；通过时可清理临时目录，除非设置 keep artifacts。
+
+推荐环境变量：
+
+| 变量 | 用途 |
+|---|---|
+| `AGENT_NEXUS_E2E_AGENT` | `codex` 或 `claudecode` |
+| `AGENT_NEXUS_E2E_KEEP_ARTIFACTS` | `1` 时保留所有 transcript |
+| `AGENT_NEXUS_E2E_CASE_TIMEOUT_MS` | 单 case 超时 |
+| `AGENT_NEXUS_E2E_WORKDIR` | 指定工作目录；默认 tmpdir |
+| `AGENT_NEXUS_E2E_ALLOW_SKIP` | 环境前提缺失时允许退出 0 |
+
+runner 不负责启动真实 Discord。真实 Discord smoke 使用独立命令，避免误触真实频道。
+
+## Transcript
+
+每个 case 产生一份 JSON transcript。transcript 是失败复盘证据，不是测试 fixture；默认不提交到仓库。
+
+最小结构：
+
+```json
+{
+  "caseId": "happy-path",
+  "runId": "2026-06-16T15:00:00.000Z-...",
+  "startedAt": "2026-06-16T15:00:00.000Z",
+  "finishedAt": "2026-06-16T15:00:05.000Z",
+  "status": "passed",
+  "environment": {
+    "agentBackend": "codex",
+    "node": "v22.x",
+    "platform": "fake-discord"
+  },
+  "events": [],
+  "assertions": []
+}
+```
+
+事件项按发生顺序追加：
+
+| `kind` | 内容 |
+|---|---|
+| `inbound` | 注入的 `eventId`、`messageId`、`traceId`、session key、text 摘要 |
+| `agent_event` | `AgentEvent.type`、sequence、traceId、payload 摘要 |
+| `outbound_send` | session key、message ids、text 摘要或脱敏文本 |
+| `outbound_edit` | message ref、text 摘要或脱敏文本 |
+| `typing` | set / clear 与 session key |
+| `log` | 与断言相关的结构化日志事件 |
+| `assertion` | 断言名、结果、失败细节 |
+
+transcript 禁止写入：
+
+- Discord token 或 secret ref 内容。
+- raw Discord payload 全量。
+- agent 子进程 stdout 全量。
+- 未脱敏的绝对路径、API key、邮箱、手机号。
+
+当 redactor 不可用时，runner 必须退化为摘要和 hash，不得把原文写进 transcript。
+
+## 同步模型
+
+E2E 禁止用固定 sleep 等待业务结果。harness 提供显式等待：
+
+| helper | 等待条件 |
+|---|---|
+| `waitForOutbound(predicate, timeoutMs)` | 某条 send/edit 满足断言 |
+| `waitForAgentEvent(predicate, timeoutMs)` | recorder 看到某个 AgentEvent |
+| `waitForTurnFinished(traceId, timeoutMs)` | 同 traceId 的 turn terminal 到达 |
+| `waitForNoAgentCall(windowMs)` | 授权拒绝等负路径短窗口内未触发 agent |
+
+等待失败时，runner 写出当前 transcript 并报告最后一条事件。
+
+## Seed Case
+
+第一批 seed case 是最终验收的最小集合。每个 case 必须独立 tmpdir、独立 fake platform、独立 transcript。
+
+| Case | 目的 | 关键断言 |
+|---|---|---|
+| `happy-path` | 合法 Discord 消息触发真实 agent 并回送 Discord | route 命中；auth 通过；agent 收到输入；至少一条 outbound；traceId 串联 |
+| `auth-denied` | 非 allowlist 用户不触发 agent | `auth_denied`；无 agent session；无 outbound；无幂等记录 |
+| `idempotency-replay` | Discord at-least-once 重放只处理一次 | 同 `(sessionKey, messageId)` 第二次不触发 agent；记录命中日志 |
+| `long-output-slicing` | 长回复在 Discord outbound 中按平台能力切片 | `MessageRef.messageIds.length > 1`；切片顺序稳定；拼接等于脱敏后原文 |
+| `redaction` | agent 输出敏感模式时发到 Discord 前已脱敏 | outbound 不含原始 secret / 绝对路径；transcript 也不含原文 |
+
+当前代码缺口影响：
+
+- `idempotency-replay` 必须按 spec 的 `(sessionKey, messageId)` 语义实现；当前仅有 `eventId` 内存 dedup，不足以作为最终通过证据。
+- `redaction` 必须等 daemon redaction layer 落地后才可通过；当前直接发送 agent 文本，不能声明通过。
+- 若 session/idempotency 存储仍是内存实现，E2E 可以用 tmpdir state，但不能声称已覆盖 SQLite 持久化。
+
+## 真实 Agent 选择
+
+第一实现优先 Codex backend：
+
+- `codex exec --json` 已有 runtime 和 verify 脚本。
+- 默认 `read-only` sandbox、`--ask-for-approval never`、忽略 user config/rules。
+- case 可用 sentinel prompt 降低自然语言不确定性。
+
+Claude Code backend 保留为同一 runner 的可选 backend：
+
+- 覆盖 stream-json 长驻进程路径。
+- 成本和输出 runtime 信息更多，默认 transcript 必须只保留摘要。
+
+case 断言不能依赖完整 LLM 文本逐字一致。需要确定输出时，prompt 使用短 sentinel；仍需把模型偏差归类为 `model_behavior`，不同于 contract failure。
+
+## Fixture 与 Artifact
+
+版本控制内 fixture：
+
+- Discord raw gateway fixture 继续放 `testdata/discord/events/`，供 adapter 合约测试使用。
+- agent transcript fixture 继续放 owner backend 的 testdata 或 `testdata/cc-cli/transcripts/`，供 replay / integration 使用。
+- E2E seed case 配置可以放 `tests/e2e/discord/cases/`，只写脱敏输入和断言，不写运行产物。
+
+运行产物：
+
+- 默认写入 tmpdir。
+- 失败时输出 artifact 绝对路径。
+- 需要人工复盘的 transcript 可复制到 goal workspace 或 PR 附件，不直接提交。
+
+## 真实 Discord Smoke
+
+真实 Discord smoke 只验证部署面：
+
+- token 可登录。
+- bot user id 自检通过或正确 warn。
+- test guild slash command 可注册。
+- 指定测试频道能收到一条最小回复。
+
+smoke 必须显式 opt-in：
+
+```bash
+corepack pnpm smoke:discord -- --guild <testGuildId> --channel <channelId>
+```
+
+缺少 token、guild、channel 时直接跳过或失败为环境前提，不回退到默认配置。smoke 不进入 PR 必跑路径，不作为 seed case 通过证据。
+
+## CI 证据
+
+CI 分三类：
+
+| 命令 | 触发 | 失败含义 |
+|---|---|---|
+| harness qualification | PR 必跑 | 测试工具或 daemon contract 破坏 |
+| Discord E2E real-agent | 核心路径 PR / main / 手动 | 完整链路破坏或环境前提缺失 |
+| real Discord smoke | 手动 / 夜间私有环境 | 部署凭据或 Discord 侧行为异常 |
+
+CI 触发与门禁编排仍以 [`../process/tdd.md`](../process/tdd.md) 为准；本文只定义每类证据证明什么。
+
+## 不测什么
+
+默认 Discord E2E 不证明：
+
+- 真实 gateway reconnect 是否成功 resume。
+- Discord global slash command 传播延迟。
+- 真实 REST rate limit 行为。
+- 第三方 SDK 内部行为。
+- LLM 对开放式问题的质量。
+
+这些分别由 platform 合约测试、真实 Discord smoke、eval 或后续专项测试覆盖。

--- a/docs/dev/testing/fixtures.md
+++ b/docs/dev/testing/fixtures.md
@@ -14,7 +14,7 @@ related:
 
 # 测试数据与 Fixture
 
-所有测试数据（输入 fixture、预期输出 snapshot、CC transcript）的组织、命名、更新规则。
+所有测试数据（输入 fixture、预期输出 snapshot、agent backend transcript）的组织、命名、更新规则。
 
 ## 目录结构
 
@@ -33,9 +33,9 @@ related:
     │   │   └── ...
     │   └── snapshots/         # NormalizedEvent 快照比对
     │       └── ...
-    ├── cc-cli/
-    │   ├── transcripts/       # CC 输出回放
-    │   │   ├── v<ccver>/      # 按 CC 版本分组
+    ├── <agent-backend>/
+    │   ├── transcripts/       # agent backend 输出回放；现有目录如 cc-cli/
+    │   │   ├── v<backend-ver>/ # 按 backend 版本分组
     │   │   │   ├── basic_qa.jsonl
     │   │   │   ├── tool_call_read.jsonl
     │   │   │   └── ...
@@ -89,11 +89,12 @@ related:
 }
 ```
 
-### CC CLI Transcript（`testdata/cc-cli/transcripts/v<ver>/*.jsonl`）
+### Agent Backend Transcript（`testdata/<agent-backend>/transcripts/v<ver>/*.jsonl`）
 
-- CC 输出的 JSONL（按行一个事件）
+- agent backend 输出的 JSONL（按行一个事件）
 - 包含 timestamp、事件类型、payload
-- 用于 transcript 回放测试：mock CC runtime 按节奏吐出这些行
+- 用于 transcript 回放测试：mock backend runtime 按节奏吐出这些行
+- 现有 Claude Code CLI transcript 使用 `testdata/cc-cli/transcripts/`
 
 示例（简化）：
 
@@ -122,11 +123,11 @@ related:
 
 ## 版本控制
 
-### CC Transcript
+### Agent Backend Transcript
 
-- 按 CC CLI 版本分目录：`v1.3.0/`, `v1.4.0/`
-- 测试根据测的 CC 版本读对应目录
-- 新增 CC 版本：新开目录，运行录制脚本生成一批
+- 按 backend 和 backend 版本分目录：`testdata/cc-cli/transcripts/v1.3.0/`
+- 测试根据目标 backend 版本读对应目录
+- 新增 backend 或版本：新开目录，运行对应录制脚本生成一批
 
 ### 快照
 
@@ -152,7 +153,7 @@ Fixture 是契约的一部分，不是"试试看"：
 需要的工具（ADR-0004 语言定后补实现）：
 
 - `scripts/record-discord-event`：从真实 Discord 连接录制事件 + 脱敏
-- `scripts/record-cc-transcript`：在一个指定 prompt 下运行 CC CLI，落盘 JSONL
+- backend 专用 transcript 录制脚本：在一个指定 prompt 下运行目标 backend，落盘 JSONL（现有例：`scripts/record-cc-transcript`）
 - `scripts/regenerate-snapshots`：重新生成所有 snapshot（需要手工 review diff）
 
 ## 脱敏
@@ -179,7 +180,7 @@ Fixture 是契约的一部分，不是"试试看"：
 - 在测试代码里内联大段 JSON（放 fixture 文件）
 - Fixture 文件用 `final_v2_fixed.json` 这种人类命名（用语义化名字）
 - 录制的 fixture 未脱敏直接入库
-- CC 升级了但不更新 transcript fixture（下次测试不稳）
+- agent backend 升级了但不更新 transcript fixture（下次测试不稳）
 - 多个测试共享一个 mutable fixture（改一处挂一片）
 
 ## Out of spec

--- a/docs/dev/testing/fixtures.md
+++ b/docs/dev/testing/fixtures.md
@@ -6,6 +6,7 @@ summary: testdata 目录结构、fixture 类型、命名与版本、录制与脱
 tags: [testing, fixtures]
 related:
   - dev/testing/strategy
+  - dev/testing/discord-e2e
   - dev/testing/eval
   - dev/spec/platform-adapter
   - dev/spec/agent-runtime

--- a/docs/dev/testing/strategy.md
+++ b/docs/dev/testing/strategy.md
@@ -5,6 +5,7 @@ status: active
 summary: 四层测试模型（Unit/Integration/E2E/Eval）的职责、Mock 策略、组织命名与覆盖目标
 tags: [testing, strategy]
 related:
+  - dev/testing/discord-e2e
   - dev/process/tdd
   - dev/testing/fixtures
   - dev/testing/eval
@@ -20,7 +21,7 @@ related:
  ┌──────────────┐ ← 最少量
  │    Eval      │  对话质量回归（LLM 输出）
  ├──────────────┤
- │     E2E      │  真实 CC CLI + mock Discord
+ │     E2E      │  真实 agent backend + mock Discord
  ├──────────────┤
  │  Integration │  模块间（adapter ↔ daemon、daemon ↔ store）
  ├──────────────┤
@@ -57,10 +58,12 @@ related:
 
 ### E2E
 
-- 真实 CC CLI 子进程
+- 真实 agent backend 子进程（Claude Code / Codex）
 - Mock Discord（用 fake server 或 in-memory adapter 实现）
 - 端到端断言：用户消息 → 经过完整链路 → 产生正确的 outbound 消息
 - **数量很少**：5–10 个关键流程（happy path、权限拒绝、超预算、断线重连、熔断）
+
+Discord E2E 的 fake platform 边界、runner、transcript 与 seed case 见 [`discord-e2e.md`](discord-e2e.md)。
 
 ### Eval
 
@@ -74,7 +77,7 @@ related:
 
 - **单元测试**：mock 所有 I/O（网络、磁盘、时钟、子进程）
 - **集成测试**：只 mock 系统边界（Discord API、Anthropic API、CC CLI 子进程）
-- **E2E**：只 mock Discord（CC CLI 真跑）
+- **E2E**：只 mock Discord（agent backend 真跑）
 - **Eval**：什么都不 mock
 
 ### 每个依赖的 mock 策略
@@ -83,17 +86,17 @@ related:
 |---|---|---|---|---|
 | Discord API | mock | mock | mock（fake server） | mock |
 | Anthropic API | mock | 真（对核心路径） | 真 | 真 |
-| CC CLI 子进程 | mock | transcript 回放 | 真（spawn） | 真 |
+| Agent backend 子进程 | mock | transcript 回放 | 真（spawn） | 真 |
 | SQLite | mock / in-memory | 真（临时文件） | 真 | 真 |
 | 时钟 | mock | 真 | 真 | 真 |
 | 文件系统 | mock / tmpdir | tmpdir | tmpdir | 真（项目目录） |
 
-### CC CLI 的两种 mock
+### Agent backend 的两种 mock
 
-CC 是黑盒，输出格式可能变。维护两种 mock：
+Agent backend CLI 是黑盒，输出格式可能变。维护两种 mock：
 
-1. **Transcript 回放**：预录的 CC 输出 JSONL，按时间戳重放；用于稳定的 integration/unit 测试
-2. **真实 spawn**：CC 真跑；用于 E2E 与 eval；每个 CC 版本升级需要重新录一批 transcript
+1. **Transcript 回放**：预录的 backend 输出 JSONL，按时间戳重放；用于稳定的 integration/unit 测试
+2. **真实 spawn**：backend 真跑；用于 E2E 与 eval；每个 backend 版本升级需要重新录一批 transcript
 
 详细见 [`fixtures.md`](fixtures.md)。
 

--- a/docs/dev/testing/strategy.md
+++ b/docs/dev/testing/strategy.md
@@ -36,7 +36,7 @@ related:
 | Unit | 单函数、单类 | 外部 I/O 全 mock | <50ms / 测试 |
 | Integration | 模块对接 | 只 mock 系统边界 | <500ms / 测试 |
 | E2E | 完整链路 | 只 mock Discord | 5–30s / 测试 |
-| Eval | 对话质量 | 真实 LLM + 真实 CC | 数十秒 / case |
+| Eval | 对话质量 | 真实 LLM + 真实 agent backend | 数十秒 / case |
 
 ## 各层目标
 
@@ -76,7 +76,7 @@ Discord E2E 的 fake platform 边界、runner、transcript 与 seed case 见 [`d
 ### 总原则
 
 - **单元测试**：mock 所有 I/O（网络、磁盘、时钟、子进程）
-- **集成测试**：只 mock 系统边界（Discord API、Anthropic API、CC CLI 子进程）
+- **集成测试**：只 mock 系统边界（Discord API、Anthropic API、agent backend 子进程）
 - **E2E**：只 mock Discord（agent backend 真跑）
 - **Eval**：什么都不 mock
 
@@ -138,7 +138,7 @@ Agent backend CLI 是黑盒，输出格式可能变。维护两种 mock：
 
 ## 反模式
 
-- 每个测试都起一个真 CC 子进程（慢且脆弱，应 transcript 回放）
+- 每个测试都起一个真 agent backend 子进程（慢且脆弱，应 transcript 回放）
 - Mock 自己（只 mock 外部依赖）
 - 用 sleep 等异步（用 fake clock 或显式同步）
 - 用 print 调试后不删


### PR DESCRIPTION
## Summary

Adds the P2 Discord E2E design plan.

本 PR：
- adds `docs/dev/testing/discord-e2e.md` as the Discord E2E evidence model
- links the new Discord E2E plan from testing strategy and fixture owner docs
- generalizes testing docs from CC-only wording to agent backend wording where the E2E plan now supports Codex or Claude Code

## Why

The Discord E2E harness needs an explicit, agent-friendly test contract before implementation starts. The design fixes the default boundary at fake Discord `PlatformAdapter` plus real `AgentRuntime`, keeps real Discord as opt-in smoke only, and records current implementation gaps that cannot be counted as passing E2E evidence yet.

ADR: N/A - testing evidence model only.
Spec: `docs/dev/testing/discord-e2e.md`; links existing owner specs for platform adapter, message protocol, auth, idempotency, redaction, and agent runtime.

## Test plan

- [x] `git diff --check`
- [x] `scripts/docs-read --head docs/dev/testing/discord-e2e.md`
- [x] independent Claude review saved at `/home/node/.goal/discord-e2e-agent-friendly-tests/reviews/p2-design-claude-review.md`

## Review notes

- Independent agent review: Claude review completed; important finding on long-output slicing ownership was verified against implementation/spec and fixed.
- Deep review: Claude review covered the design diff against platform-adapter, message-protocol, auth, idempotency, redaction, and agent-runtime owner boundaries.

## Out of scope

- Harness implementation, runner command wiring, and seed test code.
- Resolving the existing platform-adapter/spec mismatch around long-output slicing ownership.
- Marking idempotency replay, redaction, SQLite persistence, or long-output slicing seed cases as passing.
