### PR TITLE
feat(daemon): 支持 Discord E2E seed 前置能力

### DIFF
--- a/docs/dev/testing/discord-e2e.md
+++ b/docs/dev/testing/discord-e2e.md
@@ -187,11 +187,11 @@ E2E 禁止用固定 sleep 等待业务结果。harness 提供显式等待：
 | `long-output-slicing` | 长回复切片归属清晰后，证明默认 E2E 不产生 fake-only 通过 | 不由 fake adapter 复刻 Discord `buildSlices`；最终断言随 platform-adapter owner 对切片归属的修正确定 |
 | `redaction` | agent 输出敏感模式时发到 Discord 前已脱敏 | outbound 不含原始 secret / 绝对路径；transcript 也不含原文 |
 
-当前代码缺口影响：
+当前实现状态与缺口：
 
-- `idempotency-replay` 必须按 spec 的 `(sessionKey, messageId)` 语义实现；当前仅有 `eventId` 内存 dedup，不足以作为最终通过证据。
-- `redaction` 必须等 daemon redaction layer 落地后才可通过；当前直接发送 agent 文本，不能声明通过。
-- `long-output-slicing` 必须先澄清切片归属；当前实现的切片在真实 Discord adapter 内，默认 fake-adapter E2E 不能通过复刻该逻辑来声明生产切片通过。
+- `idempotency-replay` 需要按 spec 的 `(sessionKey, messageId)` 语义实现；当前已有可注入的内存 `IdempotencyStore`，但尚未覆盖 SQLite 持久化、TTL、GC 与 failed 重试窗口。
+- `redaction` 当前覆盖 daemon 到 IM outbound 的基础文本脱敏；日志 sink、agent 子进程 transcript 等全出口脱敏仍需后续按 redaction spec 补齐。
+- `long-output-slicing` 当前 seed 通过 fake platform 的 `maxTextLength` 能力模拟证明 harness 能捕获多条 outbound；真实 Discord 仍由 adapter 的 `buildSlices` 维护切片与 `MessageRef.messageIds`，段落 / 代码块边界、续页标记的最终归属仍需后续收敛。
 - 若 session/idempotency 存储仍是内存实现，E2E 可以用 tmpdir state，但不能声称已覆盖 SQLite 持久化。
 
 ## 真实 Agent 选择

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -3,6 +3,7 @@ import { mkdir } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import {
   Engine,
+  InMemoryIdempotencyStore,
   SessionStore,
   createLogger,
   type RoutingEntry,
@@ -85,6 +86,7 @@ async function main(): Promise<void> {
   );
 
   const sessionStore = new SessionStore();
+  const idempotencyStore = new InMemoryIdempotencyStore();
   const engines: Engine[] = [];
 
   for (const platformConfig of config.platforms) {
@@ -140,6 +142,7 @@ async function main(): Promise<void> {
         platformAuth: platformConfig.auth,
         agents,
         routingTable,
+        idempotencyStore,
         logger,
         sessionStore,
         toolMessages: {

--- a/packages/daemon/src/engine.test.ts
+++ b/packages/daemon/src/engine.test.ts
@@ -18,6 +18,7 @@ import type {
 } from '@agent-nexus/protocol';
 import { withPlatformName } from '@agent-nexus/protocol';
 import { Engine } from './engine.js';
+import { InMemoryIdempotencyStore } from './idempotency.js';
 import { createLogger, type Logger } from './logger.js';
 import type { RoutingEntry } from './router.js';
 import { SessionStore } from './session-store.js';
@@ -622,6 +623,91 @@ describe('Engine', () => {
     expect(dedupLog![0]).toMatchObject({ eventId: dup.eventId, traceId: 't-1' });
   });
 
+  it('注入 IdempotencyStore 后同 session/messageId 重放不触发第二次 agent 调用', async () => {
+    const platform = makePlatform();
+    const agent = makeAgent();
+    const store = new SessionStore();
+    const mockLogger = {
+      info: vi.fn(),
+      debug: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      trace: vi.fn(),
+      fatal: vi.fn(),
+      child: vi.fn(),
+    } as unknown as Logger;
+    const engine = new Engine({
+      platform,
+      agent: agent.runtime,
+      logger: mockLogger,
+      sessionStore: store,
+      idempotencyStore: new InMemoryIdempotencyStore(),
+      defaultSessionConfig: DEFAULT_CFG,
+    });
+
+    await engine.start();
+    const dispatchHandler = (platform.start as ReturnType<typeof vi.fn>).mock.calls[0]![0] as EventHandler;
+    agent.queueEvents([
+      ev('text_final', { text: 'first' }),
+      ev('turn_finished', { reason: 'stop', turnSequence: 1 }),
+    ]);
+
+    await dispatchHandler(makeEvent('first', {
+      eventId: 'e-replay-1',
+      messageId: 'm-replay',
+    }));
+    await dispatchHandler(makeEvent('second', {
+      eventId: 'e-replay-2',
+      messageId: 'm-replay',
+    }));
+
+    expect(agent.sendInput).toHaveBeenCalledTimes(1);
+    expect(platform.send).toHaveBeenCalledTimes(1);
+    expect((mockLogger.info as ReturnType<typeof vi.fn>).mock.calls).toEqual(
+      expect.arrayContaining([
+        expect.arrayContaining([expect.any(Object), 'idempotency_insert']),
+        expect.arrayContaining([expect.any(Object), 'idempotency_hit']),
+      ]),
+    );
+  });
+
+  it('auth_denied 不占用幂等键，后续同 messageId 授权事件仍可处理', async () => {
+    const platform = makePlatform();
+    const agent = makeAgent();
+    const store = new SessionStore();
+    const engine = new Engine({
+      platform,
+      agent: agent.runtime,
+      logger: SILENT_LOGGER,
+      sessionStore: store,
+      idempotencyStore: new InMemoryIdempotencyStore(),
+      platformAuth: PLATFORM_AUTH_ALLOW_U1,
+      defaultSessionConfig: DEFAULT_CFG,
+    });
+
+    await engine.start();
+    const dispatchHandler = (platform.start as ReturnType<typeof vi.fn>).mock.calls[0]![0] as EventHandler;
+
+    await dispatchHandler(makeEvent('denied', {
+      eventId: 'e-denied',
+      messageId: 'm-same',
+      initiator: { userId: 'U2', displayName: 'U2', isBot: false },
+      sessionKey: { ...SESSION_KEY, initiatorUserId: 'U2' },
+    }));
+
+    agent.queueEvents([
+      ev('text_final', { text: 'allowed' }),
+      ev('turn_finished', { reason: 'stop', turnSequence: 1 }),
+    ]);
+    await dispatchHandler(makeEvent('allowed', {
+      eventId: 'e-allowed',
+      messageId: 'm-same',
+    }));
+
+    expect(agent.sendInput).toHaveBeenCalledTimes(1);
+    expect(platform.send).toHaveBeenCalledTimes(1);
+  });
+
   it('eventId 去重 cap 淘汰：最早 entry 被淘汰，最新 entry 仍被 dedup（非整表 clear）', async () => {
     const platform = makePlatform();
     const agent = makeAgent();
@@ -1206,6 +1292,83 @@ describe('Engine', () => {
     expect((platform.send.mock.calls[0]![1] as OutboundMessage).text).toBe('he');
     expect(platform.edit).toHaveBeenCalledTimes(1);
     expect((platform.edit.mock.calls[0]![1] as OutboundMessage).text).toBe('hello');
+  });
+
+  it('长回复 edit 交给 platform adapter 维护切片与 messageIds', async () => {
+    const platform = makePlatform({ supportsEdit: true, maxTextLength: 5 });
+    const agent = makeAgent();
+    const store = new SessionStore();
+    const initialRef: MessageRef = {
+      platform: 'discord',
+      channelId: 'C1',
+      messageId: 'out-1',
+      messageIds: ['out-1'],
+      sentAt: new Date(0),
+    };
+    platform.send.mockResolvedValue(initialRef);
+    platform.edit.mockImplementation(async (ref: MessageRef) => {
+      ref.messageIds = ['out-1', 'out-2'];
+      ref.messageId = 'out-2';
+    });
+    const engine = new Engine({
+      platform,
+      agent: agent.runtime,
+      logger: SILENT_LOGGER,
+      sessionStore: store,
+      defaultSessionConfig: DEFAULT_CFG,
+      streaming: { streamEditThrottleMs: 1000 },
+    });
+
+    await engine.start();
+    const dispatchHandler = (platform.start as ReturnType<typeof vi.fn>).mock.calls[0]![0] as EventHandler;
+
+    agent.queueEvents([
+      ev('text_delta', { text: 'ab' }),
+      ev('text_final', { text: 'abcdefghijkl' }),
+      ev('turn_finished', { reason: 'stop', turnSequence: 1 }),
+    ]);
+
+    await dispatchHandler(makeEvent('hello'));
+
+    expect(platform.send).toHaveBeenCalledTimes(1);
+    expect(platform.edit).toHaveBeenCalledTimes(1);
+    const editedRef = platform.edit.mock.calls[0]![0] as MessageRef;
+    expect((platform.edit.mock.calls[0]![1] as OutboundMessage).text).toBe(
+      'abcdefghijkl',
+    );
+    expect(editedRef.messageIds).toEqual(['out-1', 'out-2']);
+    expect(editedRef.messageId).toBe('out-2');
+  });
+
+  it('outbound send 前会脱敏 secret 和用户 home 绝对路径', async () => {
+    const platform = makePlatform();
+    const agent = makeAgent();
+    const store = new SessionStore();
+    const engine = new Engine({
+      platform,
+      agent: agent.runtime,
+      logger: SILENT_LOGGER,
+      sessionStore: store,
+      defaultSessionConfig: DEFAULT_CFG,
+    });
+
+    await engine.start();
+    const dispatchHandler = (platform.start as ReturnType<typeof vi.fn>).mock.calls[0]![0] as EventHandler;
+
+    agent.queueEvents([
+      ev('text_final', {
+        text: 'ANTHROPIC_API_KEY=sk-ant-abc123 path=/home/node/secret/file.ts',
+      }),
+      ev('turn_finished', { reason: 'stop', turnSequence: 1 }),
+    ]);
+
+    await dispatchHandler(makeEvent('hello'));
+
+    const out = platform.send.mock.calls[0]![1] as OutboundMessage;
+    expect(out.text).toContain('ANTHROPIC_API_KEY=<redacted>');
+    expect(out.text).toContain('path=~/secret/file.ts');
+    expect(out.text).not.toContain('sk-ant-abc123');
+    expect(out.text).not.toContain('/home/node/secret');
   });
 
   it('默认 append：tool start 单独发送，tool_result 不编辑用户可见消息，final 追加新消息', async () => {

--- a/packages/daemon/src/engine.ts
+++ b/packages/daemon/src/engine.ts
@@ -12,7 +12,9 @@ import type {
 import { serializeSessionKey, withPlatformName } from '@agent-nexus/protocol';
 import { checkPlatformAuth } from './auth.js';
 import type { PlatformAuthConfig, ToolMessageMode } from './config.js';
+import type { IdempotencyStore } from './idempotency.js';
 import type { Logger } from './logger.js';
+import { BasicRedactor, type Redactor } from './redaction.js';
 import { RouteError, selectRoute, type RoutingEntry } from './router.js';
 import type { SessionStore } from './session-store.js';
 
@@ -33,6 +35,8 @@ export interface EngineDeps {
   agents?: readonly EngineAgent[];
   routingTable?: readonly RoutingEntry[];
   platformAuth?: PlatformAuthConfig;
+  idempotencyStore?: IdempotencyStore;
+  redactor?: Redactor;
   logger: Logger;
   sessionStore: SessionStore;
   /** 每轮 sessionId 由 Engine 生成；resumeFromAgentSessionId 由 store 决定 */
@@ -88,10 +92,11 @@ function renderToolStart(toolName: string, inputSummary: string): string {
  * Engine：把 platform 入站事件路由到 agent，并把 agent 输出回送 platform。
  *
  * MVP 跳过的横切能力——下一批 PR 逐个补：
- * - 持久化幂等 / auth ordering → docs/dev/spec/infra/idempotency.md
- *   （进程内 eventId LRU 已落，详见 seenEventIds 字段）
+ * - 持久化 SQLite 幂等 → docs/dev/spec/infra/idempotency.md
+ *   （Engine 支持注入 IdempotencyStore；进程内 eventId LRU 仍作纵深防御）
+ * - 日志 sink / transcript 全出口脱敏 → docs/dev/spec/security/redaction.md
+ *   （Engine 已对 IM outbound 应用 Redactor）
  * - 限流 / 预算 → docs/dev/spec/infra/cost-and-limits.md
- * - 出口脱敏 → docs/dev/spec/security/redaction.md
  * - sessionStore 持久化 + 状态机 → docs/dev/architecture/session-model.md
  */
 export class Engine {
@@ -99,6 +104,8 @@ export class Engine {
   private readonly platformName: string;
   private readonly platformType: 'discord';
   private readonly platformAuth?: PlatformAuthConfig;
+  private readonly idempotencyStore?: IdempotencyStore;
+  private readonly redactor: Redactor;
   private readonly agents: Map<string, EngineAgent>;
   private readonly routingTable?: readonly RoutingEntry[];
   private readonly logger: Logger;
@@ -131,6 +138,8 @@ export class Engine {
       throw new Error('Engine with routingTable requires platformAuth');
     }
     this.platformAuth = deps.platformAuth;
+    this.idempotencyStore = deps.idempotencyStore;
+    this.redactor = deps.redactor ?? new BasicRedactor();
     this.routingTable = deps.routingTable;
     this.agents = new Map();
     if (deps.agents) {
@@ -170,6 +179,7 @@ export class Engine {
     }
     this.agentSessions.clear();
     this.sessionStore.clearAll();
+    this.idempotencyStore?.clearAll();
   }
 
   private dispatch(event: NormalizedEvent): Promise<void> {
@@ -210,6 +220,33 @@ export class Engine {
       );
       return Promise.resolve();
     }
+    const idempotencyMessageId = event.messageId;
+    if (this.idempotencyStore && idempotencyMessageId) {
+      const decision = this.idempotencyStore.checkAndSet(
+        routedSessionKey,
+        idempotencyMessageId,
+      );
+      if (decision.kind === 'hit') {
+        this.logger.info(
+          {
+            traceId: event.traceId,
+            sessionKey: serializeSessionKey(routedSessionKey),
+            messageId: idempotencyMessageId,
+            status: decision.status,
+          },
+          'idempotency_hit',
+        );
+        return Promise.resolve();
+      }
+      this.logger.info(
+        {
+          traceId: event.traceId,
+          sessionKey: serializeSessionKey(routedSessionKey),
+          messageId: idempotencyMessageId,
+        },
+        'idempotency_insert',
+      );
+    }
     const keyStr = serializeSessionKey(routedSessionKey);
     const prev = this.inflight.get(keyStr) ?? Promise.resolve();
     // 链式 await：上一条 settle 后再跑当前这条。前一条若 reject 不影响后续——
@@ -217,7 +254,25 @@ export class Engine {
     // 链上某条 throw 把整条链 poison 掉。
     const next = prev
       .catch(() => {})
-      .then(() => this.dispatchImpl(routedEvent, agentSlot));
+      .then(async () => {
+        try {
+          await this.dispatchImpl(routedEvent, agentSlot);
+          if (this.idempotencyStore && idempotencyMessageId) {
+            this.idempotencyStore.markProcessed(
+              routedSessionKey,
+              idempotencyMessageId,
+            );
+          }
+        } catch (err) {
+          if (this.idempotencyStore && idempotencyMessageId) {
+            this.idempotencyStore.markFailed(
+              routedSessionKey,
+              idempotencyMessageId,
+            );
+          }
+          throw err;
+        }
+      });
     this.inflight.set(keyStr, next);
     // 链尾 cleanup：当前这条就是最末时清掉 map 项，避免长期累积空 promise。
     void next.finally(() => {
@@ -263,6 +318,15 @@ export class Engine {
         return undefined;
       }
       throw err;
+    }
+  }
+
+  private redactForOutbound(text: string, traceId: string): string {
+    try {
+      return this.redactor.redact(text);
+    } catch (err) {
+      this.logger.error({ traceId, err }, 'redaction_failed');
+      return '[redacted output unavailable]';
     }
   }
 
@@ -352,8 +416,9 @@ export class Engine {
 
       const safeSend = async (text: string): Promise<MessageRef | undefined> => {
         try {
+          const outboundText = this.redactForOutbound(text, event.traceId);
           return await this.platform.send(event.sessionKey, {
-            text,
+            text: outboundText,
             traceId: event.traceId,
             sessionKey: event.sessionKey,
           });
@@ -375,8 +440,9 @@ export class Engine {
         text: string,
       ): Promise<void> => {
         try {
+          const outboundText = this.redactForOutbound(text, event.traceId);
           await this.platform.edit(ref, {
-            text,
+            text: outboundText,
             traceId: event.traceId,
             sessionKey: event.sessionKey,
           });
@@ -506,6 +572,7 @@ export class Engine {
           return;
         }
         const text = buf.length > 0 ? buf : '[empty response]';
+        const outboundText = this.redactForOutbound(text, event.traceId);
         if (platformCaps.supportsEdit) {
           await flushEdit(text);
         } else {
@@ -515,7 +582,7 @@ export class Engine {
           {
             traceId: event.traceId,
             sessionKey: sessionKeyStr,
-            length: text.length,
+            length: outboundText.length,
           },
           'outbound',
         );
@@ -523,7 +590,7 @@ export class Engine {
           {
             traceId: event.traceId,
             sessionKey: sessionKeyStr,
-            text,
+            text: outboundText,
           },
           'outbound',
         );

--- a/packages/daemon/src/idempotency.test.ts
+++ b/packages/daemon/src/idempotency.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { withPlatformName } from '@agent-nexus/protocol';
+import { InMemoryIdempotencyStore } from './idempotency.js';
+
+const sessionKey = withPlatformName(
+  {
+    platform: 'discord',
+    channelId: 'C1',
+    initiatorUserId: 'U1',
+  },
+  'discord-main',
+);
+
+describe('InMemoryIdempotencyStore', () => {
+  it('first check inserts processing and replay hits the existing status', () => {
+    const store = new InMemoryIdempotencyStore();
+
+    expect(store.checkAndSet(sessionKey, 'm-1')).toEqual({ kind: 'inserted' });
+    expect(store.checkAndSet(sessionKey, 'm-1')).toEqual({
+      kind: 'hit',
+      status: 'processing',
+    });
+
+    store.markProcessed(sessionKey, 'm-1');
+    expect(store.checkAndSet(sessionKey, 'm-1')).toEqual({
+      kind: 'hit',
+      status: 'processed',
+    });
+  });
+
+  it('keys records by the routed session key and messageId pair', () => {
+    const store = new InMemoryIdempotencyStore();
+    const otherSessionKey = withPlatformName(
+      {
+        platform: 'discord',
+        channelId: 'C2',
+        initiatorUserId: 'U1',
+      },
+      'discord-main',
+    );
+
+    expect(store.checkAndSet(sessionKey, 'm-1')).toEqual({ kind: 'inserted' });
+    expect(store.checkAndSet(otherSessionKey, 'm-1')).toEqual({
+      kind: 'inserted',
+    });
+    expect(store.checkAndSet(sessionKey, 'm-2')).toEqual({ kind: 'inserted' });
+  });
+
+  it('clearAll drops prior replay state', () => {
+    const store = new InMemoryIdempotencyStore();
+
+    expect(store.checkAndSet(sessionKey, 'm-1')).toEqual({ kind: 'inserted' });
+    store.clearAll();
+
+    expect(store.checkAndSet(sessionKey, 'm-1')).toEqual({ kind: 'inserted' });
+  });
+});

--- a/packages/daemon/src/idempotency.ts
+++ b/packages/daemon/src/idempotency.ts
@@ -1,0 +1,43 @@
+import type { SessionKey } from '@agent-nexus/protocol';
+import { serializeSessionKey } from '@agent-nexus/protocol';
+
+export type IdempotencyStatus = 'processing' | 'processed' | 'failed';
+
+export type IdempotencyDecision =
+  | { kind: 'inserted' }
+  | { kind: 'hit'; status: IdempotencyStatus };
+
+export interface IdempotencyStore {
+  checkAndSet(sessionKey: SessionKey, messageId: string): IdempotencyDecision;
+  markProcessed(sessionKey: SessionKey, messageId: string): void;
+  markFailed(sessionKey: SessionKey, messageId: string): void;
+  clearAll(): void;
+}
+
+function keyFor(sessionKey: SessionKey, messageId: string): string {
+  return `${serializeSessionKey(sessionKey)}:${messageId}`;
+}
+
+export class InMemoryIdempotencyStore implements IdempotencyStore {
+  private readonly entries = new Map<string, IdempotencyStatus>();
+
+  checkAndSet(sessionKey: SessionKey, messageId: string): IdempotencyDecision {
+    const key = keyFor(sessionKey, messageId);
+    const existing = this.entries.get(key);
+    if (existing) return { kind: 'hit', status: existing };
+    this.entries.set(key, 'processing');
+    return { kind: 'inserted' };
+  }
+
+  markProcessed(sessionKey: SessionKey, messageId: string): void {
+    this.entries.set(keyFor(sessionKey, messageId), 'processed');
+  }
+
+  markFailed(sessionKey: SessionKey, messageId: string): void {
+    this.entries.set(keyFor(sessionKey, messageId), 'failed');
+  }
+
+  clearAll(): void {
+    this.entries.clear();
+  }
+}

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -2,6 +2,13 @@ export { createLogger, type Logger, type CreateLoggerOptions } from './logger.js
 export { checkPlatformAuth, type AuthDecision } from './auth.js';
 export { Engine, type EngineAgent, type EngineDeps } from './engine.js';
 export {
+  InMemoryIdempotencyStore,
+  type IdempotencyDecision,
+  type IdempotencyStatus,
+  type IdempotencyStore,
+} from './idempotency.js';
+export { BasicRedactor, redactText, type Redactor } from './redaction.js';
+export {
   RouteError,
   selectRoute,
   type RouteContext,

--- a/packages/daemon/src/redaction.test.ts
+++ b/packages/daemon/src/redaction.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { redactText } from './redaction.js';
+
+describe('redactText', () => {
+  it('redacts env secrets, known token prefixes, and user home paths', () => {
+    const output = redactText(
+      'ANTHROPIC_API_KEY=sk-ant-abc123 token sk-ant-def456 path=/home/node/project/file.ts',
+    );
+
+    expect(output).toContain('ANTHROPIC_API_KEY=<redacted>');
+    expect(output).toContain('<redacted:secret>');
+    expect(output).toContain('path=~/project/file.ts');
+    expect(output).not.toContain('sk-ant-abc123');
+    expect(output).not.toContain('sk-ant-def456');
+    expect(output).not.toContain('/home/node/project');
+  });
+
+  it('redacts Windows user profile paths', () => {
+    expect(redactText('path=C:\\Users\\alice\\repo\\file.ts')).toBe(
+      'path=~\\repo\\file.ts',
+    );
+  });
+});

--- a/packages/daemon/src/redaction.ts
+++ b/packages/daemon/src/redaction.ts
@@ -1,0 +1,26 @@
+export interface Redactor {
+  redact(text: string): string;
+}
+
+const ENV_SECRET_RE = /\b([A-Z0-9_]*(?:KEY|TOKEN|SECRET))=([^\s]+)/g;
+const SECRET_PREFIX_RE = /\b(?:sk-ant-[A-Za-z0-9._-]+|MTk[A-Za-z0-9._-]+)\b/g;
+const HOME_PATH_RE = /(?:\/home\/[^/\s]+|\/Users\/[^/\s]+)(\/[^\s]*)?/g;
+const WINDOWS_USER_PATH_RE = /C:\\Users\\[^\\\s]+((?:\\[^\s\\]+)*)/g;
+
+export function redactText(text: string): string {
+  return text
+    .replace(ENV_SECRET_RE, '$1=<redacted>')
+    .replace(SECRET_PREFIX_RE, '<redacted:secret>')
+    .replace(HOME_PATH_RE, (_match, rest: string | undefined) => {
+      return `~${rest ?? ''}`;
+    })
+    .replace(WINDOWS_USER_PATH_RE, (_match, rest: string | undefined) => {
+      return `~${rest ?? ''}`;
+    });
+}
+
+export class BasicRedactor implements Redactor {
+  redact(text: string): string {
+    return redactText(text);
+  }
+}

--- a/tests/e2e/discord/harness.ts
+++ b/tests/e2e/discord/harness.ts
@@ -20,6 +20,7 @@ import type {
 } from '../../../packages/protocol/src/index.js';
 import { Engine } from '../../../packages/daemon/src/engine.js';
 import type { PlatformAuthConfig } from '../../../packages/daemon/src/config.js';
+import { InMemoryIdempotencyStore } from '../../../packages/daemon/src/idempotency.js';
 import { createLogger } from '../../../packages/daemon/src/logger.js';
 import { SessionStore } from '../../../packages/daemon/src/session-store.js';
 
@@ -181,6 +182,27 @@ class FakeDiscordPlatform implements PlatformAdapter {
     return this.caps;
   }
 
+  private splitText(text: string): string[] {
+    const maxTextLength = this.caps.maxTextLength;
+    if (maxTextLength <= 0 || text.length <= maxTextLength) return [text];
+    const chunks: string[] = [];
+    for (let i = 0; i < text.length; i += maxTextLength) {
+      chunks.push(text.slice(i, i + maxTextLength));
+    }
+    return chunks.length > 0 ? chunks : [''];
+  }
+
+  private nextRef(sessionKey: SessionKey): MessageRef {
+    const messageId = `fake-discord-${this.nextMessageId++}`;
+    return {
+      platform: sessionKey.platform,
+      channelId: sessionKey.channelId,
+      messageId,
+      messageIds: [messageId],
+      sentAt: new Date(),
+    };
+  }
+
   async start(handler: EventHandler): Promise<void> {
     this.handler = handler;
   }
@@ -208,34 +230,55 @@ class FakeDiscordPlatform implements PlatformAdapter {
     sessionKey: SessionKey,
     message: OutboundMessage,
   ): Promise<MessageRef> {
-    const messageId = `fake-discord-${this.nextMessageId++}`;
-    const ref: MessageRef = {
-      platform: sessionKey.platform,
-      channelId: sessionKey.channelId,
-      messageId,
-      messageIds: [messageId],
-      sentAt: new Date(),
+    const refs: MessageRef[] = [];
+    for (const chunk of this.splitText(message.text)) {
+      const ref = this.nextRef(sessionKey);
+      refs.push(ref);
+      const entry: OutboundSendEvent = {
+        kind: 'outbound_send',
+        sessionKey,
+        message: { ...message, text: chunk },
+        ref,
+      };
+      this.transcript.events.push(entry);
+      this.onOutbound(entry);
+    }
+    const first = refs[0]!;
+    const last = refs[refs.length - 1]!;
+    return {
+      platform: last.platform,
+      channelId: last.channelId,
+      messageId: last.messageId,
+      messageIds: refs.flatMap((ref) => ref.messageIds),
+      sentAt: first.sentAt,
     };
-    const entry: OutboundSendEvent = {
-      kind: 'outbound_send',
-      sessionKey,
-      message,
-      ref,
-    };
-    this.transcript.events.push(entry);
-    this.onOutbound(entry);
-    return ref;
   }
 
   async edit(ref: MessageRef, message: OutboundMessage): Promise<void> {
-    const entry: OutboundEvent = {
-      kind: 'outbound_edit',
-      sessionKey: message.sessionKey,
-      ref,
-      message,
-    };
-    this.transcript.events.push(entry);
-    this.onOutbound(entry);
+    const chunks = this.splitText(message.text);
+    const existingIds = ref.messageIds.length > 0 ? ref.messageIds : [ref.messageId];
+    const nextIds: string[] = [];
+    chunks.forEach((chunk, index) => {
+      const messageId = existingIds[index] ?? `fake-discord-${this.nextMessageId++}`;
+      nextIds.push(messageId);
+      const chunkRef: MessageRef = {
+        platform: ref.platform,
+        channelId: ref.channelId,
+        messageId,
+        messageIds: [messageId],
+        sentAt: ref.sentAt,
+      };
+      const entry: OutboundEvent = {
+        kind: index < existingIds.length ? 'outbound_edit' : 'outbound_send',
+        sessionKey: message.sessionKey,
+        ref: chunkRef,
+        message: { ...message, text: chunk },
+      };
+      this.transcript.events.push(entry);
+      this.onOutbound(entry);
+    });
+    ref.messageIds = nextIds;
+    ref.messageId = nextIds[nextIds.length - 1] ?? ref.messageId;
   }
 
   async delete(_ref: MessageRef): Promise<void> {
@@ -422,6 +465,7 @@ export function createDiscordE2EHarness(options: DiscordE2EHarnessOptions): {
     platform,
     platformName: options.platformName ?? 'discord-main',
     platformAuth: options.platformAuth,
+    idempotencyStore: new InMemoryIdempotencyStore(),
     agent,
     logger: createLogger({ level: 'fatal', pretty: false }),
     sessionStore: new SessionStore(),

--- a/tests/e2e/discord/seed.test.ts
+++ b/tests/e2e/discord/seed.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  createDiscordE2EHarness,
+  scriptedTextReply,
+  type TranscriptEvent,
+} from './harness.js';
+
+type DiscordE2EHarness = ReturnType<typeof createDiscordE2EHarness>;
+
+const harnesses: DiscordE2EHarness[] = [];
+
+function makeHarness(
+  options: Parameters<typeof createDiscordE2EHarness>[0],
+): DiscordE2EHarness {
+  const harness = createDiscordE2EHarness(options);
+  harnesses.push(harness);
+  return harness;
+}
+
+afterEach(async () => {
+  const pending = harnesses.splice(0);
+  await Promise.all(
+    pending.map(async (harness) => {
+      try {
+        await harness.stop();
+      } catch {
+        // Best-effort cleanup only; keep the original test failure primary.
+      }
+    }),
+  );
+});
+
+function allowOnlyOwner() {
+  return {
+    allowlist: {
+      userIds: ['U-e2e-owner'],
+      roleIds: [],
+      allowedGuildIds: [],
+      allowedChannelIds: [],
+      allowDM: true,
+      requireMentionOrSlash: true,
+    },
+  };
+}
+
+function outboundSends(events: TranscriptEvent[]) {
+  return events.filter((event) => event.kind === 'outbound_send');
+}
+
+describe('Discord E2E seed cases', () => {
+  it('seed_happy_path_should_route_allowed_message_to_agent_and_send_reply', async () => {
+    const harness = makeHarness({
+      agentEvents: scriptedTextReply('seed happy reply'),
+    });
+
+    await harness.start();
+    const inbound = await harness.injectMessage('seed happy input');
+    const outbound = await harness.waitForOutbound(
+      (entry) => entry.message.text === 'seed happy reply',
+    );
+
+    expect(harness.agent.inputs).toHaveLength(1);
+    expect(harness.agent.inputs[0]?.input.text).toBe('seed happy input');
+    expect(outbound.message.traceId).toBe(inbound.traceId);
+    expect(outbound.sessionKey.platformName).toBe('discord-main');
+  });
+
+  it('seed_auth_denied_should_not_call_agent_or_send_agent_outbound', async () => {
+    const harness = makeHarness({
+      platformAuth: allowOnlyOwner(),
+      agentEvents: scriptedTextReply('must not be sent'),
+    });
+
+    await harness.start();
+    await harness.injectMessage('denied input', {
+      initiatorUserId: 'U-e2e-denied',
+      traceId: 'seed-auth-denied',
+    });
+
+    await harness.waitForNoAgentCall(10);
+    expect(outboundSends(harness.transcript.events)).toHaveLength(0);
+  });
+
+  it('seed_idempotency_replay_should_process_same_session_message_only_once', async () => {
+    const harness = makeHarness({
+      agentEvents: scriptedTextReply('idempotent reply'),
+    });
+
+    await harness.start();
+    await harness.injectMessage('dedupe me', {
+      eventId: 'seed-idem-event-1',
+      messageId: 'seed-idem-message',
+      traceId: 'seed-idem-trace-1',
+    });
+    await harness.waitForOutbound(
+      (entry) => entry.message.text === 'idempotent reply',
+    );
+
+    await harness.injectMessage('dedupe me replay', {
+      eventId: 'seed-idem-event-2',
+      messageId: 'seed-idem-message',
+      traceId: 'seed-idem-trace-2',
+    });
+
+    await harness.waitForNoAgentCall(10, 1);
+    expect(harness.agent.inputs).toHaveLength(1);
+    expect(outboundSends(harness.transcript.events)).toHaveLength(1);
+  });
+
+  it('seed_long_output_slicing_should_split_by_fake_platform_max_text_length', async () => {
+    const text = 'abcdefghijkl';
+    const harness = makeHarness({
+      platformCaps: { maxTextLength: 5 },
+      agentEvents: scriptedTextReply(text),
+    });
+
+    await harness.start();
+    await harness.injectMessage('long output please');
+    await harness.waitForTurnFinished('e2e-trace-1');
+
+    const sends = outboundSends(harness.transcript.events);
+    expect(sends.map((send) => send.message.text)).toEqual([
+      'abcde',
+      'fghij',
+      'kl',
+    ]);
+    expect(sends.map((send) => send.message.text).join('')).toBe(text);
+    expect(sends.every((send) => send.message.text.length <= 5)).toBe(true);
+  });
+
+  it('seed_redaction_should_filter_secrets_and_absolute_paths_before_outbound', async () => {
+    const harness = makeHarness({
+      agentEvents: scriptedTextReply(
+        'ANTHROPIC_API_KEY=sk-ant-abc123 path=/home/node/secret/file.txt',
+      ),
+    });
+
+    await harness.start();
+    await harness.injectMessage('redact output please');
+    const outbound = await harness.waitForOutbound(
+      (entry) => entry.kind === 'outbound_send',
+    );
+
+    expect(outbound.message.text).not.toContain('sk-ant-abc123');
+    expect(outbound.message.text).not.toContain('/home/node/secret');
+    expect(outbound.message.text).toContain('ANTHROPIC_API_KEY=<redacted>');
+    expect(outbound.message.text).toContain('~/secret/file.txt');
+  });
+});

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -4,5 +4,8 @@ export default defineConfig({
   test: {
     include: ['tests/e2e/**/*.test.ts'],
     environment: 'node',
+    fileParallelism: false,
+    maxWorkers: 1,
+    minWorkers: 1,
   },
 });


### PR DESCRIPTION
## Summary

Adds the P5 Discord E2E seed prerequisite coverage and the daemon seams needed by those cases.

本 PR：
- Adds scripted-agent Discord E2E seed cases for happy path, auth denied, idempotency replay, long output slicing, and redaction.
- Adds an injectable in-memory daemon `IdempotencyStore` and wires the CLI to use one shared store across platform engines.
- Adds daemon outbound redaction for IM sends/edits and unit coverage for the basic redactor.
- Makes the fake Discord harness model `maxTextLength` at the platform boundary and runs Discord E2E with one Vitest worker.
- Updates the Discord E2E testing doc with the current seed prerequisite status and remaining limits.

## Why

P5 needs the seed matrix to pass before the runner can be polished for failure artifacts and real-agent execution. The previous harness could route and synchronize scripted turns, but it did not prove replay dedupe, outbound redaction, or long-output multi-message capture.

This PR keeps the scope honest: the new seed cases are still harness qualification with fake Discord and a scripted agent. They do not claim SQLite idempotency, full redaction coverage for logs/transcripts, or final real-agent Discord E2E completion.

ADR: N/A - no new architecture decision.
Spec: `docs/dev/testing/discord-e2e.md`; existing contracts referenced by the implementation are `docs/dev/spec/infra/idempotency.md`, `docs/dev/spec/security/redaction.md`, and `docs/dev/spec/platform-adapter.md`.

## Test plan

- [x] `corepack pnpm exec vitest run packages/daemon/src/idempotency.test.ts packages/daemon/src/redaction.test.ts packages/daemon/src/engine.test.ts --maxWorkers=1 --minWorkers=1 --no-file-parallelism` - passed.
- [x] `corepack pnpm test:e2e:discord` - passed.
- [x] `corepack pnpm typecheck` - passed.
- [x] `corepack pnpm exec vitest run --maxWorkers=2 --minWorkers=1` - passed.
- [x] `scripts/docs-read --head docs/dev/testing/discord-e2e.md` - passed.
- [x] `git diff --check` - passed.
- [x] Confirmed no lingering `vitest` / `tsc` / `pnpm` / `corepack` processes after E2E runs.

## Review notes

- Independent agent review: Claude review saved at `/home/node/.goal/discord-e2e-agent-friendly-tests/reviews/p5-seed-prereqs-claude-review.md`; it found one blocker in daemon-side slicing, which was fixed.
- Deep review: Claude focused re-review saved at `/home/node/.goal/discord-e2e-agent-friendly-tests/reviews/p5-seed-prereqs-b1-rereview.md`; it confirmed `B1 resolved` and found no remaining blocker or must-fix important issue.

## Out of scope

- Real-agent Discord E2E execution and persisted failure artifact polish.
- SQLite-backed idempotency, TTL/GC, and failed retry windows.
- Full redaction coverage for logger sinks, agent subprocess transcripts, and every configured redaction pattern.
- Real Discord gateway/REST smoke; that remains opt-in and not a PR-required path.