### PR TITLE
feat(daemon): track resumable session state

### DIFF
--- a/docs/dev/architecture/session-model.md
+++ b/docs/dev/architecture/session-model.md
@@ -139,6 +139,16 @@ SessionKey 维度上的查询索引与唯一约束见 [`persistence.md`](../spec
 
 Agent-owned `/new`、`/stop`、`/steer` 等 command 不直接改写本状态机；daemon 只把它们按 command registry 路由给 agent package。若 agent command 结果要求更新 opaque agent conversation ref，daemon 只保存该 opaque ref，不解释 agent conversation 语义。Daemon-owned `/nexus-kill` 是 RoutingSession 级控制：清除当前 route 与 opaque ref，并释放当前 runtime handle。
 
+### 可恢复 AgentConversation 绑定
+
+RoutingSession 持有的 opaque agent conversation ref 与 live `AgentSession` handle 分离：
+前者是跨 turn / 跨进程恢复用的绑定，字段契约与更新语义见 [`persistence.md` §sessions](../spec/infra/persistence.md#sessions)；
+后者只是当前进程里的 runtime 句柄，接口契约见 [`agent-runtime.md`](../spec/agent-runtime.md#agentsession-与-session-的区分)。
+
+当同一 SessionKey 没有可复用的 live handle 但仍有 opaque ref 时，daemon 启动新的 `AgentSession`，并把该 ref 放进 `SessionConfig.resumeFromAgentSessionId`。
+
+用户把已有 resumable session 绑定到新的 SessionKey 时，daemon 迁移 opaque ref 和下一次 spawn 所需的一次性 override；平台 thread 拓扑仍归原 channel，不随 rebind 复制。
+
 ## 幂等
 
 ### 为什么需要

--- a/docs/dev/spec/infra/persistence.md
+++ b/docs/dev/spec/infra/persistence.md
@@ -55,7 +55,9 @@ contracts:
 | `last_activity_at` | TEXT NOT NULL | RFC3339 |
 | `archived_at` | TEXT | |
 | `agent_backend` | TEXT NOT NULL | `"claudecode"` \| `"codex"` |
+| `agent_conversation_ref` | TEXT | opaque agent conversation ref；回传给 `SessionConfig.resumeFromAgentSessionId` |
 | `working_dir` | TEXT NOT NULL | |
+| `next_session_json` | TEXT | 一次性 next-session override；消费后置 NULL |
 | `transcript_path` | TEXT NOT NULL | 相对 `~/.agent-nexus/`，按 session_id 归属 |
 | `turns_used` | INTEGER NOT NULL DEFAULT 0 | 一等计量 |
 | `tool_calls_used` | INTEGER NOT NULL DEFAULT 0 | 一等计量 |
@@ -72,6 +74,13 @@ contracts:
 - `UNIQUE (session_key, generation)` — 同 key 的 generation 唯一
 
 **不变量**：任一时刻同 `session_key` 下非终态实例（`state ∉ {Archived}`）至多一个。核心插入前校验。
+
+字段更新语义：
+
+- `agent_conversation_ref` 对 daemon 是 opaque token，来源与 runtime 契约见 [`agent-runtime.md` §Agent command envelope](../agent-runtime.md#agent-command-envelope) / [`agent-runtime.md` §事件 payload 字段](../agent-runtime.md#事件-payload-字段)。
+  普通 metadata upsert 不携带该字段表示保留旧值；只有 runtime 给出新 ref 时覆盖，显式清除时置 NULL。
+- `next_session_json` 表示下一次 spawn 前的一次性 override，例如 pending `workingDir`。
+  普通 metadata upsert 不携带该字段表示保留旧值；消费后置 NULL；将现有 resumable session 绑定到新 SessionKey 时，它随 `agent_conversation_ref` 一起迁移。
 
 ### idempotency
 

--- a/packages/daemon/src/session-store.test.ts
+++ b/packages/daemon/src/session-store.test.ts
@@ -63,18 +63,30 @@ describe('SessionStore', () => {
 
   it('clearAll empties the store', () => {
     const store = new SessionStore();
-    store.set(makeKey({ channelId: 'A' }), {
+    const keyA = makeKey({ channelId: 'A' });
+    const keyB = makeKey({ channelId: 'B' });
+    store.set(keyA, {
       agentSessionId: 'sid-a',
       lastTurnAt: new Date(),
     });
-    store.set(makeKey({ channelId: 'B' }), {
+    store.set(keyB, {
       agentSessionId: 'sid-b',
       lastTurnAt: new Date(),
     });
+    store.registerThread(keyA, {
+      parentChannelId: 'C-parent',
+      ownerUserId: 'U1',
+      autoArchiveDurationMinutes: 1440,
+    });
+    store.setChannelWorkingDir(keyB, '/workspace/channel');
+
     expect(store.size).toBe(2);
     store.clearAll();
+
     expect(store.size).toBe(0);
-    expect(store.get(makeKey({ channelId: 'A' }))).toBeUndefined();
+    expect(store.get(keyA)).toBeUndefined();
+    expect(store.findThreadByChannelId(keyA)).toBeUndefined();
+    expect(store.getChannelWorkingDir(keyB)).toBeUndefined();
   });
 
   it('lists resumable sessions for the same platform user', () => {
@@ -106,10 +118,13 @@ describe('SessionStore', () => {
       'sid-1',
     ]);
     expect(sessions[0]).toMatchObject({
-      channelId: 'C2',
       title: 'Second question',
       key: makeKey({ channelId: 'C2' }),
     });
+    expect(sessions[0]).not.toHaveProperty('channelId');
+    expect(sessions[0]).not.toHaveProperty('platformName');
+    expect(sessions[0]).not.toHaveProperty('platform');
+    expect(sessions[0]).not.toHaveProperty('initiatorUserId');
   });
 
   it('does not list thread placeholders before an agent session exists', () => {
@@ -150,6 +165,25 @@ describe('SessionStore', () => {
 
     expect(store.get(key)).toMatchObject({
       agentSessionId: 'sid-2',
+      title: 'Original prompt',
+    });
+  });
+
+  it('preserves the agent session id when an existing session is refreshed without one', () => {
+    const store = new SessionStore();
+    const key = makeKey();
+    store.set(key, {
+      agentSessionId: 'sid-1',
+      lastTurnAt: new Date(1),
+      title: 'Original prompt',
+    });
+    store.set(key, {
+      lastTurnAt: new Date(2),
+    });
+
+    expect(store.get(key)).toMatchObject({
+      agentSessionId: 'sid-1',
+      lastTurnAt: new Date(2),
       title: 'Original prompt',
     });
   });
@@ -253,6 +287,28 @@ describe('SessionStore', () => {
     });
   });
 
+  it('does not expose mutable nextSession state from listed sessions', () => {
+    const store = new SessionStore();
+    const key = makeKey();
+    store.setNextWorkingDir(key, '/workspace/next', new Date(1));
+    store.set(key, {
+      agentSessionId: 'sid-1',
+      lastTurnAt: new Date(2),
+    });
+
+    const [session] = store.listForUser({
+      platformName: 'discord-main',
+      platform: 'discord',
+      initiatorUserId: 'U1',
+      limit: 10,
+    });
+    session!.nextSession!.workingDir = '/workspace/mutated';
+
+    expect(store.get(key)?.nextSession).toEqual({
+      workingDir: '/workspace/next',
+    });
+  });
+
   it('stores channel workingDir defaults separately from session entries', () => {
     const store = new SessionStore();
     const channel = {
@@ -297,6 +353,75 @@ describe('SessionStore', () => {
       lastTurnAt: new Date(2),
       title: 'Old prompt',
     });
+    expect(store.get(sourceKey)).toBeUndefined();
+  });
+
+  it('moves pending next workingDir when rebinding a resumable session', () => {
+    const store = new SessionStore();
+    const sourceKey = makeKey({ channelId: 'C-old' });
+    const targetKey = makeKey({ channelId: 'C-new' });
+    store.setNextWorkingDir(sourceKey, '/workspace/next', new Date(1));
+    store.set(sourceKey, {
+      agentSessionId: 'sid-old',
+      lastTurnAt: new Date(2),
+      title: 'Old prompt',
+    });
+    const [source] = store.listForUser({
+      platformName: 'discord-main',
+      platform: 'discord',
+      initiatorUserId: 'U1',
+      limit: 10,
+    });
+
+    const rebound = store.bindExistingToKey(
+      targetKey,
+      source!.sessionId,
+      new Date(3),
+    );
+
+    expect(rebound).toMatchObject({
+      agentSessionId: 'sid-old',
+      nextSession: { workingDir: '/workspace/next' },
+    });
+    expect(store.get(targetKey)).toMatchObject({
+      agentSessionId: 'sid-old',
+      nextSession: { workingDir: '/workspace/next' },
+    });
+    expect(store.get(sourceKey)).toBeUndefined();
+  });
+
+  it('replaces stale target session metadata when rebinding', () => {
+    const store = new SessionStore();
+    const sourceKey = makeKey({ channelId: 'C-old' });
+    const targetKey = makeKey({ channelId: 'C-new' });
+    store.set(sourceKey, {
+      agentSessionId: 'sid-old',
+      lastTurnAt: new Date(2),
+      title: 'Old prompt',
+    });
+    store.setNextWorkingDir(targetKey, '/workspace/stale-target', new Date(1));
+    store.set(targetKey, {
+      agentSessionId: 'sid-target',
+      lastTurnAt: new Date(1),
+      title: 'Target prompt',
+    });
+    const source = store
+      .listForUser({
+        platformName: 'discord-main',
+        platform: 'discord',
+        initiatorUserId: 'U1',
+        limit: 10,
+      })
+      .find((session) => session.key.channelId === 'C-old');
+
+    store.bindExistingToKey(targetKey, source!.sessionId, new Date(3));
+
+    expect(store.get(targetKey)).toMatchObject({
+      agentSessionId: 'sid-old',
+      title: 'Old prompt',
+    });
+    expect(store.get(targetKey)?.nextSession).toBeUndefined();
+    expect(store.get(sourceKey)).toBeUndefined();
   });
 
   it('does not copy thread topology metadata when rebinding a resumable session', () => {
@@ -333,5 +458,9 @@ describe('SessionStore', () => {
         channelId: 'C-new',
       }),
     ).toBeUndefined();
+    expect(store.findThreadByChannelId(sourceKey)).toMatchObject({
+      parentChannelId: 'C-parent',
+      ownerUserId: 'U1',
+    });
   });
 });

--- a/packages/daemon/src/session-store.test.ts
+++ b/packages/daemon/src/session-store.test.ts
@@ -76,4 +76,262 @@ describe('SessionStore', () => {
     expect(store.size).toBe(0);
     expect(store.get(makeKey({ channelId: 'A' }))).toBeUndefined();
   });
+
+  it('lists resumable sessions for the same platform user', () => {
+    const store = new SessionStore();
+    store.set(makeKey({ channelId: 'C1' }), {
+      agentSessionId: 'sid-1',
+      lastTurnAt: new Date(1),
+      title: 'First question',
+    });
+    store.set(makeKey({ channelId: 'C2' }), {
+      agentSessionId: 'sid-2',
+      lastTurnAt: new Date(2),
+      title: 'Second question',
+    });
+    store.set(makeKey({ initiatorUserId: 'U2' }), {
+      agentSessionId: 'sid-other-user',
+      lastTurnAt: new Date(3),
+    });
+
+    const sessions = store.listForUser({
+      platformName: 'discord-main',
+      platform: 'discord',
+      initiatorUserId: 'U1',
+      limit: 10,
+    });
+
+    expect(sessions.map((session) => session.agentSessionId)).toEqual([
+      'sid-2',
+      'sid-1',
+    ]);
+    expect(sessions[0]).toMatchObject({
+      channelId: 'C2',
+      title: 'Second question',
+      key: makeKey({ channelId: 'C2' }),
+    });
+  });
+
+  it('does not list thread placeholders before an agent session exists', () => {
+    const store = new SessionStore();
+    const key = makeKey({ channelId: 'T1' });
+    store.set(key, {
+      lastTurnAt: new Date(1),
+      title: 'Thread shell',
+    });
+    store.registerThread(key, {
+      parentChannelId: 'C1',
+      ownerUserId: 'U1',
+      autoArchiveDurationMinutes: 1440,
+    });
+
+    expect(
+      store.listForUser({
+        platformName: 'discord-main',
+        platform: 'discord',
+        initiatorUserId: 'U1',
+        limit: 10,
+      }),
+    ).toEqual([]);
+  });
+
+  it('preserves the first title when an existing session is refreshed', () => {
+    const store = new SessionStore();
+    const key = makeKey();
+    store.set(key, {
+      agentSessionId: 'sid-1',
+      lastTurnAt: new Date(1),
+      title: 'Original prompt',
+    });
+    store.set(key, {
+      agentSessionId: 'sid-2',
+      lastTurnAt: new Date(2),
+    });
+
+    expect(store.get(key)).toMatchObject({
+      agentSessionId: 'sid-2',
+      title: 'Original prompt',
+    });
+  });
+
+  it('preserves registered thread metadata when the first agent session starts', () => {
+    const store = new SessionStore();
+    const key = makeKey({ channelId: 'T1' });
+    store.set(key, {
+      lastTurnAt: new Date(1),
+      title: 'Thread shell',
+    });
+    store.registerThread(key, {
+      parentChannelId: 'C1',
+      ownerUserId: 'U1',
+      autoArchiveDurationMinutes: 1440,
+    });
+    store.set(key, {
+      agentSessionId: 'sid-thread',
+      lastTurnAt: new Date(2),
+      title: 'First prompt',
+    });
+
+    expect(store.get(key)).toMatchObject({
+      agentSessionId: 'sid-thread',
+      title: 'First prompt',
+    });
+    expect(store.findThreadByChannelId(key)).toMatchObject({
+      parentChannelId: 'C1',
+      ownerUserId: 'U1',
+      autoArchiveDurationMinutes: 1440,
+    });
+  });
+
+  it('finds daemon-created thread metadata by thread channel id', () => {
+    const store = new SessionStore();
+    store.registerThread(makeKey({ channelId: 'T1' }), {
+      parentChannelId: 'C1',
+      ownerUserId: 'U1',
+      autoArchiveDurationMinutes: 1440,
+    });
+
+    expect(
+      store.findThreadByChannelId({
+        platformName: 'discord-main',
+        platform: 'discord',
+        channelId: 'T1',
+      }),
+    ).toMatchObject({ parentChannelId: 'C1', ownerUserId: 'U1' });
+  });
+
+  it('keeps registered thread metadata after deleting the routing session entry', () => {
+    const store = new SessionStore();
+    const key = makeKey({ channelId: 'T1' });
+    store.set(key, {
+      lastTurnAt: new Date(1),
+    });
+    store.registerThread(key, {
+      parentChannelId: 'C1',
+      ownerUserId: 'U1',
+      autoArchiveDurationMinutes: 1440,
+    });
+
+    store.delete(key);
+
+    expect(store.get(key)).toBeUndefined();
+    expect(
+      store.findThreadByChannelId({
+        platformName: 'discord-main',
+        platform: 'discord',
+        channelId: 'T1',
+      }),
+    ).toMatchObject({ parentChannelId: 'C1', ownerUserId: 'U1' });
+  });
+
+  it('stores and consumes a one-shot next workingDir override per session key', () => {
+    const store = new SessionStore();
+    const parentKey = makeKey({ channelId: 'C1' });
+    const threadKey = makeKey({ channelId: 'T1' });
+
+    store.setNextWorkingDir(parentKey, '/workspace/parent', new Date(1));
+    store.setNextWorkingDir(threadKey, '/workspace/thread', new Date(2));
+
+    expect(store.consumeNextWorkingDir(threadKey)).toBe('/workspace/thread');
+    expect(store.consumeNextWorkingDir(threadKey)).toBeUndefined();
+    expect(store.consumeNextWorkingDir(parentKey)).toBe('/workspace/parent');
+  });
+
+  it('preserves pending next workingDir when the session entry is refreshed', () => {
+    const store = new SessionStore();
+    const key = makeKey();
+    store.setNextWorkingDir(key, '/workspace/next', new Date(1));
+    store.set(key, {
+      agentSessionId: 'sid-1',
+      lastTurnAt: new Date(2),
+      title: 'Prompt',
+    });
+
+    expect(store.get(key)).toMatchObject({
+      agentSessionId: 'sid-1',
+      nextSession: { workingDir: '/workspace/next' },
+    });
+  });
+
+  it('stores channel workingDir defaults separately from session entries', () => {
+    const store = new SessionStore();
+    const channel = {
+      platformName: 'discord-main',
+      platform: 'discord',
+      channelId: 'C1',
+    };
+    store.setChannelWorkingDir(channel, '/tmp/channel');
+    store.set(makeKey({ channelId: 'C1' }), {
+      agentSessionId: 'sid-1',
+      lastTurnAt: new Date(1),
+    });
+
+    expect(store.getChannelWorkingDir(channel)).toBe('/tmp/channel');
+    store.delete(makeKey({ channelId: 'C1' }));
+    expect(store.getChannelWorkingDir(channel)).toBe('/tmp/channel');
+  });
+
+  it('can bind an existing resumable session to a new session key', () => {
+    const store = new SessionStore();
+    const sourceKey = makeKey({ channelId: 'C-old' });
+    const targetKey = makeKey({ channelId: 'C-new' });
+    store.set(sourceKey, {
+      agentSessionId: 'sid-old',
+      lastTurnAt: new Date(1),
+      title: 'Old prompt',
+    });
+
+    const [source] = store.listForUser({
+      platformName: 'discord-main',
+      platform: 'discord',
+      initiatorUserId: 'U1',
+      limit: 10,
+    });
+    expect(source).toBeDefined();
+
+    const rebound = store.bindExistingToKey(targetKey, source!.sessionId, new Date(2));
+
+    expect(rebound?.agentSessionId).toBe('sid-old');
+    expect(store.get(targetKey)).toMatchObject({
+      agentSessionId: 'sid-old',
+      lastTurnAt: new Date(2),
+      title: 'Old prompt',
+    });
+  });
+
+  it('does not copy thread topology metadata when rebinding a resumable session', () => {
+    const store = new SessionStore();
+    const sourceKey = makeKey({ channelId: 'T-old' });
+    const targetKey = makeKey({ channelId: 'C-new' });
+    store.set(sourceKey, {
+      agentSessionId: 'sid-thread',
+      lastTurnAt: new Date(1),
+      title: 'Thread prompt',
+    });
+    store.registerThread(sourceKey, {
+      parentChannelId: 'C-parent',
+      ownerUserId: 'U1',
+      autoArchiveDurationMinutes: 1440,
+    });
+    const [source] = store.listForUser({
+      platformName: 'discord-main',
+      platform: 'discord',
+      initiatorUserId: 'U1',
+      limit: 10,
+    });
+
+    store.bindExistingToKey(targetKey, source!.sessionId, new Date(2));
+
+    expect(store.get(targetKey)).toMatchObject({
+      agentSessionId: 'sid-thread',
+      title: 'Thread prompt',
+    });
+    expect(
+      store.findThreadByChannelId({
+        platformName: 'discord-main',
+        platform: 'discord',
+        channelId: 'C-new',
+      }),
+    ).toBeUndefined();
+  });
 });

--- a/packages/daemon/src/session-store.ts
+++ b/packages/daemon/src/session-store.ts
@@ -8,30 +8,187 @@ import { serializeSessionKey } from '@agent-nexus/protocol';
  * 处理留给后续 PR——TODO docs/dev/architecture/session-model.md。
  */
 export interface SessionEntry {
-  agentSessionId: string;
+  agentSessionId?: string;
   lastTurnAt: Date;
+  title?: string;
+  nextSession?: {
+    workingDir?: string;
+  };
+}
+
+export interface ThreadRegistryEntry {
+  parentChannelId: string;
+  ownerUserId: string;
+  autoArchiveDurationMinutes: 60 | 1440 | 4320 | 10080;
+  renameOnFirstPrompt?: boolean;
+}
+
+export interface ListedSessionEntry extends Omit<SessionEntry, 'agentSessionId'> {
+  sessionId: string;
+  key: SessionKey;
+  platformName?: string;
+  platform: string;
+  channelId: string;
+  initiatorUserId: string;
+  agentSessionId: string;
+}
+
+export interface ListSessionsInput {
+  platformName?: string;
+  platform: string;
+  initiatorUserId: string;
+  limit: number;
+}
+
+export interface FindThreadInput {
+  platformName?: string;
+  platform: string;
+  channelId: string;
 }
 
 export class SessionStore {
   private readonly map = new Map<string, SessionEntry>();
+  private readonly sessionIdsByKey = new Map<string, string>();
+  private readonly keysBySessionId = new Map<string, SessionKey>();
+  private readonly threadsByChannel = new Map<string, ThreadRegistryEntry>();
+  private readonly workingDirsByChannel = new Map<string, string>();
+  private nextSessionSeq = 1;
 
   get(key: SessionKey): SessionEntry | undefined {
     return this.map.get(serializeSessionKey(key));
   }
 
   set(key: SessionKey, entry: SessionEntry): void {
-    this.map.set(serializeSessionKey(key), entry);
+    const keyStr = serializeSessionKey(key);
+    if (!this.sessionIdsByKey.has(keyStr)) {
+      const sessionId = `mem-${this.nextSessionSeq}`;
+      this.nextSessionSeq += 1;
+      this.sessionIdsByKey.set(keyStr, sessionId);
+      this.keysBySessionId.set(sessionId, { ...key });
+    }
+    const existing = this.map.get(keyStr);
+    this.map.set(keyStr, {
+      ...entry,
+      title: entry.title ?? existing?.title,
+      nextSession: entry.nextSession ?? existing?.nextSession,
+    });
   }
 
   delete(key: SessionKey): boolean {
-    return this.map.delete(serializeSessionKey(key));
+    const keyStr = serializeSessionKey(key);
+    const sessionId = this.sessionIdsByKey.get(keyStr);
+    if (sessionId) {
+      this.sessionIdsByKey.delete(keyStr);
+      this.keysBySessionId.delete(sessionId);
+    }
+    return this.map.delete(keyStr);
   }
 
   clearAll(): void {
     this.map.clear();
+    this.sessionIdsByKey.clear();
+    this.keysBySessionId.clear();
+    this.threadsByChannel.clear();
+    this.workingDirsByChannel.clear();
   }
 
   get size(): number {
     return this.map.size;
   }
+
+  listForUser(input: ListSessionsInput): ListedSessionEntry[] {
+    const entries: ListedSessionEntry[] = [];
+    for (const [keyStr, entry] of this.map.entries()) {
+      if (!entry.agentSessionId) continue;
+      const sessionId = this.sessionIdsByKey.get(keyStr);
+      const key = sessionId ? this.keysBySessionId.get(sessionId) : undefined;
+      if (!sessionId || !key) continue;
+      if (key.platformName !== input.platformName) continue;
+      if (key.platform !== input.platform) continue;
+      if (key.initiatorUserId !== input.initiatorUserId) continue;
+      entries.push({
+        sessionId,
+        key: { ...key },
+        platformName: key.platformName,
+        platform: key.platform,
+        channelId: key.channelId,
+        initiatorUserId: key.initiatorUserId,
+        agentSessionId: entry.agentSessionId,
+        lastTurnAt: entry.lastTurnAt,
+        title: entry.title,
+        nextSession: entry.nextSession,
+      });
+    }
+    return entries
+      .sort((a, b) => b.lastTurnAt.getTime() - a.lastTurnAt.getTime())
+      .slice(0, input.limit);
+  }
+
+  bindExistingToKey(
+    targetKey: SessionKey,
+    sessionId: string,
+    now: Date,
+  ): SessionEntry | undefined {
+    const sourceKey = this.keysBySessionId.get(sessionId);
+    if (!sourceKey) return undefined;
+    const source = this.map.get(serializeSessionKey(sourceKey));
+    if (!source?.agentSessionId) return undefined;
+    const rebound = {
+      agentSessionId: source.agentSessionId,
+      lastTurnAt: now,
+      title: source.title,
+    };
+    this.set(targetKey, rebound);
+    return rebound;
+  }
+
+  findThreadByChannelId(input: FindThreadInput): ThreadRegistryEntry | undefined {
+    const thread = this.threadsByChannel.get(threadRegistryKey(input));
+    return thread ? { ...thread } : undefined;
+  }
+
+  setNextWorkingDir(key: SessionKey, workingDir: string, now: Date): void {
+    const existing = this.get(key);
+    this.set(key, {
+      ...(existing ?? {}),
+      lastTurnAt: existing?.lastTurnAt ?? now,
+      nextSession: { workingDir },
+    });
+  }
+
+  consumeNextWorkingDir(key: SessionKey): string | undefined {
+    const keyStr = serializeSessionKey(key);
+    const existing = this.map.get(keyStr);
+    const workingDir = existing?.nextSession?.workingDir;
+    if (!existing?.nextSession) return undefined;
+    const { nextSession: _nextSession, ...rest } = existing;
+    this.map.set(keyStr, rest);
+    return workingDir;
+  }
+
+  registerThread(key: SessionKey, thread: ThreadRegistryEntry): void {
+    this.threadsByChannel.set(
+      threadRegistryKey({
+        platformName: key.platformName,
+        platform: key.platform,
+        channelId: key.channelId,
+      }),
+      { ...thread },
+    );
+  }
+
+  setChannelWorkingDir(
+    input: FindThreadInput,
+    workingDir: string,
+  ): void {
+    this.workingDirsByChannel.set(threadRegistryKey(input), workingDir);
+  }
+
+  getChannelWorkingDir(input: FindThreadInput): string | undefined {
+    return this.workingDirsByChannel.get(threadRegistryKey(input));
+  }
+}
+
+function threadRegistryKey(input: FindThreadInput): string {
+  return `${input.platformName ?? ''}:${input.platform}:${input.channelId}`;
 }

--- a/packages/daemon/src/session-store.ts
+++ b/packages/daemon/src/session-store.ts
@@ -4,6 +4,9 @@ import { serializeSessionKey } from '@agent-nexus/protocol';
 /**
  * 跨 turn 维护 SessionKey → agentSessionId 的最小内存映射。
  *
+ * 列表、绑定、next workingDir 相关方法是 daemon-owned session/thread
+ * command 接线的 store 层契约；业务路由保持在 Engine / command handler。
+ *
  * MVP 仅在进程内存活；进程重启即清空。持久化、状态机、TTL、并发竞态
  * 处理留给后续 PR——TODO docs/dev/architecture/session-model.md。
  */
@@ -26,22 +29,18 @@ export interface ThreadRegistryEntry {
 export interface ListedSessionEntry extends Omit<SessionEntry, 'agentSessionId'> {
   sessionId: string;
   key: SessionKey;
-  platformName?: string;
-  platform: string;
-  channelId: string;
-  initiatorUserId: string;
   agentSessionId: string;
 }
 
 export interface ListSessionsInput {
-  platformName?: string;
+  platformName: string;
   platform: string;
   initiatorUserId: string;
   limit: number;
 }
 
 export interface FindThreadInput {
-  platformName?: string;
+  platformName: string;
   platform: string;
   channelId: string;
 }
@@ -67,11 +66,24 @@ export class SessionStore {
       this.keysBySessionId.set(sessionId, { ...key });
     }
     const existing = this.map.get(keyStr);
-    this.map.set(keyStr, {
-      ...entry,
-      title: entry.title ?? existing?.title,
-      nextSession: entry.nextSession ?? existing?.nextSession,
-    });
+    const nextEntry: SessionEntry = { ...entry };
+    // set() 只保留/更新 resumable 绑定；显式清除必须走 delete()。
+    if (
+      nextEntry.agentSessionId === undefined &&
+      existing?.agentSessionId !== undefined
+    ) {
+      nextEntry.agentSessionId = existing.agentSessionId;
+    }
+    if (nextEntry.title === undefined && existing?.title !== undefined) {
+      nextEntry.title = existing.title;
+    }
+    if (
+      nextEntry.nextSession === undefined &&
+      existing?.nextSession !== undefined
+    ) {
+      nextEntry.nextSession = existing.nextSession;
+    }
+    this.map.set(keyStr, nextEntry);
   }
 
   delete(key: SessionKey): boolean {
@@ -109,14 +121,10 @@ export class SessionStore {
       entries.push({
         sessionId,
         key: { ...key },
-        platformName: key.platformName,
-        platform: key.platform,
-        channelId: key.channelId,
-        initiatorUserId: key.initiatorUserId,
         agentSessionId: entry.agentSessionId,
         lastTurnAt: entry.lastTurnAt,
         title: entry.title,
-        nextSession: entry.nextSession,
+        nextSession: entry.nextSession ? { ...entry.nextSession } : undefined,
       });
     }
     return entries
@@ -131,15 +139,25 @@ export class SessionStore {
   ): SessionEntry | undefined {
     const sourceKey = this.keysBySessionId.get(sessionId);
     if (!sourceKey) return undefined;
-    const source = this.map.get(serializeSessionKey(sourceKey));
+    const sourceKeyStr = serializeSessionKey(sourceKey);
+    const targetKeyStr = serializeSessionKey(targetKey);
+    const source = this.map.get(sourceKeyStr);
     if (!source?.agentSessionId) return undefined;
     const rebound = {
       agentSessionId: source.agentSessionId,
       lastTurnAt: now,
       title: source.title,
+      nextSession: source.nextSession,
     };
+    if (sourceKeyStr !== targetKeyStr) {
+      this.delete(targetKey);
+    }
     this.set(targetKey, rebound);
-    return rebound;
+    const stored = this.get(targetKey);
+    if (sourceKeyStr !== targetKeyStr) {
+      this.delete(sourceKey);
+    }
+    return stored ? cloneEntry(stored) : undefined;
   }
 
   findThreadByChannelId(input: FindThreadInput): ThreadRegistryEntry | undefined {
@@ -190,5 +208,11 @@ export class SessionStore {
 }
 
 function threadRegistryKey(input: FindThreadInput): string {
-  return `${input.platformName ?? ''}:${input.platform}:${input.channelId}`;
+  return `${input.platformName}:${input.platform}:${input.channelId}`;
+}
+
+function cloneEntry(entry: SessionEntry): SessionEntry {
+  const cloned = { ...entry };
+  if (entry.nextSession) cloned.nextSession = { ...entry.nextSession };
+  return cloned;
 }


### PR DESCRIPTION
## Summary

从原 #151 中拆出 daemon SessionStore 的可恢复会话状态扩展，用于后续 session switcher、thread 会话与 workingDir override。

本 PR：
- 扩展 `SessionStore` 记录 session title、thread 拓扑与 next-session workingDir override。
- 增加按用户列出、绑定已有 session、thread registry、channel workingDir default 等操作。
- 补充 `session-store.test.ts` 覆盖新增状态读写与边界。

## Why

后续 `/nexus-sessions`、`/nexus-new-thread` 和 `/nexus-working-dir` 需要 daemon-owned session metadata；这些状态先落在 SessionStore，避免直接散落在 Engine handler 中。

ADR: N/A - daemon 内部状态结构扩展，不改变部署或模块依赖方向。
Spec: `docs/dev/architecture/session-model.md` 的同步在本 stack 顶部 docs PR 中承载；本 PR 先拆出 daemon 状态实现边界。

## Test plan

- [x] Tests: `packages/daemon/src/session-store.test.ts` 在 final stacked head `64dc01c` 上通过。
- [x] `CI=true COREPACK_HOME=/cache/corepack corepack pnpm vitest run packages/daemon/src/session-store.test.ts packages/daemon/src/message-queue.test.ts packages/daemon/src/engine.test.ts packages/platform/discord/src/index.test.ts packages/cli/src/config.test.ts packages/cli/src/command-registry.test.ts` — 6 files, 217 tests passed.
- [x] `CI=true COREPACK_HOME=/cache/corepack corepack pnpm typecheck` — passed.
- [ ] Manual: session switcher real Discord path not run; later stack layer exposes it.

## Review notes

- Independent agent review: Pending - split PR created from existing #151 branch; must be reviewed before merge.
- Deep review: N/A - daemon-local state expansion, no new persistence backend.

## Out of scope

- Durable session persistence across process restart.
- Discord UI for selecting sessions.
- Queueing or settings commands.