### PR TITLE
feat(platform-discord): add component interactions and threads

### DIFF
--- a/docs/dev/spec/platform-adapter.md
+++ b/docs/dev/spec/platform-adapter.md
@@ -137,6 +137,12 @@ MessageEmbed 结构见本文件附录；Component 结构见下节 `MessageCompon
 
 Platform-native ack/defer/followup/update/rate-limit 编排归 adapter。daemon 不持有 Discord interaction token、Slack ack deadline 或 Telegram callback query 等平台私有状态；daemon 只通过 `OutboundMessage` 表达平台中立的回复意图。Adapter 必须在平台要求的时限内完成 native ack/defer，并把后续 `send` / `edit` / followup 映射到对应平台 API。
 
+Discord component / modal 的 ack 约束：
+
+- 不打开 modal 的 component interaction：adapter 必须先 native defer，再调用 `EventHandler`。
+- modal submit interaction：adapter 必须先 native defer，再调用 `EventHandler`。
+- 打开 modal 的 component interaction：`showModal` 本身是该 interaction 的 native ack，adapter 必须在进入 daemon handler 前完成；adapter 只拥有 native modal 展示字段，最终会改变状态的提交仍由后续 modal submit 归一化为 `NormalizedEvent`，并在 daemon auth 后由对应 owner 处理。
+
 `EventHandler` 可返回 `EventHandlerResult.commandResponse`，仅用于已被 adapter native defer/ack 的 command interaction 收尾。Discord adapter 对非 reply-mode slash command 先发 ephemeral deferred reply；daemon 若返回 `commandResponse.text`，adapter 必须用 `editReply` 展示该 ephemeral 反馈，否则清理 deferred reply。普通消息与 agent 成功输出仍走 `OutboundMessage`。
 
 `EventHandlerResult.modalResponse` 用于 native interaction 要求立即打开 modal 的平台。Adapter 负责把平台中立的 `EventModalResponse` 映射到平台 native modal；不能支持 modal 的 adapter 不得声明 `supportsModals`。
@@ -463,6 +469,23 @@ Adapter 在 `client.on('ready')` 比较 `client.user?.id` 与 config 的 `botUse
 | `replyTo` | message_reference |
 | `ephemeral` | Interaction response flags |
 | 超过 2000 字符 | 切片成多条（切片策略见 message-protocol） |
+
+### Thread 创建错误语义
+
+```text
+CreateThreadResult {
+    threadId: string
+    parentChannelId: string
+    url?: string
+    setupWarnings?: [{ code: "initial_message_failed" }]
+}
+```
+
+`createThread(input)` 创建 thread 后的 setup 分三段处理：
+
+- `threads.create` 失败：直接返回失败，未产生 thread。
+- `members.add(initiatorUserId)` 失败：thread 对发起者不可用；adapter 可 best-effort 删除或归档已创建 thread，然后返回失败。
+- `initialMessage` 发送失败：不得删除或归档已创建 thread；adapter 记录包含 `traceId` / `threadId` / 原始错误的结构化错误日志，并返回带 `setupWarnings[{ code: "initial_message_failed" }]` 的 `CreateThreadResult`，让上层后续消息仍可在已创建 thread 内继续或恢复。
 
 ## 测试契约（合约测试）
 

--- a/packages/daemon/src/engine.test.ts
+++ b/packages/daemon/src/engine.test.ts
@@ -2553,10 +2553,9 @@ describe('Engine', () => {
       text: undefined,
       rawContentType: 'discord:modal-submit',
       interaction: {
-        customId: 'nexus:settings:working-dir-modal',
-        componentType: 'modal-submit',
-        values: [],
-        fields: { path: '/tmp/app' },
+        componentId: 'nexus:settings:working-dir-modal',
+        kind: 'modal_submit',
+        values: ['path=/tmp/app'],
       },
       initiator: { userId: 'U-denied', displayName: 'denied', isBot: false },
       sessionKey: {

--- a/packages/daemon/src/engine.test.ts
+++ b/packages/daemon/src/engine.test.ts
@@ -2505,6 +2505,83 @@ describe('Engine', () => {
     });
   });
 
+  it('settings modal submit interaction user 不在 platform auth allowlist 时不进入 agent', async () => {
+    const platform = makePlatform({ supportsButtons: true });
+    const codex = makeAgent();
+    const store = new SessionStore();
+    const mockLogger = makeMockLogger();
+    const routingTable: RoutingEntry[] = [
+      {
+        bindingName: 'discord-main-codex',
+        platformName: 'discord-main',
+        platformType: 'discord',
+        agentName: 'codex-dev',
+        match: { discord: { channelIds: ['C1'] } },
+      },
+    ];
+    const engine = new Engine({
+      platform,
+      platformName: 'discord-main',
+      platformType: 'discord',
+      agents: [
+        {
+          agentName: 'codex-dev',
+          agentOwner: 'codex',
+          agent: codex.runtime,
+          defaultSessionConfig: DEFAULT_CFG,
+        },
+      ],
+      routingTable,
+      platformAuth: {
+        allowlist: {
+          userIds: ['U-allowed'],
+          roleIds: [],
+          allowedGuildIds: [],
+          allowedChannelIds: [],
+          allowDM: true,
+          requireMentionOrSlash: true,
+        },
+      },
+      logger: mockLogger,
+      sessionStore: store,
+    });
+
+    await engine.start();
+    const dispatchHandler = (platform.start as ReturnType<typeof vi.fn>).mock.calls[0]![0] as EventHandler;
+    await dispatchHandler(makeEvent('', {
+      type: 'interaction',
+      text: undefined,
+      rawContentType: 'discord:modal-submit',
+      interaction: {
+        customId: 'nexus:settings:working-dir-modal',
+        componentType: 'modal-submit',
+        values: [],
+        fields: { path: '/tmp/app' },
+      },
+      initiator: { userId: 'U-denied', displayName: 'denied', isBot: false },
+      sessionKey: {
+        platform: 'discord',
+        channelId: 'C1',
+        initiatorUserId: 'U-denied',
+      },
+    }));
+
+    expect(codex.startSession).not.toHaveBeenCalled();
+    expect(codex.sendInput).not.toHaveBeenCalled();
+    expect(codex.handleCommand).not.toHaveBeenCalled();
+    expect(platform.send).not.toHaveBeenCalled();
+    expect(store.size).toBe(0);
+    const infoCalls = (mockLogger.info as ReturnType<typeof vi.fn>).mock.calls;
+    const authLog = infoCalls.find(([, msg]) => msg === 'auth_denied');
+    expect(authLog).toBeDefined();
+    expect(authLog![0]).toMatchObject({
+      platformName: 'discord-main',
+      channelId: 'C1',
+      userId: 'U-denied',
+      reason: 'user_not_allowed',
+    });
+  });
+
   it('两个同 type Engine 共享 SessionStore 时，同 channel/user 仍按 platformName 隔离', async () => {
     const platformMain = makePlatform();
     const platformSide = makePlatform();

--- a/packages/platform/discord/src/index.test.ts
+++ b/packages/platform/discord/src/index.test.ts
@@ -464,6 +464,15 @@ describe('command registry integration', () => {
     const editReply = vi.fn(async () => undefined);
     await interactionCreate({
       id: 'i-select',
+      applicationId: 'app-1',
+      token: 'interaction-token',
+      type: 3,
+      data: {
+        component_type: 3,
+        custom_id: 'nexus:sessions:resume',
+        values: ['mem-1'],
+      },
+      message: { id: 'm-components' },
       customId: 'nexus:sessions:resume',
       values: ['mem-1'],
       channelId: 'C1',
@@ -500,12 +509,21 @@ describe('command registry integration', () => {
       threadParentChannelId: 'C1',
       rawContentType: 'discord:component-interaction',
     });
+    expect(handler.mock.calls[0]![0].rawPayload).toMatchObject({
+      type: 3,
+      data: {
+        component_type: 3,
+        custom_id: 'nexus:sessions:resume',
+        values: ['mem-1'],
+      },
+      token: 'interaction-token',
+    });
     expect(editReply).toHaveBeenCalledWith({
       content: '[session resumed: sid-old]',
     });
   });
 
-  it('settings workingDir button can open a Discord modal before defer', async () => {
+  it('settings workingDir button opens its Discord modal before daemon handling', async () => {
     const platform = createDiscordPlatform({
       token: 'test-token',
       botUserId: BOT_ID,
@@ -514,44 +532,8 @@ describe('command registry integration', () => {
       allowedUserIds: ALLOWED,
       testGuildId: 'G-dev',
     });
-    const handler = vi.fn(async () => ({
-      modalResponse: {
-        customId: 'nexus:settings:working-dir-modal',
-        title: 'Set working directory',
-        textInputs: [
-          {
-            customId: 'path',
-            label: 'Absolute path',
-            style: 'short' as const,
-            required: true,
-          },
-        ],
-      },
-    }));
-
-    await platform.start(handler);
-    const interactionCreate = registeredHandler('interactionCreate');
-    const deferReply = vi.fn(async () => undefined);
-    const showModal = vi.fn(async () => undefined);
-    await interactionCreate({
-      id: 'i-working-dir',
-      customId: 'nexus:settings:working-dir',
-      channelId: 'C1',
-      guildId: 'G-dev',
-      createdAt: new Date(123),
-      user: { id: OTHER_ID, username: 'alice', bot: false },
-      member: { roles: { cache: new Map() } },
-      channel: { isThread: () => false },
-      deferReply,
-      showModal,
-      isChatInputCommand: () => false,
-      isStringSelectMenu: () => false,
-      isButton: () => true,
-      isModalSubmit: () => false,
-    });
-
-    expect(deferReply).not.toHaveBeenCalled();
-    expect(showModal).toHaveBeenCalledWith({
+    const handler = vi.fn(async () => undefined);
+    const expectedModal = {
       custom_id: 'nexus:settings:working-dir-modal',
       title: 'Set working directory',
       components: [
@@ -568,7 +550,45 @@ describe('command registry integration', () => {
           ],
         },
       ],
-    });
+    };
+
+    await platform.start(handler);
+    const interactionCreate = registeredHandler('interactionCreate');
+    const deferReply = vi.fn(async () => undefined);
+    const showModal = vi.fn(async () => undefined);
+    const interactionPromise = Promise.resolve(
+      interactionCreate({
+        id: 'i-working-dir',
+        applicationId: 'app-1',
+        token: 'interaction-token',
+        type: 3,
+        data: {
+          component_type: 2,
+          custom_id: 'nexus:settings:working-dir',
+        },
+        customId: 'nexus:settings:working-dir',
+        channelId: 'C1',
+        guildId: 'G-dev',
+        createdAt: new Date(123),
+        user: { id: OTHER_ID, username: 'alice', bot: false },
+        member: { roles: { cache: new Map() } },
+        channel: { isThread: () => false },
+        deferReply,
+        showModal,
+        isChatInputCommand: () => false,
+        isStringSelectMenu: () => false,
+        isButton: () => true,
+        isModalSubmit: () => false,
+      }),
+    );
+    await Promise.resolve();
+    const modalCallsBeforeHandlerSettles = showModal.mock.calls.length;
+    await interactionPromise;
+
+    expect(deferReply).not.toHaveBeenCalled();
+    expect(modalCallsBeforeHandlerSettles).toBe(1);
+    expect(showModal).toHaveBeenCalledWith(expectedModal);
+    expect(handler).not.toHaveBeenCalled();
   });
 
   it('modal submit 转成 normalized interaction fields 并展示 handler 反馈', async () => {
@@ -593,6 +613,24 @@ describe('command registry integration', () => {
     const editReply = vi.fn(async () => undefined);
     await interactionCreate({
       id: 'i-modal',
+      applicationId: 'app-1',
+      token: 'interaction-token',
+      type: 5,
+      data: {
+        custom_id: 'nexus:settings:working-dir-modal',
+        components: [
+          {
+            type: 1,
+            components: [
+              {
+                type: 4,
+                custom_id: 'path',
+                value: '/tmp/app',
+              },
+            ],
+          },
+        ],
+      },
       customId: 'nexus:settings:working-dir-modal',
       channelId: 'C1',
       guildId: 'G-dev',
@@ -626,6 +664,25 @@ describe('command registry integration', () => {
         },
       }),
     );
+    expect(handler.mock.calls[0]![0].rawPayload).toMatchObject({
+      type: 5,
+      data: {
+        custom_id: 'nexus:settings:working-dir-modal',
+        components: [
+          {
+            type: 1,
+            components: [
+              {
+                type: 4,
+                custom_id: 'path',
+                value: '/tmp/app',
+              },
+            ],
+          },
+        ],
+      },
+      token: 'interaction-token',
+    });
     expect(editReply).toHaveBeenCalledWith({
       content: '[channel workingDir: /tmp/app]',
     });
@@ -1229,6 +1286,53 @@ describe('edit / typing capabilities', () => {
       }),
     ).rejects.toThrow('missing access');
     expect(cleanup).toHaveBeenCalledWith('agent-nexus thread setup failed');
+  });
+
+  it('createThread keeps the created thread when only the initial message fails', async () => {
+    const logger = makeLogger();
+    const cleanup = vi.fn(async () => undefined);
+    const initialMessageErr = new Error('missing send permission');
+    const create = vi.fn(async () => ({
+      id: 'T1',
+      guildId: 'G1',
+      members: { add: vi.fn(async () => undefined) },
+      send: vi.fn(async () => Promise.reject(initialMessageErr)),
+      delete: cleanup,
+    }));
+    discordMock.channelsFetch.mockResolvedValueOnce(makeThreadParentChannel({ create }));
+    const platform = createDiscordPlatform({
+      token: 'test-token',
+      botUserId: BOT_ID,
+      logger,
+      statePath: '/tmp/agent-nexus-discord-state-test.json',
+      allowedUserIds: ALLOWED,
+    });
+
+    await expect(
+      platform.createThread!({
+        parentChannelId: 'C1',
+        initiatorUserId: OTHER_ID,
+        title: 'Design auth flow',
+        visibility: 'private',
+        autoArchiveDurationMinutes: 1440,
+        initialMessage: '[new Nexus session: Design auth flow]',
+        traceId: 't-1',
+      }),
+    ).resolves.toEqual({
+      threadId: 'T1',
+      parentChannelId: 'C1',
+      setupWarnings: [{ code: 'initial_message_failed' }],
+      url: 'https://discord.com/channels/G1/T1',
+    });
+    expect(cleanup).not.toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalledWith(
+      {
+        traceId: 't-1',
+        threadId: 'T1',
+        err: initialMessageErr,
+      },
+      'discord_thread_initial_message_failed',
+    );
   });
 
   it('updateThread renames the Discord thread', async () => {

--- a/packages/platform/discord/src/index.test.ts
+++ b/packages/platform/discord/src/index.test.ts
@@ -383,8 +383,8 @@ describe('command registry integration', () => {
         ephemeral: true,
         components: [
           {
-            type: 'string-select' as const,
-            customId: 'nexus:sessions:resume',
+            type: 'select' as const,
+            componentId: 'nexus:sessions:resume',
             placeholder: 'Resume session',
             options: [
               {
@@ -495,8 +495,8 @@ describe('command registry integration', () => {
       platform: 'discord',
       type: 'interaction',
       interaction: {
-        customId: 'nexus:sessions:resume',
-        componentType: 'string-select',
+        componentId: 'nexus:sessions:resume',
+        kind: 'select',
         values: ['mem-1'],
       },
       sessionKey: {
@@ -657,10 +657,9 @@ describe('command registry integration', () => {
       expect.objectContaining({
         type: 'interaction',
         interaction: {
-          customId: 'nexus:settings:working-dir-modal',
-          componentType: 'modal-submit',
-          values: [],
-          fields: { path: '/tmp/app' },
+          componentId: 'nexus:settings:working-dir-modal',
+          kind: 'modal_submit',
+          values: ['path=/tmp/app'],
         },
       }),
     );

--- a/packages/platform/discord/src/index.test.ts
+++ b/packages/platform/discord/src/index.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { ApplicationCommandOptionType, type Message } from 'discord.js';
+import { readFile, rm } from 'node:fs/promises';
+import { ApplicationCommandOptionType, ChannelType, type Message } from 'discord.js';
 import {
   buildBotMentionRegex,
   buildSlices,
@@ -84,6 +85,7 @@ function makeMsg(overrides: {
   roleIds?: string[];
   id?: string;
   system?: boolean;
+  channel?: unknown;
 }): Message {
   const {
     content,
@@ -95,6 +97,7 @@ function makeMsg(overrides: {
     roleIds = [],
     id = 'm-1',
     system = false,
+    channel,
   } = overrides;
   // 只构造测试覆盖路径需要的字段；rawPayload 直接挂整个 mock。
   return {
@@ -114,6 +117,7 @@ function makeMsg(overrides: {
         cache: new Map(roleIds.map((roleId) => [roleId, { id: roleId }])),
       },
     },
+    ...(channel ? { channel } : {}),
   } as unknown as Message;
 }
 
@@ -235,6 +239,7 @@ describe('command registry integration', () => {
       createdAt: new Date(123),
       user: { id: OTHER_ID, username: 'alice', bot: false },
       member: { roles: { cache: new Map([['R1', { id: 'R1' }]]) } },
+      channel: { isThread: () => false },
       options: {
         data: [
           {
@@ -285,6 +290,41 @@ describe('command registry integration', () => {
     expect(event.traceId).toBeTruthy();
   });
 
+  it('thread slash command event carries the parent channel id', async () => {
+    const platform = createDiscordPlatform({
+      token: 'test-token',
+      botUserId: BOT_ID,
+      logger: makeLogger(),
+      statePath: '/tmp/agent-nexus-discord-state-test.json',
+      allowedUserIds: ALLOWED,
+      testGuildId: 'G-dev',
+    });
+    const handler = vi.fn(async () => undefined);
+
+    await platform.start(handler);
+    const interactionCreate = registeredHandler('interactionCreate');
+    await interactionCreate({
+      id: 'i-thread-command',
+      commandName: 'new',
+      channelId: 'T1',
+      guildId: 'G-dev',
+      createdAt: new Date(123),
+      user: { id: OTHER_ID, username: 'alice', bot: false },
+      member: { roles: { cache: new Map() } },
+      channel: { isThread: () => true, parentId: 'C1' },
+      options: { data: [] },
+      deferReply: vi.fn(async () => undefined),
+      deleteReply: vi.fn(async () => undefined),
+      editReply: vi.fn(async () => undefined),
+      isChatInputCommand: () => true,
+    });
+
+    expect(handler.mock.calls[0]![0]).toMatchObject({
+      sessionKey: { channelId: 'T1' },
+      threadParentChannelId: 'C1',
+    });
+  });
+
   it('daemon 返回 commandResponse 时用 deferred ephemeral reply 展示反馈', async () => {
     const platform = createDiscordPlatform({
       token: 'test-token',
@@ -326,6 +366,350 @@ describe('command registry integration', () => {
       content: 'This command is not available in this channel.',
     });
     expect(deleteReply).not.toHaveBeenCalled();
+  });
+
+  it('daemon commandResponse 带 components 时传给 Discord deferred reply', async () => {
+    const platform = createDiscordPlatform({
+      token: 'test-token',
+      botUserId: BOT_ID,
+      logger: makeLogger(),
+      statePath: '/tmp/agent-nexus-discord-state-test.json',
+      allowedUserIds: ALLOWED,
+      testGuildId: 'G-dev',
+    });
+    const handler = vi.fn(async () => ({
+      commandResponse: {
+        text: 'Select a session to resume.',
+        ephemeral: true,
+        components: [
+          {
+            type: 'string-select' as const,
+            customId: 'nexus:sessions:resume',
+            placeholder: 'Resume session',
+            options: [
+              {
+                label: 'C-old',
+                value: 'mem-1',
+                description: 'sid-old',
+              },
+            ],
+          },
+        ],
+      },
+    }));
+
+    await platform.start(handler);
+    const interactionCreate = registeredHandler('interactionCreate');
+    const editReply = vi.fn(async () => undefined);
+    await interactionCreate({
+      id: 'i-components',
+      commandName: 'nexus-sessions',
+      channelId: 'C1',
+      guildId: 'G-dev',
+      createdAt: new Date(123),
+      user: { id: OTHER_ID, username: 'alice', bot: false },
+      member: { roles: { cache: new Map() } },
+      options: { data: [] },
+      deferReply: vi.fn(async () => undefined),
+      deleteReply: vi.fn(async () => undefined),
+      editReply,
+      isChatInputCommand: () => true,
+    });
+
+    expect(editReply).toHaveBeenCalledWith({
+      content: 'Select a session to resume.',
+      components: [
+        {
+          type: 1,
+          components: [
+            {
+              type: 3,
+              custom_id: 'nexus:sessions:resume',
+              placeholder: 'Resume session',
+              options: [
+                {
+                  label: 'C-old',
+                  value: 'mem-1',
+                  description: 'sid-old',
+                },
+              ],
+              min_values: 1,
+              max_values: 1,
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('string select component interaction 转成 normalized interaction event 并展示 handler 反馈', async () => {
+    const platform = createDiscordPlatform({
+      token: 'test-token',
+      botUserId: BOT_ID,
+      logger: makeLogger(),
+      statePath: '/tmp/agent-nexus-discord-state-test.json',
+      allowedUserIds: ALLOWED,
+      testGuildId: 'G-dev',
+    });
+    const handler = vi.fn(async () => ({
+      commandResponse: {
+        text: '[session resumed: sid-old]',
+        ephemeral: true,
+      },
+    }));
+
+    await platform.start(handler);
+    const interactionCreate = registeredHandler('interactionCreate');
+    const deferReply = vi.fn(async () => undefined);
+    const editReply = vi.fn(async () => undefined);
+    await interactionCreate({
+      id: 'i-select',
+      customId: 'nexus:sessions:resume',
+      values: ['mem-1'],
+      channelId: 'C1',
+      guildId: 'G-dev',
+      createdAt: new Date(123),
+      user: { id: OTHER_ID, username: 'alice', bot: false },
+      member: { roles: { cache: new Map([['R1', { id: 'R1' }]]) } },
+      channel: { isThread: () => true, parentId: 'C1' },
+      deferReply,
+      editReply,
+      isChatInputCommand: () => false,
+      isStringSelectMenu: () => true,
+      isButton: () => false,
+    });
+
+    expect(deferReply).toHaveBeenCalledWith({ ephemeral: true });
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler.mock.calls[0]![0]).toMatchObject({
+      eventId: 'i-select',
+      platform: 'discord',
+      type: 'interaction',
+      interaction: {
+        customId: 'nexus:sessions:resume',
+        componentType: 'string-select',
+        values: ['mem-1'],
+      },
+      sessionKey: {
+        platform: 'discord',
+        channelId: 'C1',
+        initiatorUserId: OTHER_ID,
+      },
+      guildId: 'G-dev',
+      initiatorRoleIds: ['R1'],
+      threadParentChannelId: 'C1',
+      rawContentType: 'discord:component-interaction',
+    });
+    expect(editReply).toHaveBeenCalledWith({
+      content: '[session resumed: sid-old]',
+    });
+  });
+
+  it('settings workingDir button can open a Discord modal before defer', async () => {
+    const platform = createDiscordPlatform({
+      token: 'test-token',
+      botUserId: BOT_ID,
+      logger: makeLogger(),
+      statePath: '/tmp/agent-nexus-discord-state-test.json',
+      allowedUserIds: ALLOWED,
+      testGuildId: 'G-dev',
+    });
+    const handler = vi.fn(async () => ({
+      modalResponse: {
+        customId: 'nexus:settings:working-dir-modal',
+        title: 'Set working directory',
+        textInputs: [
+          {
+            customId: 'path',
+            label: 'Absolute path',
+            style: 'short' as const,
+            required: true,
+          },
+        ],
+      },
+    }));
+
+    await platform.start(handler);
+    const interactionCreate = registeredHandler('interactionCreate');
+    const deferReply = vi.fn(async () => undefined);
+    const showModal = vi.fn(async () => undefined);
+    await interactionCreate({
+      id: 'i-working-dir',
+      customId: 'nexus:settings:working-dir',
+      channelId: 'C1',
+      guildId: 'G-dev',
+      createdAt: new Date(123),
+      user: { id: OTHER_ID, username: 'alice', bot: false },
+      member: { roles: { cache: new Map() } },
+      channel: { isThread: () => false },
+      deferReply,
+      showModal,
+      isChatInputCommand: () => false,
+      isStringSelectMenu: () => false,
+      isButton: () => true,
+      isModalSubmit: () => false,
+    });
+
+    expect(deferReply).not.toHaveBeenCalled();
+    expect(showModal).toHaveBeenCalledWith({
+      custom_id: 'nexus:settings:working-dir-modal',
+      title: 'Set working directory',
+      components: [
+        {
+          type: 1,
+          components: [
+            {
+              type: 4,
+              custom_id: 'path',
+              label: 'Absolute path',
+              style: 1,
+              required: true,
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('modal submit 转成 normalized interaction fields 并展示 handler 反馈', async () => {
+    const platform = createDiscordPlatform({
+      token: 'test-token',
+      botUserId: BOT_ID,
+      logger: makeLogger(),
+      statePath: '/tmp/agent-nexus-discord-state-test.json',
+      allowedUserIds: ALLOWED,
+      testGuildId: 'G-dev',
+    });
+    const handler = vi.fn(async () => ({
+      commandResponse: {
+        text: '[channel workingDir: /tmp/app]',
+        ephemeral: true,
+      },
+    }));
+
+    await platform.start(handler);
+    const interactionCreate = registeredHandler('interactionCreate');
+    const deferReply = vi.fn(async () => undefined);
+    const editReply = vi.fn(async () => undefined);
+    await interactionCreate({
+      id: 'i-modal',
+      customId: 'nexus:settings:working-dir-modal',
+      channelId: 'C1',
+      guildId: 'G-dev',
+      createdAt: new Date(123),
+      user: { id: OTHER_ID, username: 'alice', bot: false },
+      member: { roles: { cache: new Map() } },
+      channel: { isThread: () => false },
+      fields: {
+        fields: new Map([['path', { customId: 'path' }]]),
+        getTextInputValue: vi.fn((customId: string) =>
+          customId === 'path' ? '/tmp/app' : '',
+        ),
+      },
+      deferReply,
+      editReply,
+      isChatInputCommand: () => false,
+      isStringSelectMenu: () => false,
+      isButton: () => false,
+      isModalSubmit: () => true,
+    });
+
+    expect(deferReply).toHaveBeenCalledWith({ ephemeral: true });
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'interaction',
+        interaction: {
+          customId: 'nexus:settings:working-dir-modal',
+          componentType: 'modal-submit',
+          values: [],
+          fields: { path: '/tmp/app' },
+        },
+      }),
+    );
+    expect(editReply).toHaveBeenCalledWith({
+      content: '[channel workingDir: /tmp/app]',
+    });
+  });
+
+  it('settingsSnapshot exposes reply-mode with user-scoped permission', async () => {
+    const statePath = '/tmp/agent-nexus-discord-settings-snapshot-test.json';
+    await rm(statePath, { force: true });
+    const platform = createDiscordPlatform({
+      token: 'test-token',
+      botUserId: BOT_ID,
+      logger: makeLogger(),
+      statePath,
+      allowedUserIds: [OTHER_ID],
+      testGuildId: 'G-dev',
+    });
+
+    await platform.start(vi.fn());
+
+    expect(
+      await platform.settingsSnapshot!({ userId: OTHER_ID, channelId: 'C1' }),
+    ).toEqual({
+      items: [
+        {
+          key: 'discord.replyMode',
+          label: 'Reply mode',
+          owner: 'platform',
+          value: 'mention',
+          source: 'discord state',
+          durability: 'durable',
+          canChange: true,
+        },
+      ],
+    });
+    expect(
+      await platform.settingsSnapshot!({ userId: 'U-denied', channelId: 'C1' }),
+    ).toMatchObject({
+      items: [
+        {
+          key: 'discord.replyMode',
+          canChange: false,
+        },
+      ],
+    });
+  });
+
+  it('applySettingsAction changes reply-mode through the Discord owner state', async () => {
+    const statePath = '/tmp/agent-nexus-discord-settings-action-test.json';
+    await rm(statePath, { force: true });
+    const platform = createDiscordPlatform({
+      token: 'test-token',
+      botUserId: BOT_ID,
+      logger: makeLogger(),
+      statePath,
+      allowedUserIds: [OTHER_ID],
+      testGuildId: 'G-dev',
+    });
+
+    await platform.start(vi.fn());
+    const result = await platform.applySettingsAction!({
+      action: 'discord.replyMode',
+      value: 'all',
+      userId: OTHER_ID,
+      channelId: 'C1',
+    });
+
+    expect(result).toEqual({
+      status: 'handled',
+      message: 'reply mode: `mention` -> `all`',
+    });
+    expect(
+      await platform.settingsSnapshot!({ userId: OTHER_ID, channelId: 'C1' }),
+    ).toMatchObject({
+      items: [
+        {
+          key: 'discord.replyMode',
+          value: 'all',
+          canChange: true,
+        },
+      ],
+    });
+    expect(JSON.parse(await readFile(statePath, 'utf8'))).toEqual({
+      replyMode: 'all',
+    });
   });
 
   it('command registration plan 存在时用 plan scope 构造 command event', async () => {
@@ -605,6 +989,26 @@ function makeTextChannel(overrides: {
   };
 }
 
+function makeThreadParentChannel(overrides: {
+  create?: ReturnType<typeof vi.fn>;
+} = {}) {
+  return {
+    isTextBased: () => true,
+    isSendable: () => true,
+    threads: {
+      create:
+        overrides.create ??
+        vi.fn(async () => ({
+          id: 'T1',
+          guildId: 'G1',
+          members: { add: vi.fn(async () => undefined) },
+          send: vi.fn(async () => ({ id: 'm-thread' })),
+          delete: vi.fn(async () => undefined),
+        })),
+    },
+  };
+}
+
 describe('buildSlices', () => {
   it('empty string → single-element [""] (guarantees at least one message)', () => {
     expect(buildSlices('')).toEqual(['']);
@@ -755,7 +1159,95 @@ describe('edit / typing capabilities', () => {
       supportsEdit: true,
       supportsTypingIndicator: true,
       supportsSlashCommands: true,
+      supportsThreads: true,
+      supportsThreadCreation: true,
     });
+  });
+
+  it('createThread creates a private thread, adds the user, and posts the initial message', async () => {
+    const memberAdd = vi.fn(async () => undefined);
+    const send = vi.fn(async () => ({ id: 'm-thread' }));
+    const create = vi.fn(async () => ({
+      id: 'T1',
+      guildId: 'G1',
+      members: { add: memberAdd },
+      send,
+      delete: vi.fn(async () => undefined),
+    }));
+    discordMock.channelsFetch.mockResolvedValueOnce(makeThreadParentChannel({ create }));
+    const platform = makePlatform();
+
+    const result = await platform.createThread!({
+      parentChannelId: 'C1',
+      initiatorUserId: OTHER_ID,
+      title: 'Design auth flow',
+      visibility: 'private',
+      autoArchiveDurationMinutes: 1440,
+      initialMessage: '[new Nexus session: Design auth flow]',
+      traceId: 't-1',
+    });
+
+    expect(create).toHaveBeenCalledWith({
+      name: 'Design auth flow',
+      type: ChannelType.PrivateThread,
+      autoArchiveDuration: 1440,
+      invitable: false,
+      reason: 'agent-nexus new thread',
+    });
+    expect(memberAdd).toHaveBeenCalledWith(OTHER_ID);
+    expect(send).toHaveBeenCalledWith({
+      content: '[new Nexus session: Design auth flow]',
+      allowedMentions: { parse: [] },
+    });
+    expect(result).toEqual({
+      threadId: 'T1',
+      parentChannelId: 'C1',
+      url: 'https://discord.com/channels/G1/T1',
+    });
+  });
+
+  it('createThread deletes the created thread if member add fails', async () => {
+    const cleanup = vi.fn(async () => undefined);
+    const create = vi.fn(async () => ({
+      id: 'T1',
+      guildId: 'G1',
+      members: { add: vi.fn(async () => Promise.reject(new Error('missing access'))) },
+      send: vi.fn(async () => ({ id: 'm-thread' })),
+      delete: cleanup,
+    }));
+    discordMock.channelsFetch.mockResolvedValueOnce(makeThreadParentChannel({ create }));
+    const platform = makePlatform();
+
+    await expect(
+      platform.createThread!({
+        parentChannelId: 'C1',
+        initiatorUserId: OTHER_ID,
+        title: 'Design auth flow',
+        visibility: 'private',
+        autoArchiveDurationMinutes: 1440,
+        traceId: 't-1',
+      }),
+    ).rejects.toThrow('missing access');
+    expect(cleanup).toHaveBeenCalledWith('agent-nexus thread setup failed');
+  });
+
+  it('updateThread renames the Discord thread', async () => {
+    const setName = vi.fn(async () => undefined);
+    discordMock.channelsFetch.mockResolvedValueOnce({
+      setName,
+    });
+    const platform = makePlatform();
+
+    await platform.updateThread!({
+      threadId: 'T1',
+      title: 'First user message',
+      traceId: 't-1',
+    });
+
+    expect(setName).toHaveBeenCalledWith(
+      'First user message',
+      'agent-nexus session title',
+    );
   });
 
   it('edit 单片消息：用 MessageManager.edit 更新已有 message id', async () => {
@@ -1161,6 +1653,21 @@ describe('parseInbound', () => {
     expect(ev.platform).toBe('discord');
     expect(ev.type).toBe('message');
     expect(ev.messageId).toBe('m-1');
+  });
+
+  it('thread message carries parent channel id when Discord exposes it', () => {
+    const msg = makeMsg({
+      content: `<@${BOT_ID}> ping`,
+      channelId: 'T42',
+      channel: {
+        isThread: () => true,
+        parentId: 'C42',
+      },
+    });
+    const ev = expectEvent(parseInbound(msg, BOT_ID, ALLOWED));
+
+    expect(ev.sessionKey.channelId).toBe('T42');
+    expect(ev.threadParentChannelId).toBe('C42');
   });
 
   it('@bot summarise what @alice said → 保留 @alice，不剥别人 mention（修 #7）', () => {

--- a/packages/platform/discord/src/index.ts
+++ b/packages/platform/discord/src/index.ts
@@ -127,7 +127,8 @@ export const DISCORD_CAPABILITIES: CapabilitySet = {
   supportsReactions: false,
   supportsEmbeds: false,
   supportsButtons: true,
-  supportsStringSelects: true,
+  supportsSelects: true,
+  supportsModals: true,
   supportsThreads: true,
   supportsThreadCreation: true,
   supportsEphemeral: true,
@@ -265,9 +266,9 @@ function discordMessageThreadParentId(msg: Message): string | undefined {
 
 function discordComponentType(
   interaction: Interaction,
-): 'button' | 'string-select' | undefined {
+): 'button' | 'select' | undefined {
   if (interaction.isButton()) return 'button';
-  if (interaction.isStringSelectMenu()) return 'string-select';
+  if (interaction.isStringSelectMenu()) return 'select';
   return undefined;
 }
 
@@ -379,8 +380,8 @@ function componentEventFromInteraction(interaction: Interaction): NormalizedEven
     traceId: randomUUID(),
     type: 'interaction',
     interaction: {
-      customId: interaction.customId,
-      componentType,
+      componentId: interaction.customId,
+      kind: componentType,
       values: componentValues(interaction),
     },
     rawPayload: interaction,
@@ -420,7 +421,6 @@ function modalEventFromInteraction(interaction: Interaction): NormalizedEvent {
           field.customId,
           interaction.fields.getTextInputValue(field.customId),
         ]);
-  const fields = Object.fromEntries(fieldEntries);
   return {
     eventId: interaction.id,
     platform: 'discord',
@@ -432,10 +432,9 @@ function modalEventFromInteraction(interaction: Interaction): NormalizedEvent {
     traceId: randomUUID(),
     type: 'interaction',
     interaction: {
-      customId: interaction.customId,
-      componentType: 'modal-submit',
-      values: [],
-      fields,
+      componentId: interaction.customId,
+      kind: 'modal_submit',
+      values: fieldEntries.map(([componentId, value]) => `${componentId}=${value}`),
     },
     rawPayload: interaction,
     rawContentType: 'discord:modal-submit',
@@ -456,7 +455,6 @@ function discordButtonStyle(
   style: Extract<MessageComponent, { type: 'button' }>['style'],
 ): number {
   if (style === 'primary') return 1;
-  if (style === 'success') return 3;
   if (style === 'danger') return 4;
   return 2;
 }
@@ -476,7 +474,7 @@ function discordMessageComponents(
     if (component.type === 'button') {
       buttonRow.push({
         type: 2,
-        custom_id: component.customId,
+        custom_id: component.componentId,
         label: component.label,
         style: discordButtonStyle(component.style),
         ...(component.disabled !== undefined
@@ -492,7 +490,7 @@ function discordMessageComponents(
       components: [
         {
           type: 3,
-          custom_id: component.customId,
+          custom_id: component.componentId,
           ...(component.placeholder ? { placeholder: component.placeholder } : {}),
           options: component.options.map((option) => ({
             label: option.label,
@@ -515,16 +513,16 @@ function discordMessageComponents(
 
 function discordModal(response: EventModalResponse): unknown {
   return {
-    custom_id: response.customId,
+    custom_id: response.modalId,
     title: response.title,
-    components: response.textInputs.slice(0, 5).map((input) => ({
+    components: response.inputs.slice(0, 5).map((input) => ({
       type: 1,
       components: [
         {
           type: 4,
-          custom_id: input.customId,
+          custom_id: input.componentId,
           label: input.label,
-          style: input.style === 'paragraph' ? 2 : 1,
+          style: input.kind === 'long_text' ? 2 : 1,
           required: input.required ?? true,
           ...(input.placeholder ? { placeholder: input.placeholder } : {}),
           ...(input.value ? { value: input.value } : {}),
@@ -540,13 +538,13 @@ function immediateModalForComponent(
   if (!interaction.isButton()) return undefined;
   if (interaction.customId === 'nexus:settings:working-dir') {
     return {
-      customId: 'nexus:settings:working-dir-modal',
+      modalId: 'nexus:settings:working-dir-modal',
       title: 'Set working directory',
-      textInputs: [
+      inputs: [
         {
-          customId: 'path',
+          componentId: 'path',
           label: 'Absolute path',
-          style: 'short',
+          kind: 'short_text',
           required: true,
         },
       ],
@@ -554,13 +552,13 @@ function immediateModalForComponent(
   }
   if (interaction.customId === 'nexus:queue:insert') {
     return {
-      customId: 'nexus:queue:insert-modal',
+      modalId: 'nexus:queue:insert-modal',
       title: 'Insert queued message',
-      textInputs: [
+      inputs: [
         {
-          customId: 'text',
+          componentId: 'text',
           label: 'Message',
-          style: 'paragraph',
+          kind: 'long_text',
           required: true,
         },
       ],
@@ -569,13 +567,13 @@ function immediateModalForComponent(
   if (interaction.customId.startsWith('nexus:queue:edit:')) {
     const queueItemId = interaction.customId.slice('nexus:queue:edit:'.length);
     return {
-      customId: `nexus:queue:edit-modal:${queueItemId}`,
+      modalId: `nexus:queue:edit-modal:${queueItemId}`,
       title: 'Edit queued message',
-      textInputs: [
+      inputs: [
         {
-          customId: 'text',
+          componentId: 'text',
           label: 'Message',
-          style: 'paragraph',
+          kind: 'long_text',
           required: true,
         },
       ],
@@ -977,7 +975,7 @@ export function createDiscordPlatform(opts: DiscordPlatformOptions): DiscordPlat
             await completeDeferredCommandReply(interaction, logger, event, result);
           } catch (err) {
             logger.error(
-              { err, traceId: event.traceId, customId: event.interaction?.customId },
+              { err, traceId: event.traceId, componentId: event.interaction?.componentId },
               'platform_handler_error',
             );
             await markDeferredCommandFailed(interaction, logger, event);
@@ -1017,7 +1015,7 @@ export function createDiscordPlatform(opts: DiscordPlatformOptions): DiscordPlat
             await completeDeferredCommandReply(interaction, logger, event, result);
           } catch (err) {
             logger.error(
-              { err, traceId: event.traceId, customId: event.interaction?.customId },
+              { err, traceId: event.traceId, componentId: event.interaction?.componentId },
               'platform_handler_error',
             );
             await markDeferredCommandFailed(interaction, logger, event);
@@ -1223,7 +1221,7 @@ export function createDiscordPlatform(opts: DiscordPlatformOptions): DiscordPlat
         create(options: {
           name: string;
           type: ChannelType.PrivateThread | ChannelType.PublicThread;
-          autoArchiveDuration: number;
+          autoArchiveDuration?: number;
           invitable?: boolean;
           reason?: string;
         }): Promise<{

--- a/packages/platform/discord/src/index.ts
+++ b/packages/platform/discord/src/index.ts
@@ -36,6 +36,7 @@ import type {
   CommandRegistrationResult,
   CommandRegistrationScope,
   CreateThreadInput,
+  CreateThreadResult,
   EventHandler,
   EventHandlerResult,
   EventModalResponse,
@@ -533,13 +534,54 @@ function discordModal(response: EventModalResponse): unknown {
   };
 }
 
-function shouldHandleComponentBeforeDefer(interaction: Interaction): boolean {
-  if (!interaction.isButton()) return false;
-  return (
-    interaction.customId === 'nexus:settings:working-dir' ||
-    interaction.customId === 'nexus:queue:insert' ||
-    interaction.customId.startsWith('nexus:queue:edit:')
-  );
+function immediateModalForComponent(
+  interaction: Interaction,
+): EventModalResponse | undefined {
+  if (!interaction.isButton()) return undefined;
+  if (interaction.customId === 'nexus:settings:working-dir') {
+    return {
+      customId: 'nexus:settings:working-dir-modal',
+      title: 'Set working directory',
+      textInputs: [
+        {
+          customId: 'path',
+          label: 'Absolute path',
+          style: 'short',
+          required: true,
+        },
+      ],
+    };
+  }
+  if (interaction.customId === 'nexus:queue:insert') {
+    return {
+      customId: 'nexus:queue:insert-modal',
+      title: 'Insert queued message',
+      textInputs: [
+        {
+          customId: 'text',
+          label: 'Message',
+          style: 'paragraph',
+          required: true,
+        },
+      ],
+    };
+  }
+  if (interaction.customId.startsWith('nexus:queue:edit:')) {
+    const queueItemId = interaction.customId.slice('nexus:queue:edit:'.length);
+    return {
+      customId: `nexus:queue:edit-modal:${queueItemId}`,
+      title: 'Edit queued message',
+      textInputs: [
+        {
+          customId: 'text',
+          label: 'Message',
+          style: 'paragraph',
+          required: true,
+        },
+      ],
+    };
+  }
+  return undefined;
 }
 
 interface DeferredInteraction {
@@ -944,41 +986,19 @@ export function createDiscordPlatform(opts: DiscordPlatformOptions): DiscordPlat
         }
         if (!interaction.isChatInputCommand()) {
           if (!interaction.isButton() && !interaction.isStringSelectMenu()) return;
-          if (shouldHandleComponentBeforeDefer(interaction)) {
-            const event = componentEventFromInteraction(interaction);
+          const immediateModal = immediateModalForComponent(interaction);
+          if (immediateModal) {
             try {
-              const result = await handler(event);
-              if (result?.modalResponse) {
-                await interaction.showModal(
-                  discordModal(result.modalResponse) as Parameters<
-                    typeof interaction.showModal
-                  >[0],
-                );
-                return;
-              }
-              await interaction.reply({
-                content: result?.commandResponse?.text ?? 'Command failed.',
-                ephemeral: true,
-                ...(result?.commandResponse?.components
-                  ? { components: discordMessageComponents(result.commandResponse.components) }
-                  : {}),
-              } as Parameters<typeof interaction.reply>[0]);
+              await interaction.showModal(
+                discordModal(immediateModal) as Parameters<
+                  typeof interaction.showModal
+                >[0],
+              );
             } catch (err) {
               logger.error(
-                { err, traceId: event.traceId, customId: event.interaction?.customId },
-                'platform_handler_error',
+                { err, interactionId: interaction.id, customId: interaction.customId },
+                'discord_component_modal_ack_failed',
               );
-              try {
-                await interaction.reply({
-                  content: 'Command failed. Try again later.',
-                  ephemeral: true,
-                });
-              } catch (replyErr) {
-                logger.error(
-                  { err: replyErr, customId: interaction.customId },
-                  'discord_component_error_reply_failed',
-                );
-              }
             }
             return;
           }
@@ -1227,12 +1247,6 @@ export function createDiscordPlatform(opts: DiscordPlatformOptions): DiscordPlat
       });
       try {
         await thread.members.add(input.initiatorUserId);
-        if (input.initialMessage) {
-          await thread.send({
-            content: input.initialMessage,
-            allowedMentions: { parse: [] },
-          });
-        }
       } catch (err) {
         try {
           if (thread.delete) {
@@ -1252,9 +1266,29 @@ export function createDiscordPlatform(opts: DiscordPlatformOptions): DiscordPlat
         }
         throw err;
       }
+      const setupWarnings: CreateThreadResult['setupWarnings'] = [];
+      if (input.initialMessage) {
+        try {
+          await thread.send({
+            content: input.initialMessage,
+            allowedMentions: { parse: [] },
+          });
+        } catch (err) {
+          setupWarnings.push({ code: 'initial_message_failed' });
+          logger.error(
+            {
+              traceId: input.traceId,
+              threadId: thread.id,
+              err,
+            },
+            'discord_thread_initial_message_failed',
+          );
+        }
+      }
       return {
         threadId: thread.id,
         parentChannelId: input.parentChannelId,
+        ...(setupWarnings.length > 0 ? { setupWarnings } : {}),
         ...(thread.guildId
           ? { url: `https://discord.com/channels/${thread.guildId}/${thread.id}` }
           : {}),

--- a/packages/platform/discord/src/index.ts
+++ b/packages/platform/discord/src/index.ts
@@ -18,10 +18,10 @@ export { discordReplyModeCommandDescriptor } from './reply-mode.js';
 // - DM 消息（intents 没开 DirectMessages）
 // - 长文本切片保留代码块边界 → docs/dev/spec/message-protocol.md §文本切片
 // - delete / react → spec/platform-adapter.md 各对应段
-// - threads → 同上
 
 import { randomUUID } from 'node:crypto';
 import {
+  ChannelType,
   Client,
   GatewayIntentBits,
   type ChatInputCommandInteraction,
@@ -35,14 +35,18 @@ import type {
   CommandRegistrationPort,
   CommandRegistrationResult,
   CommandRegistrationScope,
+  CreateThreadInput,
   EventHandler,
   EventHandlerResult,
+  EventModalResponse,
+  MessageComponent,
   MessageRef,
   NormalizedEvent,
   OutboundMessage,
   PlatformSessionKey,
   PlatformAdapter,
   SessionKey,
+  UpdateThreadInput,
 } from '@agent-nexus/protocol';
 import type { Logger } from '@agent-nexus/daemon';
 import {
@@ -121,8 +125,10 @@ export const DISCORD_CAPABILITIES: CapabilitySet = {
   supportsDelete: false,
   supportsReactions: false,
   supportsEmbeds: false,
-  supportsButtons: false,
-  supportsThreads: false,
+  supportsButtons: true,
+  supportsStringSelects: true,
+  supportsThreads: true,
+  supportsThreadCreation: true,
   supportsEphemeral: true,
   supportsAttachments: false,
   maxAttachmentsPerMessage: 0,
@@ -219,14 +225,53 @@ function discordMemberRoleIds(msg: Message): string[] {
   return [...cache.keys()];
 }
 
-function discordInteractionRoleIds(interaction: ChatInputCommandInteraction): string[] {
-  const roles = interaction.member?.roles;
+function discordInteractionRoleIds(interaction: { member?: unknown }): string[] {
+  const member = interaction.member;
+  const roles =
+    member && typeof member === 'object' && 'roles' in member
+      ? member.roles
+      : undefined;
   if (Array.isArray(roles)) return roles;
   const cache =
     roles && typeof roles === 'object' && 'cache' in roles
       ? roles.cache
       : undefined;
-  if (cache && typeof cache.keys === 'function') return [...cache.keys()];
+  if (
+    cache &&
+    typeof cache === 'object' &&
+    'keys' in cache &&
+    typeof cache.keys === 'function'
+  ) {
+    return [...cache.keys()] as string[];
+  }
+  return [];
+}
+
+function discordChannelThreadParentId(channel: unknown): string | undefined {
+  if (!channel || typeof channel !== 'object') return undefined;
+  const isThread =
+    'isThread' in channel && typeof channel.isThread === 'function'
+      ? channel.isThread()
+      : false;
+  if (!isThread) return undefined;
+  const parentId = 'parentId' in channel ? channel.parentId : undefined;
+  return typeof parentId === 'string' ? parentId : undefined;
+}
+
+function discordMessageThreadParentId(msg: Message): string | undefined {
+  return discordChannelThreadParentId(msg.channel);
+}
+
+function discordComponentType(
+  interaction: Interaction,
+): 'button' | 'string-select' | undefined {
+  if (interaction.isButton()) return 'button';
+  if (interaction.isStringSelectMenu()) return 'string-select';
+  return undefined;
+}
+
+function componentValues(interaction: Interaction): string[] {
+  if (interaction.isStringSelectMenu()) return interaction.values;
   return [];
 }
 
@@ -284,6 +329,7 @@ function commandEventFromInteraction(
   interaction: ChatInputCommandInteraction,
   scope: CommandRegistrationScope,
 ): NormalizedEvent {
+  const threadParentChannelId = discordChannelThreadParentId(interaction.channel);
   return {
     eventId: interaction.id,
     platform: 'discord',
@@ -305,12 +351,203 @@ function commandEventFromInteraction(
     platformTimestamp: interaction.createdAt,
     ...(interaction.guildId ? { guildId: interaction.guildId } : {}),
     initiatorRoleIds: discordInteractionRoleIds(interaction),
+    ...(threadParentChannelId ? { threadParentChannelId } : {}),
     initiator: {
       userId: interaction.user.id,
       displayName: interaction.user.username,
       isBot: interaction.user.bot,
     },
   };
+}
+
+function componentEventFromInteraction(interaction: Interaction): NormalizedEvent {
+  if (!interaction.isButton() && !interaction.isStringSelectMenu()) {
+    throw new Error('unsupported component interaction');
+  }
+  const componentType = discordComponentType(interaction);
+  if (!componentType) throw new Error('unsupported component interaction');
+  const threadParentChannelId = discordChannelThreadParentId(interaction.channel);
+  return {
+    eventId: interaction.id,
+    platform: 'discord',
+    sessionKey: {
+      platform: 'discord',
+      channelId: interaction.channelId,
+      initiatorUserId: interaction.user.id,
+    },
+    traceId: randomUUID(),
+    type: 'interaction',
+    interaction: {
+      customId: interaction.customId,
+      componentType,
+      values: componentValues(interaction),
+    },
+    rawPayload: interaction,
+    rawContentType: 'discord:component-interaction',
+    receivedAt: new Date(),
+    platformTimestamp: interaction.createdAt,
+    ...(interaction.guildId ? { guildId: interaction.guildId } : {}),
+    initiatorRoleIds: discordInteractionRoleIds(interaction),
+    ...(threadParentChannelId ? { threadParentChannelId } : {}),
+    initiator: {
+      userId: interaction.user.id,
+      displayName: interaction.user.username,
+      isBot: interaction.user.bot,
+    },
+  };
+}
+
+function modalEventFromInteraction(interaction: Interaction): NormalizedEvent {
+  if (!interaction.isModalSubmit()) {
+    throw new Error('unsupported modal interaction');
+  }
+  if (!interaction.channelId) {
+    throw new Error('modal interaction missing channel id');
+  }
+  const threadParentChannelId = discordChannelThreadParentId(interaction.channel);
+  const modalFields = interaction.fields.fields as {
+    map?: <T>(fn: (field: { customId: string }) => T) => T[];
+    values?: () => Iterable<{ customId: string }>;
+  };
+  const fieldEntries =
+    typeof modalFields.map === 'function'
+      ? modalFields.map((field) => [
+          field.customId,
+          interaction.fields.getTextInputValue(field.customId),
+        ])
+      : [...(modalFields.values?.() ?? [])].map((field) => [
+          field.customId,
+          interaction.fields.getTextInputValue(field.customId),
+        ]);
+  const fields = Object.fromEntries(fieldEntries);
+  return {
+    eventId: interaction.id,
+    platform: 'discord',
+    sessionKey: {
+      platform: 'discord',
+      channelId: interaction.channelId,
+      initiatorUserId: interaction.user.id,
+    },
+    traceId: randomUUID(),
+    type: 'interaction',
+    interaction: {
+      customId: interaction.customId,
+      componentType: 'modal-submit',
+      values: [],
+      fields,
+    },
+    rawPayload: interaction,
+    rawContentType: 'discord:modal-submit',
+    receivedAt: new Date(),
+    platformTimestamp: interaction.createdAt,
+    ...(interaction.guildId ? { guildId: interaction.guildId } : {}),
+    initiatorRoleIds: discordInteractionRoleIds(interaction),
+    ...(threadParentChannelId ? { threadParentChannelId } : {}),
+    initiator: {
+      userId: interaction.user.id,
+      displayName: interaction.user.username,
+      isBot: interaction.user.bot,
+    },
+  };
+}
+
+function discordButtonStyle(
+  style: Extract<MessageComponent, { type: 'button' }>['style'],
+): number {
+  if (style === 'primary') return 1;
+  if (style === 'success') return 3;
+  if (style === 'danger') return 4;
+  return 2;
+}
+
+function discordMessageComponents(
+  components: readonly MessageComponent[] | undefined,
+): unknown[] | undefined {
+  if (!components || components.length === 0) return undefined;
+  const rows: unknown[] = [];
+  let buttonRow: unknown[] = [];
+  const flushButtons = (): void => {
+    if (buttonRow.length === 0) return;
+    rows.push({ type: 1, components: buttonRow });
+    buttonRow = [];
+  };
+  for (const component of components) {
+    if (component.type === 'button') {
+      buttonRow.push({
+        type: 2,
+        custom_id: component.customId,
+        label: component.label,
+        style: discordButtonStyle(component.style),
+        ...(component.disabled !== undefined
+          ? { disabled: component.disabled }
+          : {}),
+      });
+      if (buttonRow.length === 5) flushButtons();
+      continue;
+    }
+    flushButtons();
+    rows.push({
+      type: 1,
+      components: [
+        {
+          type: 3,
+          custom_id: component.customId,
+          ...(component.placeholder ? { placeholder: component.placeholder } : {}),
+          options: component.options.map((option) => ({
+            label: option.label,
+            value: option.value,
+            ...(option.description ? { description: option.description } : {}),
+            ...(option.default !== undefined ? { default: option.default } : {}),
+          })),
+          min_values: component.minValues ?? 1,
+          max_values: component.maxValues ?? 1,
+          ...(component.disabled !== undefined
+            ? { disabled: component.disabled }
+            : {}),
+        },
+      ],
+    });
+  }
+  flushButtons();
+  return rows;
+}
+
+function discordModal(response: EventModalResponse): unknown {
+  return {
+    custom_id: response.customId,
+    title: response.title,
+    components: response.textInputs.slice(0, 5).map((input) => ({
+      type: 1,
+      components: [
+        {
+          type: 4,
+          custom_id: input.customId,
+          label: input.label,
+          style: input.style === 'paragraph' ? 2 : 1,
+          required: input.required ?? true,
+          ...(input.placeholder ? { placeholder: input.placeholder } : {}),
+          ...(input.value ? { value: input.value } : {}),
+        },
+      ],
+    })),
+  };
+}
+
+function shouldHandleComponentBeforeDefer(interaction: Interaction): boolean {
+  if (!interaction.isButton()) return false;
+  return (
+    interaction.customId === 'nexus:settings:working-dir' ||
+    interaction.customId === 'nexus:queue:insert' ||
+    interaction.customId.startsWith('nexus:queue:edit:')
+  );
+}
+
+interface DeferredInteraction {
+  id: string;
+  commandName?: string;
+  customId?: string;
+  deleteReply(): Promise<unknown>;
+  editReply(message: unknown): Promise<unknown>;
 }
 
 async function deferCommandInteraction(
@@ -330,7 +567,7 @@ async function deferCommandInteraction(
 }
 
 async function deleteDeferredCommandReply(
-  interaction: ChatInputCommandInteraction,
+  interaction: DeferredInteraction,
   logger: Logger,
   event: NormalizedEvent,
 ): Promise<void> {
@@ -343,6 +580,7 @@ async function deleteDeferredCommandReply(
         traceId: event.traceId,
         interactionId: interaction.id,
         commandName: interaction.commandName,
+        customId: interaction.customId,
       },
       'discord_command_ack_cleanup_failed',
     );
@@ -350,14 +588,19 @@ async function deleteDeferredCommandReply(
 }
 
 async function completeDeferredCommandReply(
-  interaction: ChatInputCommandInteraction,
+  interaction: DeferredInteraction,
   logger: Logger,
   event: NormalizedEvent,
   result: EventHandlerResult | void,
 ): Promise<void> {
   if (result?.commandResponse) {
     try {
-      await interaction.editReply({ content: result.commandResponse.text });
+      await interaction.editReply({
+        content: result.commandResponse.text,
+        ...(result.commandResponse.components
+          ? { components: discordMessageComponents(result.commandResponse.components) }
+          : {}),
+      });
     } catch (err) {
       logger.error(
         {
@@ -365,6 +608,7 @@ async function completeDeferredCommandReply(
           traceId: event.traceId,
           interactionId: interaction.id,
           commandName: interaction.commandName,
+          customId: interaction.customId,
         },
         'discord_command_response_update_failed',
       );
@@ -375,7 +619,7 @@ async function completeDeferredCommandReply(
 }
 
 async function markDeferredCommandFailed(
-  interaction: ChatInputCommandInteraction,
+  interaction: DeferredInteraction,
   logger: Logger,
   event: NormalizedEvent,
 ): Promise<void> {
@@ -388,6 +632,7 @@ async function markDeferredCommandFailed(
         traceId: event.traceId,
         interactionId: interaction.id,
         commandName: interaction.commandName,
+        customId: interaction.customId,
       },
       'discord_command_ack_failure_update_failed',
     );
@@ -447,6 +692,7 @@ export function parseInbound(
   }
 
   const text = msg.content.replace(buildBotMentionRegex(botUserId), '').trim();
+  const threadParentChannelId = discordMessageThreadParentId(msg);
 
   const sessionKey: PlatformSessionKey = {
     platform: 'discord',
@@ -465,6 +711,7 @@ export function parseInbound(
     platformTimestamp: msg.createdAt,
     ...(msg.guildId ? { guildId: msg.guildId } : {}),
     initiatorRoleIds: discordMemberRoleIds(msg),
+    ...(threadParentChannelId ? { threadParentChannelId } : {}),
     initiator: {
       userId: msg.author.id,
       displayName: msg.author.username,
@@ -531,6 +778,57 @@ export function createDiscordPlatform(opts: DiscordPlatformOptions): DiscordPlat
 
     capabilities(): CapabilitySet {
       return DISCORD_CAPABILITIES;
+    },
+
+    settingsSnapshot(input) {
+      return {
+        items: [
+          {
+            key: 'discord.replyMode',
+            label: 'Reply mode',
+            owner: 'platform',
+            value: replyMode,
+            source: 'discord state',
+            durability: 'durable',
+            canChange: allowedUserIds.includes(input.userId),
+          },
+        ],
+      };
+    },
+
+    async applySettingsAction(input) {
+      if (input.action !== 'discord.replyMode') {
+        return {
+          status: 'unsupported' as const,
+          message: 'This setting is not supported by Discord.',
+        };
+      }
+      if (!allowedUserIds.includes(input.userId)) {
+        logger.info({ userId: input.userId }, 'discord_settings_unauthorized');
+        return {
+          status: 'rejected' as const,
+          message: `Permission denied. Your User ID is \`${input.userId}\`; ask the bot operator to add it.`,
+        };
+      }
+      if (input.value !== 'mention' && input.value !== 'all') {
+        return {
+          status: 'rejected' as const,
+          message: `invalid mode: \`${input.value ?? ''}\` (must be \`mention\` or \`all\`)`,
+        };
+      }
+      const from = replyMode;
+      const to = input.value;
+      if (from === to) {
+        logger.info({ mode: to, userId: input.userId }, 'discord_reply_mode_noop');
+        return { status: 'handled' as const, message: `already in \`${to}\`` };
+      }
+      await writeReplyModeState(statePath, to);
+      replyMode = to;
+      logger.info({ from, to, userId: input.userId }, 'discord_reply_mode_changed');
+      return {
+        status: 'handled' as const,
+        message: `reply mode: \`${from}\` -> \`${to}\``,
+      };
     },
 
     updateAuth(update: DiscordAuthUpdate): void {
@@ -617,7 +915,95 @@ export function createDiscordPlatform(opts: DiscordPlatformOptions): DiscordPlat
       });
 
       client.on('interactionCreate', async (interaction: Interaction) => {
-        if (!interaction.isChatInputCommand()) return;
+        if (
+          'isModalSubmit' in interaction &&
+          typeof interaction.isModalSubmit === 'function' &&
+          interaction.isModalSubmit()
+        ) {
+          try {
+            await interaction.deferReply({ ephemeral: true });
+          } catch (err) {
+            logger.error(
+              { err, interactionId: interaction.id },
+              'discord_modal_ack_failed',
+            );
+            return;
+          }
+          const event = modalEventFromInteraction(interaction);
+          try {
+            const result = await handler(event);
+            await completeDeferredCommandReply(interaction, logger, event, result);
+          } catch (err) {
+            logger.error(
+              { err, traceId: event.traceId, customId: event.interaction?.customId },
+              'platform_handler_error',
+            );
+            await markDeferredCommandFailed(interaction, logger, event);
+          }
+          return;
+        }
+        if (!interaction.isChatInputCommand()) {
+          if (!interaction.isButton() && !interaction.isStringSelectMenu()) return;
+          if (shouldHandleComponentBeforeDefer(interaction)) {
+            const event = componentEventFromInteraction(interaction);
+            try {
+              const result = await handler(event);
+              if (result?.modalResponse) {
+                await interaction.showModal(
+                  discordModal(result.modalResponse) as Parameters<
+                    typeof interaction.showModal
+                  >[0],
+                );
+                return;
+              }
+              await interaction.reply({
+                content: result?.commandResponse?.text ?? 'Command failed.',
+                ephemeral: true,
+                ...(result?.commandResponse?.components
+                  ? { components: discordMessageComponents(result.commandResponse.components) }
+                  : {}),
+              } as Parameters<typeof interaction.reply>[0]);
+            } catch (err) {
+              logger.error(
+                { err, traceId: event.traceId, customId: event.interaction?.customId },
+                'platform_handler_error',
+              );
+              try {
+                await interaction.reply({
+                  content: 'Command failed. Try again later.',
+                  ephemeral: true,
+                });
+              } catch (replyErr) {
+                logger.error(
+                  { err: replyErr, customId: interaction.customId },
+                  'discord_component_error_reply_failed',
+                );
+              }
+            }
+            return;
+          }
+          try {
+            await interaction.deferReply({ ephemeral: true });
+          } catch (err) {
+            logger.error(
+              { err, interactionId: interaction.id },
+              'discord_component_ack_failed',
+            );
+            return;
+          }
+          const event = componentEventFromInteraction(interaction);
+          try {
+            const result = await handler(event);
+            await completeDeferredCommandReply(interaction, logger, event, result);
+          } catch (err) {
+            logger.error(
+              { err, traceId: event.traceId, customId: event.interaction?.customId },
+              'platform_handler_error',
+            );
+            await markDeferredCommandFailed(interaction, logger, event);
+          }
+          return;
+        }
         if (!replyModeNames.has(interaction.commandName)) {
           if (!(await deferCommandInteraction(interaction, logger))) return;
           const event = commandEventFromInteraction(
@@ -804,6 +1190,86 @@ export function createDiscordPlatform(opts: DiscordPlatformOptions): DiscordPlat
 
     async react(): Promise<void> {
       throw new Error('platform-discord MVP: react not supported');
+    },
+
+    async createThread(input: CreateThreadInput) {
+      const channel = await client.channels.fetch(input.parentChannelId);
+      if (!channel || !channel.isTextBased() || !('threads' in channel)) {
+        throw new Error(
+          `platform-discord: channel ${input.parentChannelId} cannot create threads`,
+        );
+      }
+      const threads = channel.threads as {
+        create(options: {
+          name: string;
+          type: ChannelType.PrivateThread | ChannelType.PublicThread;
+          autoArchiveDuration: number;
+          invitable?: boolean;
+          reason?: string;
+        }): Promise<{
+          id: string;
+          guildId?: string;
+          members: { add(userId: string): Promise<unknown> };
+          send(message: unknown): Promise<unknown>;
+          delete?(reason?: string): Promise<unknown>;
+          setArchived?(archived: boolean, reason?: string): Promise<unknown>;
+        }>;
+      };
+      const thread = await threads.create({
+        name: input.title.slice(0, 100),
+        type:
+          input.visibility === 'private'
+            ? ChannelType.PrivateThread
+            : ChannelType.PublicThread,
+        autoArchiveDuration: input.autoArchiveDurationMinutes,
+        invitable: false,
+        reason: 'agent-nexus new thread',
+      });
+      try {
+        await thread.members.add(input.initiatorUserId);
+        if (input.initialMessage) {
+          await thread.send({
+            content: input.initialMessage,
+            allowedMentions: { parse: [] },
+          });
+        }
+      } catch (err) {
+        try {
+          if (thread.delete) {
+            await thread.delete('agent-nexus thread setup failed');
+          } else if (thread.setArchived) {
+            await thread.setArchived(true, 'agent-nexus thread setup failed');
+          }
+        } catch (cleanupErr) {
+          logger.error(
+            {
+              traceId: input.traceId,
+              threadId: thread.id,
+              err: cleanupErr,
+            },
+            'discord_thread_cleanup_failed',
+          );
+        }
+        throw err;
+      }
+      return {
+        threadId: thread.id,
+        parentChannelId: input.parentChannelId,
+        ...(thread.guildId
+          ? { url: `https://discord.com/channels/${thread.guildId}/${thread.id}` }
+          : {}),
+      };
+    },
+
+    async updateThread(input: UpdateThreadInput): Promise<void> {
+      if (!input.title) return;
+      const channel = await client.channels.fetch(input.threadId);
+      if (!channel || !('setName' in channel) || typeof channel.setName !== 'function') {
+        throw new Error(
+          `platform-discord: thread ${input.threadId} is not editable or not found`,
+        );
+      }
+      await channel.setName(input.title.slice(0, 100), 'agent-nexus session title');
     },
 
     async setTyping(sessionKey: SessionKey): Promise<void> {

--- a/packages/protocol/src/interfaces.ts
+++ b/packages/protocol/src/interfaces.ts
@@ -58,10 +58,15 @@ export interface CreateThreadInput {
   traceId: string;
 }
 
+export interface CreateThreadSetupWarning {
+  code: 'initial_message_failed';
+}
+
 export interface CreateThreadResult {
   threadId: string;
   parentChannelId: string;
   url?: string;
+  setupWarnings?: CreateThreadSetupWarning[];
 }
 
 export interface UpdateThreadInput {


### PR DESCRIPTION
## Summary

从原 #151 中拆出 Discord adapter 的组件交互和 thread port 支持，让 platform 能把 button/select/modal 归一化给 daemon，并提供 thread 创建/更新能力。

本 PR：
- 声明 Discord capabilities 支持 buttons、string selects、threads 和 thread creation。
- 将 button/select/modal submit 转为 `NormalizedEvent` interaction。
- 将 command/component response components 映射到 Discord action rows。
- 实现 private thread 创建、成员加入、初始消息发送和 thread title update。
- 补充 Discord adapter 测试覆盖 interaction 和 thread 行为。

## Why

daemon settings/session/queue 控制面需要平台组件与 modal；thread 会话需要 adapter 提供 platform-owned create/update port。

ADR: N/A - Discord adapter 实现 protocol 可选 port，不新增平台类型。
Spec: `docs/dev/spec/platform-adapter.md` 与 `docs/dev/spec/message-protocol.md` 的同步在本 stack 顶部 docs PR 中承载。

## Test plan

- [x] Tests: `packages/platform/discord/src/index.test.ts` 在 final stacked head `64dc01c` 上通过。
- [x] `CI=true COREPACK_HOME=/cache/corepack corepack pnpm vitest run packages/daemon/src/session-store.test.ts packages/daemon/src/message-queue.test.ts packages/daemon/src/engine.test.ts packages/platform/discord/src/index.test.ts packages/cli/src/config.test.ts packages/cli/src/command-registry.test.ts` — 6 files, 217 tests passed.
- [x] `CI=true COREPACK_HOME=/cache/corepack corepack pnpm typecheck` — passed.
- [ ] Manual: real Discord button/select/modal/thread creation smoke test not run.

## Review notes

- Independent agent review: Pending - split PR created from existing #151 branch; must be reviewed before merge.
- Deep review: N/A - adapter implementation of already protocolized optional ports.

## Out of scope

- Daemon command handlers that use these interactions.
- Durable thread registry.
- Attachments/reactions/delete support.