### PR TITLE
feat(daemon): add per-session message queue

### DIFF
--- a/docs/dev/spec/infra/idempotency.md
+++ b/docs/dev/spec/infra/idempotency.md
@@ -48,6 +48,7 @@ adapter 归一化 NormalizedEvent
            ├─ daemon.idempotency.checkAndSet(sessionKey, messageId)
            │     ├─ 命中 "processed" → 丢弃事件（已经处理过）
            │     ├─ 命中 "processing" → 跳过（上一次还在进行中）
+           │     ├─ 命中 "cancelled" → 丢弃事件（上一次已在入队后、运行前取消）
            │     ├─ 命中 "failed" 且在可重试窗口内 → 重试（标回 "processing"）
            │     └─ 未命中 → 插入 "processing"，继续
            │
@@ -55,18 +56,48 @@ adapter 归一化 NormalizedEvent
            │
            ├─ 投递到 session 的 FIFO 队列
            │
-           └─ 处理完成 → 更新 status 为 "processed"（或 "failed"）
+           └─ 处理完成 → 更新 status 为 "processed"（或 "failed" / "cancelled"）
 ```
+
+## 状态语义
+
+| status | 语义 | 后续重复投递 |
+|---|---|---|
+| `processing` | 首次投递已通过 auth 和幂等检查，正在排队或运行 | 跳过 |
+| `processed` | 已完成处理 | 丢弃 |
+| `failed` | 处理失败；超过可重试窗口后允许重试 | 按可重试窗口判定 |
+| `cancelled` | 事件已入 session 队列，但在开始运行前被取消 | 丢弃 |
+
+取消只作用于 session 队列里尚未开始的 pending item。已经进入 running 的 item 不被队列取消打断，也不得把幂等状态标为 `cancelled`；它必须继续结算为 `processed` 或 `failed`。
+
+`markCancelled` 是状态写入接口，不负责判断队列项是否仍可取消。调用方只有在队列取消返回 `cancelled`（pending item 已移出队列且尚未开始运行）后才能调用；队列返回 `running` 或 `not_found` 时不得调用。
 
 ## 存储
 
 - 表：`idempotency`（见 [`persistence.md`](persistence.md) §idempotency）
 - 主键：`(session_key, message_id)`
-- 字段：`firstSeenAt`, `status: "processing" | "processed" | "failed"`, `result?`, `expires_at`
+- 字段：`firstSeenAt`, `status: "processing" | "processed" | "failed" | "cancelled"`, `result?`, `expires_at`
 - TTL 写入 `expires_at`，后台 GC 清理
 - 内存 LRU 缓存热数据加速
 
 幂等键使用路由层的 `session_key`，不使用持久化主键 `session_id`。会话分代与路由关系见 [`session-model.md`](../../architecture/session-model.md)。
+
+## 接口语义
+
+| 方法 | 语义 |
+|---|---|
+| `checkAndSet(sessionKey, messageId)` | 未命中时插入 `processing`；命中时返回现有 status |
+| `markProcessed(sessionKey, messageId)` | 处理完成后标 `processed` |
+| `markFailed(sessionKey, messageId)` | 处理失败后标 `failed` |
+| `markCancelled(sessionKey, messageId)` | pending item 被取消、且尚未开始运行时标 `cancelled` |
+| `forget(sessionKey, messageId)` | 删除单条幂等记录；用于显式恢复或测试隔离，不在普通 dispatch 路径调用 |
+| `clearAll()` | 清空内存态；用于进程内测试或重载场景，不对应持久化 GC |
+
+## 实现分层
+
+`InMemoryIdempotencyStore` 是进程内 baseline：只保存当前进程的 `(sessionKey, messageId) -> status`，提供 `checkAndSet`、状态标记、`forget` 与 `clearAll`。它不实现 TTL、后台 GC、`failed` 可重试窗口，也不跨进程保留状态。
+
+持久化 Store 必须实现本 spec 的 TTL、GC 与 `failed` 重试窗口；SQLite 字段见 [`persistence.md`](persistence.md) §idempotency。
 
 ## 后台 GC
 
@@ -90,7 +121,9 @@ retryWindowAfterFailedMs = 30000  # "failed" 到允许重试的时间
 - **首次投递**：全新 (sessionKey, messageId) → 插入 `processing`；业务正常处理后标 `processed`
 - **重复投递**：同一 fixture 连发两次 → 第二次返回 "hit"，不转发给 session 队列；CC CLI 只被触发一次
 - **auth 拒绝不入表**：`auth_denied` 的事件 → idempotency 表**无该 messageId 记录**（防刷表）
-- **failed 重试**：第一次处理标 `failed` → 超过 `retryWindowAfterFailedMs` 后再投递相同 fixture → 正常处理
+- **cancelled 终态**：pending item 取消后标 `cancelled` → 重复投递同一 messageId 返回 "hit"，不重新入队
+- **单条 forget**：删除一条 `(sessionKey, messageId)` 记录 → 同 session 其他 messageId 不受影响
+- **failed 重试（持久化 Store）**：第一次处理标 `failed` → 超过 `retryWindowAfterFailedMs` 后再投递相同 fixture → 正常处理
 - **GC 基线**：插入 10000 条过期条目 → 一轮 GC 清空（在 `gcBatchSize` 之内）
 - **GC 失败降级**：mock SQLite 写入错误 → GC 跳过本轮 + 打 warn；业务不中断
 

--- a/docs/dev/spec/infra/persistence.md
+++ b/docs/dev/spec/infra/persistence.md
@@ -89,7 +89,7 @@ contracts:
 | `session_key` | TEXT | 联合主键 |
 | `message_id` | TEXT | 联合主键 |
 | `first_seen_at` | TEXT NOT NULL | |
-| `status` | TEXT NOT NULL | `processing|processed|failed` |
+| `status` | TEXT NOT NULL | `processing|processed|failed|cancelled` |
 | `result_json` | TEXT | 处理结果摘要 |
 | `expires_at` | TEXT NOT NULL | 用于 TTL 清理 |
 
@@ -192,6 +192,8 @@ interface Store {
     checkAndSet(key, messageId) -> IdempotencyState
     markProcessed(key, messageId, result) -> void
     markFailed(key, messageId, errorKind) -> void
+    markCancelled(key, messageId) -> void
+    forget(key, messageId) -> void
     gc(now) -> int                           // 返回删除条数
 
     // messages（可选）

--- a/packages/daemon/src/idempotency.test.ts
+++ b/packages/daemon/src/idempotency.test.ts
@@ -28,6 +28,18 @@ describe('InMemoryIdempotencyStore', () => {
     });
   });
 
+  it('records cancelled as a terminal replay status', () => {
+    const store = new InMemoryIdempotencyStore();
+
+    expect(store.checkAndSet(sessionKey, 'm-1')).toEqual({ kind: 'inserted' });
+    store.markCancelled(sessionKey, 'm-1');
+
+    expect(store.checkAndSet(sessionKey, 'm-1')).toEqual({
+      kind: 'hit',
+      status: 'cancelled',
+    });
+  });
+
   it('keys records by the routed session key and messageId pair', () => {
     const store = new InMemoryIdempotencyStore();
     const otherSessionKey = withPlatformName(

--- a/packages/daemon/src/idempotency.test.ts
+++ b/packages/daemon/src/idempotency.test.ts
@@ -66,4 +66,21 @@ describe('InMemoryIdempotencyStore', () => {
 
     expect(store.checkAndSet(sessionKey, 'm-1')).toEqual({ kind: 'inserted' });
   });
+
+  it('forget drops one message replay state without clearing the session', () => {
+    const store = new InMemoryIdempotencyStore();
+
+    expect(store.checkAndSet(sessionKey, 'm-1')).toEqual({ kind: 'inserted' });
+    expect(store.checkAndSet(sessionKey, 'm-2')).toEqual({ kind: 'inserted' });
+    store.markProcessed(sessionKey, 'm-1');
+    store.markProcessed(sessionKey, 'm-2');
+
+    store.forget(sessionKey, 'm-1');
+
+    expect(store.checkAndSet(sessionKey, 'm-1')).toEqual({ kind: 'inserted' });
+    expect(store.checkAndSet(sessionKey, 'm-2')).toEqual({
+      kind: 'hit',
+      status: 'processed',
+    });
+  });
 });

--- a/packages/daemon/src/idempotency.ts
+++ b/packages/daemon/src/idempotency.ts
@@ -1,7 +1,11 @@
 import type { SessionKey } from '@agent-nexus/protocol';
 import { serializeSessionKey } from '@agent-nexus/protocol';
 
-export type IdempotencyStatus = 'processing' | 'processed' | 'failed';
+export type IdempotencyStatus =
+  | 'processing'
+  | 'processed'
+  | 'failed'
+  | 'cancelled';
 
 export type IdempotencyDecision =
   | { kind: 'inserted' }
@@ -11,6 +15,8 @@ export interface IdempotencyStore {
   checkAndSet(sessionKey: SessionKey, messageId: string): IdempotencyDecision;
   markProcessed(sessionKey: SessionKey, messageId: string): void;
   markFailed(sessionKey: SessionKey, messageId: string): void;
+  markCancelled(sessionKey: SessionKey, messageId: string): void;
+  forget(sessionKey: SessionKey, messageId: string): void;
   clearAll(): void;
 }
 
@@ -35,6 +41,14 @@ export class InMemoryIdempotencyStore implements IdempotencyStore {
 
   markFailed(sessionKey: SessionKey, messageId: string): void {
     this.entries.set(keyFor(sessionKey, messageId), 'failed');
+  }
+
+  markCancelled(sessionKey: SessionKey, messageId: string): void {
+    this.entries.set(keyFor(sessionKey, messageId), 'cancelled');
+  }
+
+  forget(sessionKey: SessionKey, messageId: string): void {
+    this.entries.delete(keyFor(sessionKey, messageId));
   }
 
   clearAll(): void {

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -14,6 +14,16 @@ export {
   type IdempotencyStatus,
   type IdempotencyStore,
 } from './idempotency.js';
+export {
+  InMemoryMessageQueue,
+  QueueFullError,
+  QueueItemCancelledError,
+  queueKeyFromEvent,
+  type MessageQueueItemKind,
+  type MessageQueueItemStatus,
+  type MessageQueueItemView,
+  type MessageQueueSnapshot,
+} from './message-queue.js';
 export { BasicRedactor, redactText, type Redactor } from './redaction.js';
 export {
   RouteError,

--- a/packages/daemon/src/message-queue.test.ts
+++ b/packages/daemon/src/message-queue.test.ts
@@ -107,7 +107,7 @@ describe('InMemoryMessageQueue', () => {
     const gate = deferred<void>();
     const onCancel: string[] = [];
 
-    const running = queue.enqueue({
+    const running = queue.enqueueWithHandle({
       key: 'k1',
       kind: 'message',
       traceId: 't1',
@@ -127,6 +127,10 @@ describe('InMemoryMessageQueue', () => {
       },
     });
 
+    expect(queue.cancelPendingItem('k1', running.id)).toMatchObject({
+      status: 'running',
+      item: expect.objectContaining({ label: 'running' }),
+    });
     expect(queue.clearPending('k1').cancelled).toBe(1);
     await expect(pending).rejects.toBeInstanceOf(QueueItemCancelledError);
     expect(onCancel).toEqual(['pending']);
@@ -136,10 +140,10 @@ describe('InMemoryMessageQueue', () => {
     });
 
     gate.resolve();
-    await running;
+    await running.done;
   });
 
-  it('rejects enqueue when per-key pending depth reaches the limit', async () => {
+  it('returns a rejected promise from enqueue when per-key pending depth reaches the limit', async () => {
     const queue = new InMemoryMessageQueue({ maxPendingPerKey: 1 });
     const gate = deferred<void>();
     const running = queue.enqueue({
@@ -159,18 +163,185 @@ describe('InMemoryMessageQueue', () => {
       run: async () => undefined,
     });
 
-    expect(() =>
-      queue.enqueue({
+    let overflow!: Promise<void>;
+    expect(() => {
+      overflow = queue.enqueue({
         key: 'k1',
         kind: 'message',
         traceId: 't3',
         label: 'overflow',
         run: async () => undefined,
-      }),
-    ).toThrow(QueueFullError);
+      });
+    }).not.toThrow();
+    await expect(overflow).rejects.toBeInstanceOf(QueueFullError);
 
     gate.resolve();
     await Promise.all([running, pending]);
+  });
+
+  it('evicts the oldest idle key state after the idle state limit', async () => {
+    const queue = new InMemoryMessageQueue({ maxIdleStates: 1 });
+
+    await queue.enqueue({
+      key: 'k1',
+      kind: 'message',
+      traceId: 't1',
+      label: 'first',
+      run: async () => undefined,
+    });
+    await Promise.resolve();
+    expect(queue.snapshot('k1').recent).toHaveLength(1);
+
+    await queue.enqueue({
+      key: 'k2',
+      kind: 'message',
+      traceId: 't2',
+      label: 'second',
+      run: async () => undefined,
+    });
+    await Promise.resolve();
+
+    expect(queue.snapshot('k1')).toMatchObject({
+      pendingCount: 0,
+      recent: [],
+    });
+    expect(queue.snapshot('k2').recent).toHaveLength(1);
+  });
+
+  it('does not evict running or pending keys while trimming idle states', async () => {
+    const queue = new InMemoryMessageQueue({ maxIdleStates: 1 });
+    const gate = deferred<void>();
+
+    const running = queue.enqueueWithHandle({
+      key: 'active',
+      kind: 'message',
+      traceId: 't-active-1',
+      label: 'running',
+      run: async () => {
+        await gate.promise;
+      },
+    });
+    const pending = queue.enqueueWithHandle({
+      key: 'active',
+      kind: 'message',
+      traceId: 't-active-2',
+      label: 'pending',
+      run: async () => undefined,
+    });
+
+    await queue.enqueue({
+      key: 'idle-1',
+      kind: 'message',
+      traceId: 't-idle-1',
+      label: 'idle 1',
+      run: async () => undefined,
+    });
+    await Promise.resolve();
+    await queue.enqueue({
+      key: 'idle-2',
+      kind: 'message',
+      traceId: 't-idle-2',
+      label: 'idle 2',
+      run: async () => undefined,
+    });
+    await Promise.resolve();
+
+    expect(queue.snapshot('active')).toMatchObject({
+      running: expect.objectContaining({ label: 'running' }),
+      pending: [expect.objectContaining({ label: 'pending' })],
+    });
+
+    gate.resolve();
+    await Promise.all([running.done, pending.done]);
+  });
+
+  it('records onCancel errors while keeping the pending item cancelled', async () => {
+    const queue = new InMemoryMessageQueue();
+    const gate = deferred<void>();
+
+    const running = queue.enqueue({
+      key: 'k1',
+      kind: 'message',
+      traceId: 't1',
+      label: 'running',
+      run: async () => {
+        await gate.promise;
+      },
+    });
+    const pending = queue.enqueue({
+      key: 'k1',
+      kind: 'message',
+      traceId: 't2',
+      label: 'pending',
+      onCancel: () => {
+        throw new Error('cleanup failed');
+      },
+      run: async () => undefined,
+    });
+
+    expect(queue.clearPending('k1').cancelled).toBe(1);
+    await expect(pending).rejects.toBeInstanceOf(QueueItemCancelledError);
+    expect(queue.snapshot('k1').recent).toEqual([
+      expect.objectContaining({
+        status: 'cancelled',
+        errorMessage: 'cleanup failed',
+      }),
+    ]);
+
+    gate.resolve();
+    await running;
+  });
+
+  it('preserves empty editable text and leaves the label unchanged unless supplied', async () => {
+    const queue = new InMemoryMessageQueue();
+    const gate = deferred<void>();
+    const edits: string[] = [];
+
+    const running = queue.enqueue({
+      key: 'k1',
+      kind: 'message',
+      traceId: 't1',
+      label: 'running',
+      run: async () => {
+        await gate.promise;
+      },
+    });
+    const draft = queue.enqueueWithHandle({
+      key: 'k1',
+      kind: 'message',
+      traceId: 't2',
+      label: 'draft',
+      editableText: '',
+      onEdit: (text) => edits.push(text),
+      run: async () => undefined,
+    });
+
+    expect(queue.snapshot('k1').pending).toEqual([
+      expect.objectContaining({ label: 'draft', editableText: '' }),
+    ]);
+    expect(queue.editPending('k1', draft.id, 'updated body')).toMatchObject({
+      status: 'updated',
+      item: expect.objectContaining({
+        label: 'draft',
+        editableText: 'updated body',
+      }),
+    });
+    expect(queue.editPending('k1', draft.id, '', 'empty draft')).toMatchObject({
+      status: 'updated',
+      item: expect.objectContaining({
+        label: 'empty draft',
+        editableText: '',
+      }),
+    });
+    expect(edits).toEqual(['updated body', '']);
+
+    expect(queue.cancelPendingItem('k1', draft.id)).toMatchObject({
+      status: 'cancelled',
+    });
+    await expect(draft.done).rejects.toBeInstanceOf(QueueItemCancelledError);
+
+    gate.resolve();
+    await running;
   });
 
   it('moves, edits, inserts, and cancels pending items by id', async () => {
@@ -220,7 +391,9 @@ describe('InMemoryMessageQueue', () => {
       },
     });
 
-    expect(queue.editPending('k1', second.id, 'edited second')).toMatchObject({
+    expect(
+      queue.editPending('k1', second.id, 'edited second', 'edited second'),
+    ).toMatchObject({
       status: 'updated',
       item: expect.objectContaining({ label: 'edited second' }),
     });

--- a/packages/daemon/src/message-queue.test.ts
+++ b/packages/daemon/src/message-queue.test.ts
@@ -1,0 +1,246 @@
+import { describe, expect, it } from 'vitest';
+import {
+  InMemoryMessageQueue,
+  QueueFullError,
+  QueueItemCancelledError,
+} from './message-queue.js';
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason?: unknown) => void;
+} {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('InMemoryMessageQueue', () => {
+  it('runs one item at a time per key while allowing different keys to run in parallel', async () => {
+    const queue = new InMemoryMessageQueue();
+    const firstGate = deferred<void>();
+    const order: string[] = [];
+
+    const first = queue.enqueue({
+      key: 'k1',
+      kind: 'message',
+      traceId: 't1',
+      label: 'first',
+      run: async () => {
+        order.push('k1:first:start');
+        await firstGate.promise;
+        order.push('k1:first:end');
+      },
+    });
+    const second = queue.enqueue({
+      key: 'k1',
+      kind: 'message',
+      traceId: 't2',
+      label: 'second',
+      run: async () => {
+        order.push('k1:second');
+      },
+    });
+    const other = queue.enqueue({
+      key: 'k2',
+      kind: 'message',
+      traceId: 't3',
+      label: 'other',
+      run: async () => {
+        order.push('k2:other');
+      },
+    });
+
+    await other;
+    expect(order).toEqual(['k1:first:start', 'k2:other']);
+
+    firstGate.resolve();
+    await Promise.all([first, second]);
+
+    expect(order).toEqual([
+      'k1:first:start',
+      'k2:other',
+      'k1:first:end',
+      'k1:second',
+    ]);
+  });
+
+  it('releases the per-key running slot after a worker failure', async () => {
+    const queue = new InMemoryMessageQueue();
+    const order: string[] = [];
+    const failed = queue.enqueue({
+      key: 'k1',
+      kind: 'message',
+      traceId: 't1',
+      label: 'failed',
+      run: async () => {
+        order.push('failed');
+        throw new Error('boom');
+      },
+    });
+    const next = queue.enqueue({
+      key: 'k1',
+      kind: 'message',
+      traceId: 't2',
+      label: 'next',
+      run: async () => {
+        order.push('next');
+      },
+    });
+
+    await expect(failed).rejects.toThrow('boom');
+    await next;
+
+    expect(order).toEqual(['failed', 'next']);
+    expect(queue.snapshot('k1').recent.map((item) => item.status)).toEqual([
+      'failed',
+      'completed',
+    ]);
+  });
+
+  it('cancels only pending items for a key', async () => {
+    const queue = new InMemoryMessageQueue();
+    const gate = deferred<void>();
+    const onCancel: string[] = [];
+
+    const running = queue.enqueue({
+      key: 'k1',
+      kind: 'message',
+      traceId: 't1',
+      label: 'running',
+      run: async () => {
+        await gate.promise;
+      },
+    });
+    const pending = queue.enqueue({
+      key: 'k1',
+      kind: 'message',
+      traceId: 't2',
+      label: 'pending',
+      onCancel: () => onCancel.push('pending'),
+      run: async () => {
+        throw new Error('pending should not run');
+      },
+    });
+
+    expect(queue.clearPending('k1').cancelled).toBe(1);
+    await expect(pending).rejects.toBeInstanceOf(QueueItemCancelledError);
+    expect(onCancel).toEqual(['pending']);
+    expect(queue.snapshot('k1')).toMatchObject({
+      pendingCount: 0,
+      running: expect.objectContaining({ label: 'running' }),
+    });
+
+    gate.resolve();
+    await running;
+  });
+
+  it('rejects enqueue when per-key pending depth reaches the limit', async () => {
+    const queue = new InMemoryMessageQueue({ maxPendingPerKey: 1 });
+    const gate = deferred<void>();
+    const running = queue.enqueue({
+      key: 'k1',
+      kind: 'message',
+      traceId: 't1',
+      label: 'running',
+      run: async () => {
+        await gate.promise;
+      },
+    });
+    const pending = queue.enqueue({
+      key: 'k1',
+      kind: 'message',
+      traceId: 't2',
+      label: 'pending',
+      run: async () => undefined,
+    });
+
+    expect(() =>
+      queue.enqueue({
+        key: 'k1',
+        kind: 'message',
+        traceId: 't3',
+        label: 'overflow',
+        run: async () => undefined,
+      }),
+    ).toThrow(QueueFullError);
+
+    gate.resolve();
+    await Promise.all([running, pending]);
+  });
+
+  it('moves, edits, inserts, and cancels pending items by id', async () => {
+    const queue = new InMemoryMessageQueue();
+    const gate = deferred<void>();
+    const prompts = { second: 'second' };
+    const order: string[] = [];
+
+    const running = queue.enqueueWithHandle({
+      key: 'k1',
+      kind: 'message',
+      traceId: 't1',
+      label: 'running',
+      run: async () => {
+        await gate.promise;
+      },
+    });
+    const second = queue.enqueueWithHandle({
+      key: 'k1',
+      kind: 'message',
+      traceId: 't2',
+      label: prompts.second,
+      onEdit: (text) => {
+        prompts.second = text;
+      },
+      run: async () => {
+        order.push(prompts.second);
+      },
+    });
+    const third = queue.enqueueWithHandle({
+      key: 'k1',
+      kind: 'message',
+      traceId: 't3',
+      label: 'third',
+      run: async () => {
+        order.push('third');
+      },
+    });
+    const inserted = queue.enqueueWithHandle({
+      key: 'k1',
+      kind: 'message',
+      traceId: 't4',
+      label: 'inserted',
+      position: 'front',
+      run: async () => {
+        order.push('inserted');
+      },
+    });
+
+    expect(queue.editPending('k1', second.id, 'edited second')).toMatchObject({
+      status: 'updated',
+      item: expect.objectContaining({ label: 'edited second' }),
+    });
+    expect(queue.movePending('k1', third.id, 'up')).toMatchObject({
+      status: 'moved',
+    });
+    expect(queue.cancelPendingItem('k1', second.id)).toMatchObject({
+      status: 'cancelled',
+    });
+    await expect(second.done).rejects.toBeInstanceOf(QueueItemCancelledError);
+
+    gate.resolve();
+    await Promise.all([running.done, inserted.done, third.done]);
+
+    expect(order).toEqual(['inserted', 'third']);
+    expect(queue.snapshot('k1').recent.map((item) => item.status)).toEqual([
+      'cancelled',
+      'completed',
+      'completed',
+      'completed',
+    ]);
+  });
+});

--- a/packages/daemon/src/message-queue.ts
+++ b/packages/daemon/src/message-queue.ts
@@ -1,0 +1,332 @@
+import { randomUUID } from 'node:crypto';
+import type { NormalizedEvent } from '@agent-nexus/protocol';
+import { serializeSessionKey, withPlatformName } from '@agent-nexus/protocol';
+
+export type MessageQueueItemKind =
+  | 'message'
+  | 'agent-command'
+  | 'daemon-state-command';
+
+export type MessageQueueItemStatus =
+  | 'queued'
+  | 'running'
+  | 'completed'
+  | 'failed'
+  | 'cancelled';
+
+export interface MessageQueueItemView {
+  id: string;
+  key: string;
+  kind: MessageQueueItemKind;
+  status: MessageQueueItemStatus;
+  traceId: string;
+  label: string;
+  eventId?: string;
+  editableText?: string;
+  enqueuedAt: Date;
+  startedAt?: Date;
+  finishedAt?: Date;
+  errorMessage?: string;
+}
+
+export interface MessageQueueSnapshot {
+  key: string;
+  running?: MessageQueueItemView;
+  pending: MessageQueueItemView[];
+  recent: MessageQueueItemView[];
+  pendingCount: number;
+  maxPendingPerKey: number;
+  recentCounts: {
+    completed: number;
+    failed: number;
+    cancelled: number;
+  };
+}
+
+export interface MessageQueueOptions {
+  maxPendingPerKey?: number;
+  historyLimitPerKey?: number;
+}
+
+export interface MessageQueueEnqueueInput<T> {
+  key: string;
+  kind: MessageQueueItemKind;
+  traceId: string;
+  label: string;
+  eventId?: string;
+  editableText?: string;
+  position?: 'front' | 'tail';
+  run: () => T | Promise<T>;
+  onCancel?: () => void;
+  onEdit?: (text: string) => void;
+}
+
+export interface MessageQueueEnqueueResult<T> {
+  id: string;
+  done: Promise<T>;
+}
+
+interface MessageQueueItem<T> {
+  view: MessageQueueItemView;
+  run: () => T | Promise<T>;
+  onCancel?: () => void;
+  onEdit?: (text: string) => void;
+  resolve: (value: T) => void;
+  reject: (reason?: unknown) => void;
+  done: Promise<T>;
+}
+
+interface QueueState {
+  running?: MessageQueueItem<unknown>;
+  pending: MessageQueueItem<unknown>[];
+  recent: MessageQueueItemView[];
+}
+
+export class QueueItemCancelledError extends Error {
+  constructor(item: MessageQueueItemView) {
+    super(`Queue item cancelled: ${item.label}`);
+    this.name = 'QueueItemCancelledError';
+  }
+}
+
+export class QueueFullError extends Error {
+  constructor(
+    readonly key: string,
+    readonly maxPendingPerKey: number,
+  ) {
+    super(`Queue is full for ${key}`);
+    this.name = 'QueueFullError';
+  }
+}
+
+export function queueKeyFromEvent(
+  event: NormalizedEvent,
+  platformName: string,
+): string {
+  return serializeSessionKey(withPlatformName(event.sessionKey, platformName));
+}
+
+export class InMemoryMessageQueue {
+  private readonly states = new Map<string, QueueState>();
+  readonly maxPendingPerKey: number;
+  private readonly historyLimitPerKey: number;
+
+  constructor(options: MessageQueueOptions = {}) {
+    this.maxPendingPerKey = options.maxPendingPerKey ?? 20;
+    this.historyLimitPerKey = options.historyLimitPerKey ?? 50;
+  }
+
+  enqueue<T>(input: MessageQueueEnqueueInput<T>): Promise<T> {
+    return this.enqueueWithHandle(input).done;
+  }
+
+  enqueueWithHandle<T>(
+    input: MessageQueueEnqueueInput<T>,
+  ): MessageQueueEnqueueResult<T> {
+    const state = this.stateFor(input.key);
+    if (state.pending.length >= this.maxPendingPerKey) {
+      throw new QueueFullError(input.key, this.maxPendingPerKey);
+    }
+
+    let resolve!: (value: T) => void;
+    let reject!: (reason?: unknown) => void;
+    const done = new Promise<T>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+    done.catch(() => undefined);
+
+    const item: MessageQueueItem<T> = {
+      view: {
+        id: randomUUID(),
+        key: input.key,
+        kind: input.kind,
+        status: 'queued',
+        traceId: input.traceId,
+        label: input.label,
+        ...(input.eventId ? { eventId: input.eventId } : {}),
+        ...(input.editableText ? { editableText: input.editableText } : {}),
+        enqueuedAt: new Date(),
+      },
+      run: input.run,
+      onCancel: input.onCancel,
+      onEdit: input.onEdit,
+      resolve,
+      reject,
+      done,
+    };
+    if (input.position === 'front') {
+      state.pending.unshift(item as MessageQueueItem<unknown>);
+    } else {
+      state.pending.push(item as MessageQueueItem<unknown>);
+    }
+    this.schedule(input.key, state);
+    return { id: item.view.id, done };
+  }
+
+  isIdle(key: string): boolean {
+    const state = this.states.get(key);
+    return !state?.running && (state?.pending.length ?? 0) === 0;
+  }
+
+  snapshot(key: string): MessageQueueSnapshot {
+    const state = this.states.get(key);
+    const recent = state?.recent ?? [];
+    return {
+      key,
+      ...(state?.running ? { running: { ...state.running.view } } : {}),
+      pending: (state?.pending ?? []).map((item) => ({ ...item.view })),
+      recent: recent.map((item) => ({ ...item })),
+      pendingCount: state?.pending.length ?? 0,
+      maxPendingPerKey: this.maxPendingPerKey,
+      recentCounts: {
+        completed: recent.filter((item) => item.status === 'completed').length,
+        failed: recent.filter((item) => item.status === 'failed').length,
+        cancelled: recent.filter((item) => item.status === 'cancelled').length,
+      },
+    };
+  }
+
+  clearPending(key: string): { cancelled: number } {
+    const state = this.states.get(key);
+    if (!state || state.pending.length === 0) {
+      return { cancelled: 0 };
+    }
+    const pending = state.pending.splice(0);
+    for (const item of pending) {
+      this.cancelItem(state, item);
+    }
+    return { cancelled: pending.length };
+  }
+
+  cancelPendingItem(
+    key: string,
+    itemId: string,
+  ): { status: 'cancelled'; item: MessageQueueItemView } | { status: 'not_found' } {
+    const state = this.states.get(key);
+    if (!state) return { status: 'not_found' };
+    const index = state.pending.findIndex((item) => item.view.id === itemId);
+    if (index < 0) return { status: 'not_found' };
+    const [item] = state.pending.splice(index, 1);
+    this.cancelItem(state, item!);
+    return { status: 'cancelled', item: { ...item!.view } };
+  }
+
+  editPending(
+    key: string,
+    itemId: string,
+    text: string,
+    label = text,
+  ):
+    | { status: 'updated'; item: MessageQueueItemView }
+    | { status: 'not_found' }
+    | { status: 'not_editable' } {
+    const item = this.findPending(key, itemId);
+    if (!item) return { status: 'not_found' };
+    if (!item.onEdit) return { status: 'not_editable' };
+    item.onEdit(text);
+    item.view.label = label;
+    item.view.editableText = text;
+    return { status: 'updated', item: { ...item.view } };
+  }
+
+  movePending(
+    key: string,
+    itemId: string,
+    direction: 'up' | 'down',
+  ):
+    | { status: 'moved'; item: MessageQueueItemView }
+    | { status: 'not_found' }
+    | { status: 'unchanged'; item: MessageQueueItemView } {
+    const state = this.states.get(key);
+    if (!state) return { status: 'not_found' };
+    const index = state.pending.findIndex((item) => item.view.id === itemId);
+    if (index < 0) return { status: 'not_found' };
+    const target = direction === 'up' ? index - 1 : index + 1;
+    if (target < 0 || target >= state.pending.length) {
+      return { status: 'unchanged', item: { ...state.pending[index]!.view } };
+    }
+    const [item] = state.pending.splice(index, 1);
+    state.pending.splice(target, 0, item!);
+    return { status: 'moved', item: { ...item!.view } };
+  }
+
+  clearAll(): { cancelled: number } {
+    let cancelled = 0;
+    for (const key of this.states.keys()) {
+      cancelled += this.clearPending(key).cancelled;
+    }
+    return { cancelled };
+  }
+
+  private schedule(key: string, state: QueueState): void {
+    if (state.running) return;
+    const item = state.pending.shift();
+    if (!item) return;
+    state.running = item;
+    item.view.status = 'running';
+    item.view.startedAt = new Date();
+
+    void Promise.resolve()
+      .then(() => item.run())
+      .then(
+        (value) => {
+          item.view.status = 'completed';
+          item.view.finishedAt = new Date();
+          item.resolve(value);
+        },
+        (err: unknown) => {
+          item.view.status = 'failed';
+          item.view.finishedAt = new Date();
+          item.view.errorMessage =
+            err instanceof Error ? err.message : String(err);
+          item.reject(err);
+        },
+      )
+      .finally(() => {
+        if (state.running === item) {
+          state.running = undefined;
+        }
+        this.pushHistory(state, item.view);
+        this.schedule(key, state);
+      });
+  }
+
+  private stateFor(key: string): QueueState {
+    const existing = this.states.get(key);
+    if (existing) return existing;
+    const state: QueueState = { pending: [], recent: [] };
+    this.states.set(key, state);
+    return state;
+  }
+
+  private pushHistory(state: QueueState, view: MessageQueueItemView): void {
+    state.recent.push({ ...view });
+    while (state.recent.length > this.historyLimitPerKey) {
+      state.recent.shift();
+    }
+  }
+
+  private findPending(
+    key: string,
+    itemId: string,
+  ): MessageQueueItem<unknown> | undefined {
+    return this.states.get(key)?.pending.find((item) => item.view.id === itemId);
+  }
+
+  private cancelItem(
+    state: QueueState,
+    item: MessageQueueItem<unknown>,
+  ): void {
+    item.view.status = 'cancelled';
+    item.view.finishedAt = new Date();
+    try {
+      item.onCancel?.();
+    } catch (err) {
+      item.view.errorMessage =
+        err instanceof Error ? err.message : String(err);
+    }
+    item.reject(new QueueItemCancelledError(item.view));
+    this.pushHistory(state, item.view);
+  }
+}

--- a/packages/daemon/src/message-queue.ts
+++ b/packages/daemon/src/message-queue.ts
@@ -46,6 +46,7 @@ export interface MessageQueueSnapshot {
 export interface MessageQueueOptions {
   maxPendingPerKey?: number;
   historyLimitPerKey?: number;
+  maxIdleStates?: number;
 }
 
 export interface MessageQueueEnqueueInput<T> {
@@ -80,6 +81,7 @@ interface QueueState {
   running?: MessageQueueItem<unknown>;
   pending: MessageQueueItem<unknown>[];
   recent: MessageQueueItemView[];
+  idleOrder?: number;
 }
 
 export class QueueItemCancelledError extends Error {
@@ -110,14 +112,22 @@ export class InMemoryMessageQueue {
   private readonly states = new Map<string, QueueState>();
   readonly maxPendingPerKey: number;
   private readonly historyLimitPerKey: number;
+  private readonly maxIdleStates: number;
+  private idleSequence = 0;
 
   constructor(options: MessageQueueOptions = {}) {
     this.maxPendingPerKey = options.maxPendingPerKey ?? 20;
     this.historyLimitPerKey = options.historyLimitPerKey ?? 50;
+    this.maxIdleStates = Math.max(0, options.maxIdleStates ?? 1000);
   }
 
+  /** Callers must await or catch the returned promise, including enqueue-time failures. */
   enqueue<T>(input: MessageQueueEnqueueInput<T>): Promise<T> {
-    return this.enqueueWithHandle(input).done;
+    try {
+      return this.enqueueWithHandle(input).done;
+    } catch (err) {
+      return Promise.reject(err);
+    }
   }
 
   enqueueWithHandle<T>(
@@ -127,6 +137,7 @@ export class InMemoryMessageQueue {
     if (state.pending.length >= this.maxPendingPerKey) {
       throw new QueueFullError(input.key, this.maxPendingPerKey);
     }
+    state.idleOrder = undefined;
 
     let resolve!: (value: T) => void;
     let reject!: (reason?: unknown) => void;
@@ -145,7 +156,9 @@ export class InMemoryMessageQueue {
         traceId: input.traceId,
         label: input.label,
         ...(input.eventId ? { eventId: input.eventId } : {}),
-        ...(input.editableText ? { editableText: input.editableText } : {}),
+        ...(input.editableText !== undefined
+          ? { editableText: input.editableText }
+          : {}),
         enqueuedAt: new Date(),
       },
       run: input.run,
@@ -196,27 +209,36 @@ export class InMemoryMessageQueue {
     for (const item of pending) {
       this.cancelItem(state, item);
     }
+    this.markIdle(key, state);
     return { cancelled: pending.length };
   }
 
   cancelPendingItem(
     key: string,
     itemId: string,
-  ): { status: 'cancelled'; item: MessageQueueItemView } | { status: 'not_found' } {
+  ):
+    | { status: 'cancelled'; item: MessageQueueItemView }
+    | { status: 'running'; item: MessageQueueItemView }
+    | { status: 'not_found' } {
     const state = this.states.get(key);
     if (!state) return { status: 'not_found' };
+    if (state.running?.view.id === itemId) {
+      return { status: 'running', item: { ...state.running.view } };
+    }
     const index = state.pending.findIndex((item) => item.view.id === itemId);
     if (index < 0) return { status: 'not_found' };
     const [item] = state.pending.splice(index, 1);
     this.cancelItem(state, item!);
+    this.markIdle(key, state);
     return { status: 'cancelled', item: { ...item!.view } };
   }
 
+  /** Edits queued text; omitting label keeps the current human-facing label. */
   editPending(
     key: string,
     itemId: string,
     text: string,
-    label = text,
+    label?: string,
   ):
     | { status: 'updated'; item: MessageQueueItemView }
     | { status: 'not_found' }
@@ -225,7 +247,9 @@ export class InMemoryMessageQueue {
     if (!item) return { status: 'not_found' };
     if (!item.onEdit) return { status: 'not_editable' };
     item.onEdit(text);
-    item.view.label = label;
+    if (label !== undefined) {
+      item.view.label = label;
+    }
     item.view.editableText = text;
     return { status: 'updated', item: { ...item.view } };
   }
@@ -253,7 +277,7 @@ export class InMemoryMessageQueue {
 
   clearAll(): { cancelled: number } {
     let cancelled = 0;
-    for (const key of this.states.keys()) {
+    for (const key of Array.from(this.states.keys())) {
       cancelled += this.clearPending(key).cancelled;
     }
     return { cancelled };
@@ -262,7 +286,11 @@ export class InMemoryMessageQueue {
   private schedule(key: string, state: QueueState): void {
     if (state.running) return;
     const item = state.pending.shift();
-    if (!item) return;
+    if (!item) {
+      this.markIdle(key, state);
+      return;
+    }
+    state.idleOrder = undefined;
     state.running = item;
     item.view.status = 'running';
     item.view.startedAt = new Date();
@@ -304,6 +332,27 @@ export class InMemoryMessageQueue {
     state.recent.push({ ...view });
     while (state.recent.length > this.historyLimitPerKey) {
       state.recent.shift();
+    }
+  }
+
+  private markIdle(key: string, state: QueueState): void {
+    if (state.running || state.pending.length > 0) return;
+    if (state.recent.length === 0 || this.maxIdleStates === 0) {
+      this.states.delete(key);
+      return;
+    }
+    state.idleOrder = ++this.idleSequence;
+    this.evictIdleStates();
+  }
+
+  private evictIdleStates(): void {
+    const idleStates = Array.from(this.states.entries())
+      .filter(([, state]) => state.idleOrder !== undefined)
+      .sort(([, a], [, b]) => a.idleOrder! - b.idleOrder!);
+    const evictCount = idleStates.length - this.maxIdleStates;
+    if (evictCount <= 0) return;
+    for (const [key] of idleStates.slice(0, evictCount)) {
+      this.states.delete(key);
     }
   }
 


### PR DESCRIPTION
## Summary

从原 #151 中拆出 daemon per-session queue，用于把同一 SessionKey 的消息、queued agent command 和 daemon state command 统一串行化。

本 PR：
- 新增 `InMemoryMessageQueue` 与 queue item lifecycle。
- 扩展 idempotency store 支持 `cancelled` 和 `forget` 路径。
- 导出 queue 相关类型并补充 queue/idempotency 测试。

## Why

后续 `/nexus-queue` 与 workingDir mutation 需要可观察、可取消、可重排的 daemon queue；仅靠 promise 串行链无法表达 pending item 管理。

ADR: N/A - daemon 内部排队实现，延续 session ordering 约束。
Spec: `docs/dev/architecture/session-model.md` 与 `docs/dev/spec/infra/idempotency.md` 的同步在本 stack 顶部 docs PR 中承载。

## Test plan

- [x] Tests: `packages/daemon/src/message-queue.test.ts` 与 idempotency 相关测试在 final stacked head `64dc01c` 上通过。
- [x] `CI=true COREPACK_HOME=/cache/corepack corepack pnpm vitest run packages/daemon/src/session-store.test.ts packages/daemon/src/message-queue.test.ts packages/daemon/src/engine.test.ts packages/platform/discord/src/index.test.ts packages/cli/src/config.test.ts packages/cli/src/command-registry.test.ts` — 6 files, 217 tests passed.
- [x] `CI=true COREPACK_HOME=/cache/corepack corepack pnpm typecheck` — passed.
- [ ] Manual: `/nexus-queue` Discord interaction path not run; later stack layer exposes it.

## Review notes

- Independent agent review: Pending - split PR created from existing #151 branch; must be reviewed before merge.
- Deep review: N/A - in-memory daemon queue v1; no durable scheduler introduced.

## Out of scope

- Cross-process queue persistence.
- Global concurrency limits.
- Discord queue controls UI.