### PR TITLE
test(discord): 搭建 E2E harness scaffold

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "pack:cli": "corepack pnpm --dir packages/cli pack",
     "typecheck": "tsc --build",
     "test": "vitest run",
+    "test:e2e:discord": "vitest run --config vitest.e2e.config.ts tests/e2e/discord",
     "test:watch": "vitest"
   },
   "devDependencies": {

--- a/tests/e2e/discord/harness.test.ts
+++ b/tests/e2e/discord/harness.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import type { SessionKey } from '../../../packages/protocol/src/index.js';
+import {
+  createDiscordE2EHarness,
+  scriptedTextReply,
+} from './harness.js';
+
+describe('Discord E2E harness', () => {
+  it('should_drive_fake_discord_input_through_engine_to_outbound_when_scripted_agent_replies', async () => {
+    const harness = createDiscordE2EHarness({
+      agentEvents: scriptedTextReply('pong from agent'),
+    });
+
+    await harness.start();
+    const inbound = await harness.injectMessage('hello from discord');
+
+    const outbound = await harness.waitForOutbound(
+      (entry) => entry.message.text === 'pong from agent',
+    );
+
+    expect(harness.agent.inputs).toHaveLength(1);
+    expect(harness.agent.inputs[0]?.input.text).toBe('hello from discord');
+    expect(harness.agent.inputs[0]?.session.key).toEqual<SessionKey>({
+      platformName: 'discord-main',
+      platform: 'discord',
+      channelId: 'C-e2e-main',
+      initiatorUserId: 'U-e2e-owner',
+    });
+    expect(outbound.sessionKey).toEqual(harness.agent.inputs[0]?.session.key);
+    expect(outbound.message.traceId).toBe(inbound.traceId);
+
+    expect(harness.transcript.events.map((event) => event.kind)).toContain(
+      'inbound',
+    );
+    expect(harness.transcript.events.map((event) => event.kind)).toContain(
+      'outbound_send',
+    );
+    expect(harness.transcript.events.at(-1)).toMatchObject({
+      kind: 'assertion',
+      passed: true,
+    });
+
+    await harness.stop();
+  });
+
+  it('should_resolve_waitForOutbound_when_wait_starts_before_message_is_injected', async () => {
+    const harness = createDiscordE2EHarness({
+      agentEvents: scriptedTextReply('async pong'),
+    });
+
+    await harness.start();
+    const outboundPromise = harness.waitForOutbound(
+      (entry) => entry.message.text === 'async pong',
+    );
+
+    await harness.injectMessage('hello after waiter');
+
+    await expect(outboundPromise).resolves.toMatchObject({
+      kind: 'outbound_send',
+      message: { text: 'async pong' },
+    });
+    expect(
+      harness.transcript.events.some(
+        (event) => event.kind === 'assertion' && event.passed,
+      ),
+    ).toBe(true);
+
+    await harness.stop();
+  });
+
+  it('should_reject_waitForOutbound_when_no_new_outbound_matches_before_timeout', async () => {
+    const harness = createDiscordE2EHarness({
+      agentEvents: scriptedTextReply('single pong'),
+    });
+
+    await harness.start();
+    await harness.injectMessage('hello once');
+
+    await expect(
+      harness.waitForOutbound((entry) => entry.message.text === 'single pong'),
+    ).resolves.toMatchObject({
+      kind: 'outbound_send',
+      message: { text: 'single pong' },
+    });
+
+    await expect(
+      harness.waitForOutbound((entry) => entry.message.text === 'single pong', 1),
+    ).rejects.toThrow('no outbound matched within 1ms');
+    expect(harness.transcript.events.at(-1)).toMatchObject({
+      kind: 'assertion',
+      passed: false,
+    });
+
+    await harness.stop();
+  });
+});

--- a/tests/e2e/discord/harness.ts
+++ b/tests/e2e/discord/harness.ts
@@ -1,0 +1,432 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import type {
+  AgentCapabilitySet,
+  AgentEvent,
+  AgentEventHandler,
+  AgentInput,
+  AgentRuntime,
+  AgentSession,
+  CapabilitySet,
+  EventHandler,
+  MessageRef,
+  NormalizedEvent,
+  OutboundMessage,
+  PlatformAdapter,
+  PlatformSessionKey,
+  SessionConfig,
+  SessionKey,
+} from '../../../packages/protocol/src/index.js';
+import { Engine } from '../../../packages/daemon/src/engine.js';
+import { createLogger } from '../../../packages/daemon/src/logger.js';
+import { SessionStore } from '../../../packages/daemon/src/session-store.js';
+
+const DEFAULT_PLATFORM_CAPS: CapabilitySet = {
+  maxTextLength: 2_000,
+  supportsEdit: false,
+  supportsDelete: false,
+  supportsReactions: false,
+  supportsEmbeds: false,
+  supportsButtons: false,
+  supportsThreads: false,
+  supportsEphemeral: false,
+  supportsAttachments: false,
+  maxAttachmentsPerMessage: 0,
+  supportsTypingIndicator: false,
+};
+
+const DEFAULT_AGENT_CAPS: AgentCapabilitySet = {
+  supportsThinking: false,
+  supportsStreaming: false,
+  supportsToolCallEvents: false,
+  supportsInterrupt: false,
+  supportsStdinInterrupt: false,
+};
+
+const DEFAULT_PLATFORM_SESSION_KEY: PlatformSessionKey = {
+  platform: 'discord',
+  channelId: 'C-e2e-main',
+  initiatorUserId: 'U-e2e-owner',
+};
+
+export type TranscriptEvent =
+  | {
+      kind: 'inbound';
+      eventId: string;
+      messageId?: string;
+      traceId: string;
+      sessionKey: PlatformSessionKey;
+      text: string;
+    }
+  | {
+      kind: 'agent_event';
+      eventType: AgentEvent['type'];
+      sequence: number;
+      traceId: string;
+    }
+  | {
+      kind: 'outbound_send';
+      sessionKey: SessionKey;
+      message: OutboundMessage;
+      ref: MessageRef;
+    }
+  | {
+      kind: 'outbound_edit';
+      sessionKey: SessionKey;
+      ref: MessageRef;
+      message: OutboundMessage;
+    }
+  | {
+      kind: 'typing';
+      action: 'set' | 'clear';
+      sessionKey: SessionKey;
+    }
+  | {
+      kind: 'assertion';
+      name: string;
+      passed: boolean;
+      details?: string;
+    };
+
+export interface Transcript {
+  caseId: string;
+  events: TranscriptEvent[];
+}
+
+export type OutboundSendEvent = Extract<
+  TranscriptEvent,
+  { kind: 'outbound_send' }
+>;
+export type OutboundEvent = Extract<
+  TranscriptEvent,
+  { kind: 'outbound_send' | 'outbound_edit' }
+>;
+
+export type ScriptedAgentEvents = (ctx: {
+  session: AgentSession;
+  input: AgentInput;
+}) => AgentEvent[];
+
+export interface DiscordE2EHarnessOptions {
+  caseId?: string;
+  platformName?: string;
+  platformCaps?: Partial<CapabilitySet>;
+  sessionKey?: PlatformSessionKey;
+  agentEvents: ScriptedAgentEvents;
+}
+
+export function scriptedTextReply(text: string): ScriptedAgentEvents {
+  return ({ input }) => [
+    {
+      type: 'text_final',
+      traceId: input.traceId,
+      timestamp: new Date(),
+      sequence: 1,
+      payload: { text },
+    },
+    {
+      type: 'turn_finished',
+      traceId: input.traceId,
+      timestamp: new Date(),
+      sequence: 2,
+      payload: { reason: 'stop', turnSequence: 1 },
+    },
+  ];
+}
+
+class FakeDiscordPlatform implements PlatformAdapter {
+  private handler?: EventHandler;
+  private nextMessageId = 1;
+  private readonly caps: CapabilitySet;
+
+  constructor(
+    private readonly transcript: Transcript,
+    capOverrides: Partial<CapabilitySet>,
+    private readonly onOutbound: (entry: OutboundEvent) => void,
+  ) {
+    this.caps = { ...DEFAULT_PLATFORM_CAPS, ...capOverrides };
+  }
+
+  name(): string {
+    return 'discord-main';
+  }
+
+  capabilities(): CapabilitySet {
+    return this.caps;
+  }
+
+  async start(handler: EventHandler): Promise<void> {
+    this.handler = handler;
+  }
+
+  async stop(): Promise<void> {
+    this.handler = undefined;
+  }
+
+  async inject(event: NormalizedEvent): Promise<void> {
+    if (!this.handler) {
+      throw new Error('FakeDiscordPlatform must be started before inject');
+    }
+    this.transcript.events.push({
+      kind: 'inbound',
+      eventId: event.eventId,
+      messageId: event.messageId,
+      traceId: event.traceId,
+      sessionKey: event.sessionKey,
+      text: event.text ?? '',
+    });
+    await this.handler(event);
+  }
+
+  async send(
+    sessionKey: SessionKey,
+    message: OutboundMessage,
+  ): Promise<MessageRef> {
+    const messageId = `fake-discord-${this.nextMessageId++}`;
+    const ref: MessageRef = {
+      platform: sessionKey.platform,
+      channelId: sessionKey.channelId,
+      messageId,
+      messageIds: [messageId],
+      sentAt: new Date(),
+    };
+    const entry: OutboundSendEvent = {
+      kind: 'outbound_send',
+      sessionKey,
+      message,
+      ref,
+    };
+    this.transcript.events.push(entry);
+    this.onOutbound(entry);
+    return ref;
+  }
+
+  async edit(ref: MessageRef, message: OutboundMessage): Promise<void> {
+    const entry: OutboundEvent = {
+      kind: 'outbound_edit',
+      sessionKey: message.sessionKey,
+      ref,
+      message,
+    };
+    this.transcript.events.push(entry);
+    this.onOutbound(entry);
+  }
+
+  async delete(_ref: MessageRef): Promise<void> {
+    throw new Error('FakeDiscordPlatform.delete is not implemented');
+  }
+
+  async react(_ref: MessageRef, _emoji: string): Promise<void> {
+    throw new Error('FakeDiscordPlatform.react is not implemented');
+  }
+
+  async setTyping(sessionKey: SessionKey): Promise<void> {
+    this.transcript.events.push({ kind: 'typing', action: 'set', sessionKey });
+  }
+
+  async clearTyping(sessionKey: SessionKey): Promise<void> {
+    this.transcript.events.push({
+      kind: 'typing',
+      action: 'clear',
+      sessionKey,
+    });
+  }
+}
+
+class ScriptedAgentRuntime implements AgentRuntime {
+  readonly inputs: Array<{ session: AgentSession; input: AgentInput }> = [];
+  private readonly handlers = new Map<AgentSession, AgentEventHandler>();
+  private nextSessionId = 1;
+
+  constructor(
+    private readonly transcript: Transcript,
+    private readonly events: ScriptedAgentEvents,
+  ) {}
+
+  name(): string {
+    return 'scripted-agent';
+  }
+
+  capabilities(): AgentCapabilitySet {
+    return DEFAULT_AGENT_CAPS;
+  }
+
+  startSession(key: SessionKey, _config: SessionConfig): AgentSession {
+    return {
+      key,
+      backend: 'scripted',
+      state: 'Ready',
+      startedAt: new Date(),
+      agentSessionId: `scripted-${this.nextSessionId++}`,
+    };
+  }
+
+  stopSession(session: AgentSession): void {
+    this.handlers.delete(session);
+    session.state = 'Stopped';
+  }
+
+  isAlive(session: AgentSession): boolean {
+    return session.state !== 'Stopped';
+  }
+
+  async sendInput(session: AgentSession, input: AgentInput): Promise<void> {
+    this.inputs.push({ session, input });
+    const handler = this.handlers.get(session);
+    if (!handler) return;
+    for (const event of this.events({ session, input })) {
+      this.transcript.events.push({
+        kind: 'agent_event',
+        eventType: event.type,
+        sequence: event.sequence,
+        traceId: event.traceId,
+      });
+      await handler(event);
+    }
+  }
+
+  onEvent(session: AgentSession, handler: AgentEventHandler): void {
+    this.handlers.set(session, handler);
+  }
+
+  interrupt(_session: AgentSession): void {}
+}
+
+export function createDiscordE2EHarness(options: DiscordE2EHarnessOptions): {
+  agent: ScriptedAgentRuntime;
+  injectMessage(text: string): Promise<NormalizedEvent>;
+  platform: FakeDiscordPlatform;
+  start(): Promise<void>;
+  stop(): Promise<void>;
+  transcript: Transcript;
+  waitForOutbound(
+    predicate: (entry: OutboundEvent) => boolean,
+    timeoutMs?: number,
+  ): Promise<OutboundEvent>;
+} {
+  const transcript: Transcript = {
+    caseId: options.caseId ?? 'harness-qualification',
+    events: [],
+  };
+  type OutboundWaiter = {
+    predicate: (entry: OutboundEvent) => boolean;
+    resolve: (entry: OutboundEvent) => void;
+    timer: ReturnType<typeof setTimeout>;
+  };
+  const outboundWaiters = new Set<OutboundWaiter>();
+  const consumedOutbounds = new WeakSet<OutboundEvent>();
+  const settleOutboundWaiters = (entry: OutboundEvent): void => {
+    let matched = false;
+    for (const waiter of [...outboundWaiters]) {
+      if (!waiter.predicate(entry)) continue;
+      clearTimeout(waiter.timer);
+      outboundWaiters.delete(waiter);
+      matched = true;
+      transcript.events.push({
+        kind: 'assertion',
+        name: 'waitForOutbound',
+        passed: true,
+      });
+      waiter.resolve(entry);
+    }
+    if (matched) consumedOutbounds.add(entry);
+  };
+  const platform = new FakeDiscordPlatform(
+    transcript,
+    options.platformCaps ?? {},
+    settleOutboundWaiters,
+  );
+  const agent = new ScriptedAgentRuntime(transcript, options.agentEvents);
+  const workingDir = mkdtempSync(
+    path.join(tmpdir(), 'agent-nexus-discord-e2e-'),
+  );
+  const engine = new Engine({
+    platform,
+    platformName: options.platformName ?? 'discord-main',
+    agent,
+    logger: createLogger({ level: 'fatal', pretty: false }),
+    sessionStore: new SessionStore(),
+    defaultSessionConfig: {
+      workingDir,
+      timeoutMs: 10_000,
+    },
+  });
+  const sessionKey = options.sessionKey ?? DEFAULT_PLATFORM_SESSION_KEY;
+  let nextInboundId = 1;
+
+  return {
+    agent,
+    platform,
+    transcript,
+    async start(): Promise<void> {
+      await engine.start();
+    },
+    async stop(): Promise<void> {
+      await engine.stop();
+      rmSync(workingDir, { recursive: true, force: true });
+    },
+    async injectMessage(text: string): Promise<NormalizedEvent> {
+      const id = nextInboundId++;
+      const event: NormalizedEvent = {
+        eventId: `e2e-event-${id}`,
+        platform: 'discord',
+        sessionKey,
+        messageId: `e2e-message-${id}`,
+        traceId: `e2e-trace-${id}`,
+        type: 'message',
+        text,
+        rawPayload: {},
+        rawContentType: 'application/json',
+        receivedAt: new Date(),
+        platformTimestamp: new Date(),
+        guildId: 'G-e2e',
+        initiator: {
+          userId: sessionKey.initiatorUserId,
+          displayName: 'e2e-owner',
+          isBot: false,
+        },
+      };
+      await platform.inject(event);
+      return event;
+    },
+    async waitForOutbound(
+      predicate: (entry: OutboundEvent) => boolean,
+      timeoutMs = 1_000,
+    ): Promise<OutboundEvent> {
+      const existing = transcript.events.find(
+        (event): event is OutboundEvent =>
+          (event.kind === 'outbound_send' || event.kind === 'outbound_edit') &&
+          !consumedOutbounds.has(event) &&
+          predicate(event),
+      );
+      if (existing) {
+        consumedOutbounds.add(existing);
+        transcript.events.push({
+          kind: 'assertion',
+          name: 'waitForOutbound',
+          passed: true,
+        });
+        return existing;
+      }
+
+      return await new Promise<OutboundEvent>((resolve, reject) => {
+        const waiter: OutboundWaiter = {
+          predicate,
+          resolve,
+          timer: setTimeout(() => {
+            outboundWaiters.delete(waiter);
+            transcript.events.push({
+              kind: 'assertion',
+              name: 'waitForOutbound',
+              passed: false,
+              details: `no outbound matched within ${timeoutMs}ms`,
+            });
+            reject(new Error(`no outbound matched within ${timeoutMs}ms`));
+          }, timeoutMs),
+        };
+        outboundWaiters.add(waiter);
+      });
+    },
+  };
+}

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['tests/e2e/**/*.test.ts'],
+    environment: 'node',
+  },
+});


### PR DESCRIPTION
## Summary

Adds the P3 Discord E2E harness scaffold.

本 PR：
- adds a fake Discord `PlatformAdapter` harness under `tests/e2e/discord`
- adds a scripted agent runtime for harness qualification without claiming real-agent E2E evidence
- adds event-driven `waitForOutbound` transcript assertions for send/edit outbound events
- adds `test:e2e:discord` backed by an isolated E2E Vitest config

## Why

The Discord E2E implementation needs a reusable harness before real-agent seed cases can be added. This PR establishes the fake platform seam, deterministic event injection, outbound capture, transcript events, and a dedicated runner entry while keeping default `pnpm test` isolated from future real-agent E2E cases.

ADR: N/A - follows the accepted testing design.
Spec: `docs/dev/testing/discord-e2e.md` P3 harness scaffold.

## Test plan

- [x] Red: `corepack pnpm exec vitest run tests/e2e/discord/harness.test.ts` initially failed because E2E tests were not discoverable.
- [x] Red: after runner plumbing, the same command failed because `./harness.js` did not exist.
- [x] Red: after first harness implementation, async waiter test failed because `waitForOutbound` did not resolve when wait started before injection.
- [x] `corepack pnpm test:e2e:discord`
- [x] `corepack pnpm test`
- [x] `corepack pnpm typecheck`
- [x] `corepack pnpm exec tsc --noEmit --target ES2022 --module NodeNext --moduleResolution NodeNext --lib ES2022 --strict --noUncheckedIndexedAccess --noImplicitOverride --noFallthroughCasesInSwitch --esModuleInterop --forceConsistentCasingInFileNames --skipLibCheck --resolveJsonModule --isolatedModules --types node,vitest tests/e2e/discord/harness.ts tests/e2e/discord/harness.test.ts`
- [x] `git diff --check`

## Review notes

- Independent agent review: Claude review completed at `/home/node/.goal/discord-e2e-agent-friendly-tests/reviews/p3-harness-claude-review.md`; important findings on runner isolation and outbound history matching were fixed.
- Deep review: Claude re-review completed at `/home/node/.goal/discord-e2e-agent-friendly-tests/reviews/p3-harness-claude-rereview.md`; it confirmed the important findings were fixed and reported no required changes.

## Out of scope

- Real Codex/Claude agent runtime E2E seed cases.
- Persistent `(sessionKey,messageId)` idempotency.
- Daemon redaction and transcript artifact persistence.
- Resolving long-output slicing ownership.
