### PR TITLE
test(discord): 扩展 E2E harness 同步能力

### DIFF
--- a/tests/e2e/discord/harness.test.ts
+++ b/tests/e2e/discord/harness.test.ts
@@ -1,13 +1,52 @@
-import { describe, expect, it } from 'vitest';
+import { existsSync } from 'node:fs';
+import { afterEach, describe, expect, it } from 'vitest';
 import type { SessionKey } from '../../../packages/protocol/src/index.js';
 import {
   createDiscordE2EHarness,
   scriptedTextReply,
 } from './harness.js';
 
+type DiscordE2EHarness = ReturnType<typeof createDiscordE2EHarness>;
+
+const harnesses: DiscordE2EHarness[] = [];
+
+function makeHarness(
+  options: Parameters<typeof createDiscordE2EHarness>[0],
+): DiscordE2EHarness {
+  const harness = createDiscordE2EHarness(options);
+  harnesses.push(harness);
+  return harness;
+}
+
+afterEach(async () => {
+  const pending = harnesses.splice(0);
+  await Promise.all(
+    pending.map(async (harness) => {
+      try {
+        await harness.stop();
+      } catch {
+        // Best-effort cleanup only; the test's own assertion failure should remain primary.
+      }
+    }),
+  );
+});
+
+function allowOnlyOwner() {
+  return {
+    allowlist: {
+      userIds: ['U-e2e-owner'],
+      roleIds: [],
+      allowedGuildIds: [],
+      allowedChannelIds: [],
+      allowDM: true,
+      requireMentionOrSlash: true,
+    },
+  };
+}
+
 describe('Discord E2E harness', () => {
   it('should_drive_fake_discord_input_through_engine_to_outbound_when_scripted_agent_replies', async () => {
-    const harness = createDiscordE2EHarness({
+    const harness = makeHarness({
       agentEvents: scriptedTextReply('pong from agent'),
     });
 
@@ -44,7 +83,7 @@ describe('Discord E2E harness', () => {
   });
 
   it('should_resolve_waitForOutbound_when_wait_starts_before_message_is_injected', async () => {
-    const harness = createDiscordE2EHarness({
+    const harness = makeHarness({
       agentEvents: scriptedTextReply('async pong'),
     });
 
@@ -69,7 +108,7 @@ describe('Discord E2E harness', () => {
   });
 
   it('should_reject_waitForOutbound_when_no_new_outbound_matches_before_timeout', async () => {
-    const harness = createDiscordE2EHarness({
+    const harness = makeHarness({
       agentEvents: scriptedTextReply('single pong'),
     });
 
@@ -86,6 +125,94 @@ describe('Discord E2E harness', () => {
     await expect(
       harness.waitForOutbound((entry) => entry.message.text === 'single pong', 1),
     ).rejects.toThrow('no outbound matched within 1ms');
+    expect(harness.transcript.events.at(-1)).toMatchObject({
+      kind: 'assertion',
+      passed: false,
+    });
+
+    await harness.stop();
+  });
+
+  it('should_expose_tmpdir_paths_and_remove_them_on_stop_by_default', async () => {
+    const harness = makeHarness({
+      agentEvents: scriptedTextReply('pong'),
+    });
+
+    expect(existsSync(harness.paths.rootDir)).toBe(true);
+    expect(existsSync(harness.paths.workingDir)).toBe(true);
+    expect(existsSync(harness.paths.stateDir)).toBe(true);
+    expect(existsSync(harness.paths.transcriptDir)).toBe(true);
+
+    const rootDir = harness.paths.rootDir;
+    await harness.start();
+    await harness.stop();
+
+    expect(existsSync(rootDir)).toBe(false);
+  });
+
+  it('should_wait_for_agent_event_and_turn_finished_when_waiters_start_before_injection', async () => {
+    const harness = makeHarness({
+      agentEvents: scriptedTextReply('event pong'),
+    });
+
+    await harness.start();
+    const textFinalPromise = harness.waitForAgentEvent(
+      (event) => event.eventType === 'text_final',
+    );
+    const turnFinishedPromise = harness.waitForTurnFinished('e2e-trace-1');
+
+    await harness.injectMessage('hello event waiters');
+
+    await expect(textFinalPromise).resolves.toMatchObject({
+      kind: 'agent_event',
+      eventType: 'text_final',
+      traceId: 'e2e-trace-1',
+    });
+    await expect(turnFinishedPromise).resolves.toMatchObject({
+      kind: 'agent_event',
+      eventType: 'turn_finished',
+      traceId: 'e2e-trace-1',
+    });
+
+    await harness.stop();
+  });
+
+  it('should_support_event_overrides_and_waitForNoAgentCall_for_auth_denied_paths', async () => {
+    const harness = makeHarness({
+      platformAuth: allowOnlyOwner(),
+      agentEvents: scriptedTextReply('should not run'),
+    });
+
+    await harness.start();
+    const inbound = await harness.injectMessage('blocked user', {
+      initiatorUserId: 'U-e2e-denied',
+      traceId: 'blocked-trace',
+    });
+
+    await harness.waitForNoAgentCall(10);
+
+    expect(inbound.traceId).toBe('blocked-trace');
+    expect(harness.agent.inputs).toHaveLength(0);
+    expect(
+      harness.transcript.events.some(
+        (event) => event.kind === 'assertion' && event.passed,
+      ),
+    ).toBe(true);
+
+    await harness.stop();
+  });
+
+  it('should_reject_waitForNoAgentCall_when_agent_was_already_called', async () => {
+    const harness = makeHarness({
+      agentEvents: scriptedTextReply('already called'),
+    });
+
+    await harness.start();
+    await harness.injectMessage('hello before no-call assertion');
+
+    await expect(harness.waitForNoAgentCall(1)).rejects.toThrow(
+      'expected 0 agent inputs, got 1',
+    );
     expect(harness.transcript.events.at(-1)).toMatchObject({
       kind: 'assertion',
       passed: false,

--- a/tests/e2e/discord/harness.ts
+++ b/tests/e2e/discord/harness.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import type {
@@ -19,6 +19,7 @@ import type {
   SessionKey,
 } from '../../../packages/protocol/src/index.js';
 import { Engine } from '../../../packages/daemon/src/engine.js';
+import type { PlatformAuthConfig } from '../../../packages/daemon/src/config.js';
 import { createLogger } from '../../../packages/daemon/src/logger.js';
 import { SessionStore } from '../../../packages/daemon/src/session-store.js';
 
@@ -102,6 +103,10 @@ export type OutboundEvent = Extract<
   TranscriptEvent,
   { kind: 'outbound_send' | 'outbound_edit' }
 >;
+export type AgentTranscriptEvent = Extract<
+  TranscriptEvent,
+  { kind: 'agent_event' }
+>;
 
 export type ScriptedAgentEvents = (ctx: {
   session: AgentSession;
@@ -110,10 +115,30 @@ export type ScriptedAgentEvents = (ctx: {
 
 export interface DiscordE2EHarnessOptions {
   caseId?: string;
+  keepArtifacts?: boolean;
+  platformAuth?: PlatformAuthConfig;
   platformName?: string;
   platformCaps?: Partial<CapabilitySet>;
   sessionKey?: PlatformSessionKey;
   agentEvents: ScriptedAgentEvents;
+}
+
+export interface DiscordE2EHarnessPaths {
+  rootDir: string;
+  workingDir: string;
+  stateDir: string;
+  transcriptDir: string;
+}
+
+export interface InjectMessageOptions {
+  eventId?: string;
+  messageId?: string;
+  traceId?: string;
+  channelId?: string;
+  initiatorUserId?: string;
+  displayName?: string;
+  guildId?: string;
+  initiatorRoleIds?: string[];
 }
 
 export function scriptedTextReply(text: string): ScriptedAgentEvents {
@@ -241,6 +266,7 @@ class ScriptedAgentRuntime implements AgentRuntime {
 
   constructor(
     private readonly transcript: Transcript,
+    private readonly onAgentEvent: (entry: AgentTranscriptEvent) => void,
     private readonly events: ScriptedAgentEvents,
   ) {}
 
@@ -276,12 +302,14 @@ class ScriptedAgentRuntime implements AgentRuntime {
     const handler = this.handlers.get(session);
     if (!handler) return;
     for (const event of this.events({ session, input })) {
-      this.transcript.events.push({
+      const entry: AgentTranscriptEvent = {
         kind: 'agent_event',
         eventType: event.type,
         sequence: event.sequence,
         traceId: event.traceId,
-      });
+      };
+      this.transcript.events.push(entry);
+      this.onAgentEvent(entry);
       await handler(event);
     }
   }
@@ -295,15 +323,28 @@ class ScriptedAgentRuntime implements AgentRuntime {
 
 export function createDiscordE2EHarness(options: DiscordE2EHarnessOptions): {
   agent: ScriptedAgentRuntime;
-  injectMessage(text: string): Promise<NormalizedEvent>;
+  injectMessage(
+    text: string,
+    overrides?: InjectMessageOptions,
+  ): Promise<NormalizedEvent>;
+  paths: DiscordE2EHarnessPaths;
   platform: FakeDiscordPlatform;
   start(): Promise<void>;
   stop(): Promise<void>;
   transcript: Transcript;
+  waitForAgentEvent(
+    predicate: (entry: AgentTranscriptEvent) => boolean,
+    timeoutMs?: number,
+  ): Promise<AgentTranscriptEvent>;
   waitForOutbound(
     predicate: (entry: OutboundEvent) => boolean,
     timeoutMs?: number,
   ): Promise<OutboundEvent>;
+  waitForNoAgentCall(windowMs?: number, expectedTotal?: number): Promise<void>;
+  waitForTurnFinished(
+    traceId: string,
+    timeoutMs?: number,
+  ): Promise<AgentTranscriptEvent>;
 } {
   const transcript: Transcript = {
     caseId: options.caseId ?? 'harness-qualification',
@@ -337,26 +378,103 @@ export function createDiscordE2EHarness(options: DiscordE2EHarnessOptions): {
     options.platformCaps ?? {},
     settleOutboundWaiters,
   );
-  const agent = new ScriptedAgentRuntime(transcript, options.agentEvents);
-  const workingDir = mkdtempSync(
+  type AgentWaiter = {
+    predicate: (entry: AgentTranscriptEvent) => boolean;
+    resolve: (entry: AgentTranscriptEvent) => void;
+    timer: ReturnType<typeof setTimeout>;
+  };
+  const agentWaiters = new Set<AgentWaiter>();
+  const consumedAgentEvents = new WeakSet<AgentTranscriptEvent>();
+  const settleAgentWaiters = (entry: AgentTranscriptEvent): void => {
+    let matched = false;
+    for (const waiter of [...agentWaiters]) {
+      if (!waiter.predicate(entry)) continue;
+      clearTimeout(waiter.timer);
+      agentWaiters.delete(waiter);
+      matched = true;
+      transcript.events.push({
+        kind: 'assertion',
+        name: 'waitForAgentEvent',
+        passed: true,
+      });
+      waiter.resolve(entry);
+    }
+    if (matched) consumedAgentEvents.add(entry);
+  };
+  const agent = new ScriptedAgentRuntime(
+    transcript,
+    settleAgentWaiters,
+    options.agentEvents,
+  );
+  const rootDir = mkdtempSync(
     path.join(tmpdir(), 'agent-nexus-discord-e2e-'),
   );
+  const paths: DiscordE2EHarnessPaths = {
+    rootDir,
+    workingDir: path.join(rootDir, 'workdir'),
+    stateDir: path.join(rootDir, 'state'),
+    transcriptDir: path.join(rootDir, 'transcripts'),
+  };
+  mkdirSync(paths.workingDir, { recursive: true });
+  mkdirSync(paths.stateDir, { recursive: true });
+  mkdirSync(paths.transcriptDir, { recursive: true });
   const engine = new Engine({
     platform,
     platformName: options.platformName ?? 'discord-main',
+    platformAuth: options.platformAuth,
     agent,
     logger: createLogger({ level: 'fatal', pretty: false }),
     sessionStore: new SessionStore(),
     defaultSessionConfig: {
-      workingDir,
+      workingDir: paths.workingDir,
       timeoutMs: 10_000,
     },
   });
   const sessionKey = options.sessionKey ?? DEFAULT_PLATFORM_SESSION_KEY;
   let nextInboundId = 1;
 
+  const waitForAgentEvent = async (
+    predicate: (entry: AgentTranscriptEvent) => boolean,
+    timeoutMs = 1_000,
+  ): Promise<AgentTranscriptEvent> => {
+    const existing = transcript.events.find(
+      (event): event is AgentTranscriptEvent =>
+        event.kind === 'agent_event' &&
+        !consumedAgentEvents.has(event) &&
+        predicate(event),
+    );
+    if (existing) {
+      consumedAgentEvents.add(existing);
+      transcript.events.push({
+        kind: 'assertion',
+        name: 'waitForAgentEvent',
+        passed: true,
+      });
+      return existing;
+    }
+
+    return await new Promise<AgentTranscriptEvent>((resolve, reject) => {
+      const waiter: AgentWaiter = {
+        predicate,
+        resolve,
+        timer: setTimeout(() => {
+          agentWaiters.delete(waiter);
+          transcript.events.push({
+            kind: 'assertion',
+            name: 'waitForAgentEvent',
+            passed: false,
+            details: `no agent event matched within ${timeoutMs}ms`,
+          });
+          reject(new Error(`no agent event matched within ${timeoutMs}ms`));
+        }, timeoutMs),
+      };
+      agentWaiters.add(waiter);
+    });
+  };
+
   return {
     agent,
+    paths,
     platform,
     transcript,
     async start(): Promise<void> {
@@ -364,32 +482,45 @@ export function createDiscordE2EHarness(options: DiscordE2EHarnessOptions): {
     },
     async stop(): Promise<void> {
       await engine.stop();
-      rmSync(workingDir, { recursive: true, force: true });
+      if (!options.keepArtifacts) {
+        rmSync(paths.rootDir, { recursive: true, force: true });
+      }
     },
-    async injectMessage(text: string): Promise<NormalizedEvent> {
+    async injectMessage(
+      text: string,
+      overrides: InjectMessageOptions = {},
+    ): Promise<NormalizedEvent> {
       const id = nextInboundId++;
+      const eventSessionKey: PlatformSessionKey = {
+        platform: sessionKey.platform,
+        channelId: overrides.channelId ?? sessionKey.channelId,
+        initiatorUserId:
+          overrides.initiatorUserId ?? sessionKey.initiatorUserId,
+      };
       const event: NormalizedEvent = {
-        eventId: `e2e-event-${id}`,
+        eventId: overrides.eventId ?? `e2e-event-${id}`,
         platform: 'discord',
-        sessionKey,
-        messageId: `e2e-message-${id}`,
-        traceId: `e2e-trace-${id}`,
+        sessionKey: eventSessionKey,
+        messageId: overrides.messageId ?? `e2e-message-${id}`,
+        traceId: overrides.traceId ?? `e2e-trace-${id}`,
         type: 'message',
         text,
         rawPayload: {},
         rawContentType: 'application/json',
         receivedAt: new Date(),
         platformTimestamp: new Date(),
-        guildId: 'G-e2e',
+        guildId: overrides.guildId ?? 'G-e2e',
+        initiatorRoleIds: overrides.initiatorRoleIds,
         initiator: {
-          userId: sessionKey.initiatorUserId,
-          displayName: 'e2e-owner',
+          userId: eventSessionKey.initiatorUserId,
+          displayName: overrides.displayName ?? 'e2e-owner',
           isBot: false,
         },
       };
       await platform.inject(event);
       return event;
     },
+    waitForAgentEvent,
     async waitForOutbound(
       predicate: (entry: OutboundEvent) => boolean,
       timeoutMs = 1_000,
@@ -427,6 +558,36 @@ export function createDiscordE2EHarness(options: DiscordE2EHarnessOptions): {
         };
         outboundWaiters.add(waiter);
       });
+    },
+    async waitForNoAgentCall(
+      windowMs = 50,
+      expectedTotal = 0,
+    ): Promise<void> {
+      await new Promise((resolve) => setTimeout(resolve, windowMs));
+      const passed = agent.inputs.length === expectedTotal;
+      transcript.events.push({
+        kind: 'assertion',
+        name: 'waitForNoAgentCall',
+        passed,
+        details: passed
+          ? undefined
+          : `expected ${expectedTotal} agent inputs, got ${agent.inputs.length}`,
+      });
+      if (!passed) {
+        throw new Error(
+          `expected ${expectedTotal} agent inputs, got ${agent.inputs.length}`,
+        );
+      }
+    },
+    async waitForTurnFinished(
+      traceId: string,
+      timeoutMs = 1_000,
+    ): Promise<AgentTranscriptEvent> {
+      return await waitForAgentEvent(
+        (entry) =>
+          entry.eventType === 'turn_finished' && entry.traceId === traceId,
+        timeoutMs,
+      );
     },
   };
 }


### PR DESCRIPTION
## Summary

Adds core Discord E2E harness helpers for P4.

本 PR：
- adds tmpdir `paths` for harness working/state/transcript directories with cleanup on stop
- adds deterministic message injection overrides for event/user/channel/guild/trace fields
- adds `waitForAgentEvent`, `waitForTurnFinished`, and stricter `waitForNoAgentCall`
- wires `platformAuth` through the harness so auth-denied paths can be qualified

## Why

P5 seed cases need more than outbound capture: they need deterministic input construction, negative-path synchronization, and a harness-owned tmpdir shape for future state/transcript artifacts. This keeps the current layer as scripted-agent harness qualification while preparing the core helpers needed by real-agent seed cases.

ADR: N/A - extends the accepted testing harness.
Spec: `docs/dev/testing/discord-e2e.md` P4 core harness implementation.

## Test plan

- [x] Red: `corepack pnpm test:e2e:discord` failed because `paths`, `waitForAgentEvent`, and `waitForNoAgentCall` were missing.
- [x] `corepack pnpm test:e2e:discord`
- [x] `corepack pnpm exec tsc --noEmit --target ES2022 --module NodeNext --moduleResolution NodeNext --lib ES2022 --strict --noUncheckedIndexedAccess --noImplicitOverride --noFallthroughCasesInSwitch --esModuleInterop --forceConsistentCasingInFileNames --skipLibCheck --resolveJsonModule --isolatedModules --types node,vitest tests/e2e/discord/harness.ts tests/e2e/discord/harness.test.ts`
- [x] `corepack pnpm test`
- [x] `corepack pnpm typecheck`
- [x] `git diff --check`

## Review notes

- Independent agent review: Claude review completed at `/home/node/.goal/discord-e2e-agent-friendly-tests/reviews/p4-core-harness-claude-review.md`; important findings on `waitForNoAgentCall` false positives and tmpdir cleanup were fixed.
- Deep review: Claude re-review completed at `/home/node/.goal/discord-e2e-agent-friendly-tests/reviews/p4-core-harness-claude-rereview.md`; it confirmed no required changes remained.

## Out of scope

- Real Codex/Claude agent runtime E2E seed cases.
- Persisted transcript artifact writing.
- Persistent `(sessionKey,messageId)` idempotency and daemon redaction.
- Long-output slicing ownership.
