### PR TITLE
feat(daemon): add trajectory read model scaffold

### DIFF
--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -52,6 +52,26 @@ export {
   type DispatchCommandEventInput,
 } from './command-dispatch.js';
 export {
+  InMemoryTrajectoryStore,
+  TrajectoryStoreError,
+  confidenceMeetsMinimum,
+  type ExternalResumeBinding,
+  type ExternalSessionImportRecord,
+  type ExternalSessionImportState,
+  type LinkExternalSessionInput,
+  type ProviderCallObservation,
+  type ProviderTurnAlignment,
+  type TrajectoryConfidence,
+  type TrajectoryLogAnchor,
+  type TrajectoryPage,
+  type TrajectoryQuery,
+  type TrajectoryRedactionState,
+  type TrajectorySegment,
+  type TrajectorySegmentKind,
+  type TrajectorySegmentSource,
+  type TrajectoryStoreErrorCode,
+} from './trajectory-store.js';
+export {
   DEFAULT_DAEMON_RUNTIME_CONFIG,
   parseDaemonConfig,
   parseDaemonRuntimeConfig,

--- a/packages/daemon/src/trajectory-store.test.ts
+++ b/packages/daemon/src/trajectory-store.test.ts
@@ -1,0 +1,263 @@
+import { describe, expect, it } from 'vitest';
+import {
+  InMemoryTrajectoryStore,
+  TrajectoryStoreError,
+  confidenceMeetsMinimum,
+} from './trajectory-store.js';
+
+describe('confidenceMeetsMinimum', () => {
+  it('orders confidence and excludes unknown for any explicit minimum', () => {
+    expect(confidenceMeetsMinimum('high', 'medium')).toBe(true);
+    expect(confidenceMeetsMinimum('medium', 'medium')).toBe(true);
+    expect(confidenceMeetsMinimum('low', 'medium')).toBe(false);
+    expect(confidenceMeetsMinimum('unknown', 'low')).toBe(false);
+    expect(confidenceMeetsMinimum('unknown', undefined)).toBe(true);
+  });
+});
+
+describe('InMemoryTrajectoryStore', () => {
+  it('redacts external import metadata on write', () => {
+    const store = new InMemoryTrajectoryStore();
+
+    store.upsertExternalSessionImport({
+      importId: 'imp-1',
+      sourceAdapter: 'codex-cli-jsonl',
+      sourceSessionId: 'codex-session-1',
+      sourcePathHash: 'sha256:path',
+      nativeSessionRef: 'codex-native-1',
+      state: 'registered',
+      confidence: 'high',
+      metadataJson:
+        '{"summary":"ANTHROPIC_API_KEY=sk-ant-abc path=/home/node/.codex/sessions/a.jsonl"}',
+      discoveredAt: '2026-06-23T08:00:00.000Z',
+    });
+
+    const imported = store.getExternalSessionImport('imp-1');
+    expect(imported?.metadataJson).toContain('ANTHROPIC_API_KEY=<redacted>');
+    expect(imported?.metadataJson).toContain('path=~/.codex/sessions/a.jsonl');
+    expect(imported?.metadataJson).not.toContain('sk-ant-abc');
+    expect(imported?.metadataJson).not.toContain('/home/node');
+  });
+
+  it('links a registered external import directly without requiring content import', () => {
+    const store = new InMemoryTrajectoryStore();
+    store.upsertExternalSessionImport({
+      importId: 'imp-1',
+      sourceAdapter: 'claude-code-jsonl',
+      sourceSessionId: 'claude-session-1',
+      sourcePathHash: 'sha256:path',
+      nativeSessionRef: 'claude-native-1',
+      state: 'registered',
+      confidence: 'medium',
+      metadataJson: '{}',
+      discoveredAt: '2026-06-23T08:00:00.000Z',
+    });
+
+    const binding = store.linkExternalSession({
+      importId: 'imp-1',
+      sessionId: 'mem-1',
+      nativeSessionRef: 'claude-native-1',
+      linkedAt: '2026-06-23T08:01:00.000Z',
+    });
+
+    expect(binding).toEqual({
+      sessionId: 'mem-1',
+      importId: 'imp-1',
+      sourceAdapter: 'claude-code-jsonl',
+      sourceSessionId: 'claude-session-1',
+      nativeSessionRef: 'claude-native-1',
+      confidence: 'medium',
+      linkedAt: '2026-06-23T08:01:00.000Z',
+    });
+    expect(store.getExternalSessionImport('imp-1')).toMatchObject({
+      state: 'linked',
+      linkedSessionId: 'mem-1',
+      linkedAt: '2026-06-23T08:01:00.000Z',
+      nativeSessionRef: 'claude-native-1',
+    });
+  });
+
+  it('fails closed when linking without a native session ref', () => {
+    const store = new InMemoryTrajectoryStore();
+    store.upsertExternalSessionImport({
+      importId: 'imp-1',
+      sourceAdapter: 'codex-app-jsonl',
+      sourceSessionId: 'codex-app-session-1',
+      sourcePathHash: 'sha256:path',
+      state: 'registered',
+      confidence: 'low',
+      metadataJson: '{}',
+      discoveredAt: '2026-06-23T08:00:00.000Z',
+    });
+
+    expect(() =>
+      store.linkExternalSession({
+        importId: 'imp-1',
+        sessionId: 'mem-1',
+        linkedAt: '2026-06-23T08:01:00.000Z',
+      }),
+    ).toThrow(TrajectoryStoreError);
+    expect(store.getExternalSessionImport('imp-1')?.state).toBe('registered');
+  });
+
+  it('rejects trajectory content refs that point at external raw transcript files', () => {
+    const store = new InMemoryTrajectoryStore();
+
+    try {
+      store.appendTrajectorySegment({
+        segmentId: 'seg-1',
+        source: 'external-import',
+        kind: 'user-message',
+        importId: 'imp-1',
+        sequence: 1,
+        ts: '2026-06-23T08:00:00.000Z',
+        summary: 'hello',
+        contentRef: '/home/node/.codex/sessions/2026/06/23/session.jsonl',
+        confidence: 'high',
+        redactionState: 'redacted',
+        metadataJson: '{}',
+      });
+      throw new Error('expected appendTrajectorySegment to fail');
+    } catch (error) {
+      expect(error).toBeInstanceOf(TrajectoryStoreError);
+      expect((error as TrajectoryStoreError).code).toBe('invalid-content-ref');
+    }
+  });
+
+  it('rejects managed-looking content refs with parent directory traversal', () => {
+    const store = new InMemoryTrajectoryStore();
+
+    expect(() =>
+      store.appendTrajectorySegment({
+        segmentId: 'seg-1',
+        source: 'external-import',
+        kind: 'user-message',
+        importId: 'imp-1',
+        sequence: 1,
+        ts: '2026-06-23T08:00:00.000Z',
+        summary: 'hello',
+        contentRef: 'transcripts/../../home/node/.codex/session.jsonl',
+        confidence: 'high',
+        redactionState: 'redacted',
+        metadataJson: '{}',
+      }),
+    ).toThrow(TrajectoryStoreError);
+  });
+
+  it('does not link rejected imports', () => {
+    const store = new InMemoryTrajectoryStore();
+    store.upsertExternalSessionImport({
+      importId: 'imp-1',
+      sourceAdapter: 'claude-code-jsonl',
+      sourceSessionId: 'claude-session-1',
+      sourcePathHash: 'sha256:path',
+      nativeSessionRef: 'claude-native-1',
+      state: 'rejected',
+      confidence: 'medium',
+      metadataJson: '{}',
+      discoveredAt: '2026-06-23T08:00:00.000Z',
+    });
+
+    expect(() =>
+      store.linkExternalSession({
+        importId: 'imp-1',
+        sessionId: 'mem-1',
+        linkedAt: '2026-06-23T08:01:00.000Z',
+      }),
+    ).toThrow(TrajectoryStoreError);
+    expect(store.getExternalSessionImport('imp-1')?.state).toBe('rejected');
+  });
+
+  it('queries trajectory segments in stable order and filters unknown confidence', () => {
+    const store = new InMemoryTrajectoryStore();
+    store.appendTrajectorySegment({
+      segmentId: 'seg-unknown',
+      sessionId: 'mem-1',
+      source: 'external-import',
+      kind: 'unknown',
+      sequence: 2,
+      ts: '2026-06-23T08:00:00.000Z',
+      summary: 'schema drift',
+      confidence: 'unknown',
+      redactionState: 'metadata-only',
+      metadataJson: '{}',
+    });
+    store.appendTrajectorySegment({
+      segmentId: 'seg-high',
+      sessionId: 'mem-1',
+      source: 'nexus-agent-event',
+      kind: 'agent-message',
+      sequence: 1,
+      ts: '2026-06-23T08:00:00.000Z',
+      summary: 'safe message',
+      confidence: 'high',
+      redactionState: 'redacted',
+      metadataJson: '{}',
+    });
+
+    expect(
+      store.queryTrajectory({ sessionId: 'mem-1' }).segments.map((s) => s.segmentId),
+    ).toEqual(['seg-high', 'seg-unknown']);
+    expect(
+      store.queryTrajectory({ sessionId: 'mem-1', minConfidence: 'low' }).segments.map(
+        (s) => s.segmentId,
+      ),
+    ).toEqual(['seg-high']);
+  });
+
+  it('drops provider payload refs when redaction failed', () => {
+    const store = new InMemoryTrajectoryStore();
+
+    store.recordProviderCallObservation({
+      observationId: 'obs-1',
+      backend: 'codex',
+      captureMode: 'reverse-proxy',
+      requestStartedAt: '2026-06-23T08:00:00.000Z',
+      requestSummary: 'Authorization: sk-ant-abc',
+      requestBodyRef: 'trajectory/provider-calls/raw-request.json',
+      responseBodyRef: 'trajectory/provider-calls/raw-response.json',
+      streamFramesRef: 'trajectory/provider-calls/raw-stream.jsonl',
+      requestBytes: 1200,
+      redactionState: 'dropped',
+      alignment: { confidence: 'low', reasons: ['redaction-failed'] },
+      errorCode: 'provider-capture-redaction-failed',
+      metadataJson: '{"secret":"sk-ant-def"}',
+    });
+
+    const observation = store.getProviderCallObservation('obs-1');
+    expect(observation).toMatchObject({ redactionState: 'dropped' });
+    expect(observation).not.toHaveProperty('requestBodyRef');
+    expect(observation).not.toHaveProperty('responseBodyRef');
+    expect(observation).not.toHaveProperty('streamFramesRef');
+    expect(store.getProviderCallObservation('obs-1')?.requestSummary).toContain(
+      '<redacted:secret>',
+    );
+    expect(store.getProviderCallObservation('obs-1')?.metadataJson).not.toContain(
+      'sk-ant-def',
+    );
+  });
+
+  it('does not keep provider payload refs for metadata-only observations', () => {
+    const store = new InMemoryTrajectoryStore();
+
+    store.recordProviderCallObservation({
+      observationId: 'obs-1',
+      backend: 'codex',
+      captureMode: 'transcript-only',
+      requestStartedAt: '2026-06-23T08:00:00.000Z',
+      requestSummary: 'metadata only',
+      requestBodyRef: 'trajectory/provider-calls/raw-request.json',
+      responseBodyRef: 'trajectory/provider-calls/raw-response.json',
+      streamFramesRef: 'trajectory/provider-calls/raw-stream.jsonl',
+      requestBytes: 1200,
+      redactionState: 'metadata-only',
+      alignment: { confidence: 'low', reasons: ['metadata-only'] },
+      metadataJson: '{}',
+    });
+
+    const observation = store.getProviderCallObservation('obs-1');
+    expect(observation).not.toHaveProperty('requestBodyRef');
+    expect(observation).not.toHaveProperty('responseBodyRef');
+    expect(observation).not.toHaveProperty('streamFramesRef');
+  });
+});

--- a/packages/daemon/src/trajectory-store.ts
+++ b/packages/daemon/src/trajectory-store.ts
@@ -1,0 +1,438 @@
+import { BasicRedactor, type Redactor } from './redaction.js';
+
+export type TrajectoryConfidence = 'high' | 'medium' | 'low' | 'unknown';
+
+export function confidenceMeetsMinimum(
+  confidence: TrajectoryConfidence,
+  minimum: TrajectoryConfidence | undefined,
+): boolean {
+  if (minimum === undefined) return true;
+  if (confidence === 'unknown') return false;
+  return confidenceRank(confidence) >= confidenceRank(minimum);
+}
+
+export type ExternalSessionImportState =
+  | 'discovered'
+  | 'registered'
+  | 'imported'
+  | 'linked'
+  | 'rejected'
+  | 'failed'
+  | 'retired';
+
+export interface TrajectoryImportError {
+  code: string;
+  message: string;
+  retryable: boolean;
+}
+
+export interface ExternalSessionImportRecord {
+  importId: string;
+  sourceAdapter: string;
+  sourceSessionId: string;
+  sourcePathHash: string;
+  nativeSessionRef?: string;
+  linkedSessionId?: string;
+  state: ExternalSessionImportState;
+  confidence: TrajectoryConfidence;
+  metadataJson: string;
+  error?: TrajectoryImportError;
+  discoveredAt: string;
+  importedAt?: string;
+  linkedAt?: string;
+}
+
+export interface LinkExternalSessionInput {
+  importId: string;
+  sessionId: string;
+  nativeSessionRef?: string;
+  linkedAt: string;
+}
+
+export interface ExternalResumeBinding {
+  sessionId: string;
+  importId: string;
+  sourceAdapter: string;
+  sourceSessionId: string;
+  nativeSessionRef: string;
+  confidence: TrajectoryConfidence;
+  linkedAt: string;
+}
+
+export type TrajectorySegmentSource =
+  | 'nexus-agent-event'
+  | 'external-import'
+  | 'provider-call';
+
+export type TrajectorySegmentKind =
+  | 'user-message'
+  | 'agent-message'
+  | 'reasoning'
+  | 'tool-call'
+  | 'tool-result'
+  | 'usage'
+  | 'provider-request'
+  | 'provider-response'
+  | 'state-change'
+  | 'unknown';
+
+export type TrajectoryRedactionState =
+  | 'redacted'
+  | 'metadata-only'
+  | 'dropped';
+
+export interface TrajectoryLogAnchor {
+  logFile?: string;
+  byteOffset?: number;
+  event?: string;
+}
+
+export interface TrajectorySegment {
+  segmentId: string;
+  sessionId?: string;
+  importId?: string;
+  providerObservationId?: string;
+  source: TrajectorySegmentSource;
+  kind: TrajectorySegmentKind;
+  traceId?: string;
+  turnSequence?: number;
+  sequence: number;
+  ts: string;
+  summary: string;
+  contentRef?: string;
+  usageEventId?: string;
+  logAnchor?: TrajectoryLogAnchor;
+  confidence: TrajectoryConfidence;
+  redactionState: TrajectoryRedactionState;
+  metadataJson: string;
+}
+
+export interface ProviderTurnAlignment {
+  confidence: TrajectoryConfidence;
+  turnSequence?: number;
+  agentEventSequence?: number;
+  reasons: string[];
+}
+
+export interface ProviderCallObservation {
+  observationId: string;
+  sessionId?: string;
+  traceId?: string;
+  backend: 'claudecode' | 'codex' | string;
+  captureMode: 'reverse-proxy' | 'forward-proxy' | 'transcript-only';
+  requestStartedAt: string;
+  responseFinishedAt?: string;
+  providerHost?: string;
+  model?: string;
+  requestSummary: string;
+  responseSummary?: string;
+  requestBodyRef?: string;
+  responseBodyRef?: string;
+  streamFramesRef?: string;
+  requestBytes: number;
+  responseBytes?: number;
+  redactionState: TrajectoryRedactionState;
+  alignment: ProviderTurnAlignment;
+  errorCode?: string;
+  metadataJson: string;
+}
+
+export interface TrajectoryQuery {
+  sessionId?: string;
+  importId?: string;
+  source?: TrajectorySegmentSource;
+  kinds?: TrajectorySegmentKind[];
+  since?: string;
+  until?: string;
+  minConfidence?: TrajectoryConfidence;
+  includeContent?: boolean;
+  limit?: number;
+  cursor?: string;
+}
+
+export interface TrajectoryPage {
+  segments: TrajectorySegment[];
+  nextCursor?: string;
+}
+
+export type TrajectoryStoreErrorCode =
+  | 'external-import-not-found'
+  | 'native-resume-unavailable'
+  | 'invalid-content-ref'
+  | 'invalid-import-state'
+  | 'invalid-query'
+  | 'duplicate-record';
+
+export class TrajectoryStoreError extends Error {
+  constructor(
+    readonly code: TrajectoryStoreErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'TrajectoryStoreError';
+  }
+}
+
+export class InMemoryTrajectoryStore {
+  private readonly imports = new Map<string, ExternalSessionImportRecord>();
+  private readonly segments = new Map<string, TrajectorySegment>();
+  private readonly observations = new Map<string, ProviderCallObservation>();
+  private readonly redactor: Redactor;
+
+  constructor(input: { redactor?: Redactor } = {}) {
+    this.redactor = input.redactor ?? new BasicRedactor();
+  }
+
+  upsertExternalSessionImport(record: ExternalSessionImportRecord): void {
+    this.imports.set(record.importId, this.cloneImport(record));
+  }
+
+  getExternalSessionImport(
+    importId: string,
+  ): ExternalSessionImportRecord | undefined {
+    const record = this.imports.get(importId);
+    return record ? this.cloneImport(record) : undefined;
+  }
+
+  linkExternalSession(input: LinkExternalSessionInput): ExternalResumeBinding {
+    const existing = this.imports.get(input.importId);
+    if (!existing) {
+      throw new TrajectoryStoreError(
+        'external-import-not-found',
+        `External import ${input.importId} was not found`,
+      );
+    }
+
+    const nativeSessionRef = input.nativeSessionRef ?? existing.nativeSessionRef;
+    if (!nativeSessionRef) {
+      throw new TrajectoryStoreError(
+        'native-resume-unavailable',
+        `External import ${input.importId} has no native session ref`,
+      );
+    }
+    if (existing.state !== 'registered' && existing.state !== 'imported') {
+      throw new TrajectoryStoreError(
+        'invalid-import-state',
+        `External import ${input.importId} cannot be linked from state ${existing.state}`,
+      );
+    }
+
+    const linked: ExternalSessionImportRecord = {
+      ...existing,
+      nativeSessionRef,
+      linkedSessionId: input.sessionId,
+      state: 'linked',
+      linkedAt: input.linkedAt,
+    };
+    this.imports.set(input.importId, linked);
+
+    return {
+      sessionId: input.sessionId,
+      importId: linked.importId,
+      sourceAdapter: linked.sourceAdapter,
+      sourceSessionId: linked.sourceSessionId,
+      nativeSessionRef,
+      confidence: linked.confidence,
+      linkedAt: input.linkedAt,
+    };
+  }
+
+  appendTrajectorySegment(segment: TrajectorySegment): void {
+    if (this.segments.has(segment.segmentId)) {
+      throw new TrajectoryStoreError(
+        'duplicate-record',
+        `Trajectory segment ${segment.segmentId} already exists`,
+      );
+    }
+    if (segment.redactionState === 'dropped' && segment.contentRef) {
+      throw new TrajectoryStoreError(
+        'invalid-content-ref',
+        'Trajectory segment with dropped redaction state cannot keep contentRef',
+      );
+    }
+    if (segment.contentRef) assertManagedContentRef(segment.contentRef);
+
+    this.segments.set(segment.segmentId, this.cloneSegment(segment));
+  }
+
+  recordProviderCallObservation(observation: ProviderCallObservation): void {
+    if (this.observations.has(observation.observationId)) {
+      throw new TrajectoryStoreError(
+        'duplicate-record',
+        `Provider observation ${observation.observationId} already exists`,
+      );
+    }
+    const next = this.cloneObservation(observation);
+    if (next.redactionState !== 'redacted') {
+      delete next.requestBodyRef;
+      delete next.responseBodyRef;
+      delete next.streamFramesRef;
+    } else {
+      if (next.requestBodyRef) assertManagedProviderRef(next.requestBodyRef);
+      if (next.responseBodyRef) assertManagedProviderRef(next.responseBodyRef);
+      if (next.streamFramesRef) assertManagedProviderRef(next.streamFramesRef);
+    }
+    this.observations.set(next.observationId, next);
+  }
+
+  getProviderCallObservation(
+    observationId: string,
+  ): ProviderCallObservation | undefined {
+    const observation = this.observations.get(observationId);
+    return observation ? this.cloneObservation(observation) : undefined;
+  }
+
+  queryTrajectory(query: TrajectoryQuery): TrajectoryPage {
+    const limit = normalizeLimit(query.limit);
+    // Offset cursor is the in-memory scaffold; durable storage should use keyset.
+    const cursor = normalizeCursor(query.cursor);
+    const kinds = query.kinds ? new Set(query.kinds) : undefined;
+    // Content dereference is intentionally out of scope for this scaffold.
+    void query.includeContent;
+
+    const filtered = [...this.segments.values()]
+      .filter((segment) => {
+        if (query.sessionId && segment.sessionId !== query.sessionId) return false;
+        if (query.importId && segment.importId !== query.importId) return false;
+        if (query.source && segment.source !== query.source) return false;
+        if (kinds && !kinds.has(segment.kind)) return false;
+        if (query.since && segment.ts < query.since) return false;
+        if (query.until && segment.ts > query.until) return false;
+        return confidenceMeetsMinimum(segment.confidence, query.minConfidence);
+      })
+      .sort(compareSegments);
+
+    const page = filtered.slice(cursor, cursor + limit);
+    const nextCursor =
+      cursor + limit < filtered.length ? String(cursor + limit) : undefined;
+
+    return {
+      segments: page.map((segment) => this.cloneSegment(segment)),
+      nextCursor,
+    };
+  }
+
+  private cloneImport(record: ExternalSessionImportRecord): ExternalSessionImportRecord {
+    // Clone helpers redact at the Store boundary and again on read as defense in depth.
+    return {
+      ...record,
+      metadataJson: this.redact(record.metadataJson),
+      error: record.error
+        ? {
+            ...record.error,
+            message: this.redact(record.error.message),
+          }
+        : undefined,
+    };
+  }
+
+  private cloneSegment(segment: TrajectorySegment): TrajectorySegment {
+    return {
+      ...segment,
+      summary: this.redact(segment.summary),
+      logAnchor: segment.logAnchor ? { ...segment.logAnchor } : undefined,
+      metadataJson: this.redact(segment.metadataJson),
+    };
+  }
+
+  private cloneObservation(
+    observation: ProviderCallObservation,
+  ): ProviderCallObservation {
+    return {
+      ...observation,
+      requestSummary: this.redact(observation.requestSummary),
+      responseSummary: observation.responseSummary
+        ? this.redact(observation.responseSummary)
+        : undefined,
+      alignment: {
+        ...observation.alignment,
+        reasons: [...observation.alignment.reasons],
+      },
+      metadataJson: this.redact(observation.metadataJson),
+    };
+  }
+
+  private redact(value: string): string {
+    return this.redactor.redact(value);
+  }
+}
+
+function confidenceRank(confidence: TrajectoryConfidence): number {
+  switch (confidence) {
+    case 'high':
+      return 3;
+    case 'medium':
+      return 2;
+    case 'low':
+      return 1;
+    case 'unknown':
+      return 0;
+  }
+}
+
+function normalizeLimit(limit: number | undefined): number {
+  if (limit === undefined) return 100;
+  if (!Number.isInteger(limit) || limit < 1) {
+    throw new TrajectoryStoreError(
+      'invalid-query',
+      'Trajectory query limit must be a positive integer',
+    );
+  }
+  return Math.min(limit, 1000);
+}
+
+function normalizeCursor(cursor: string | undefined): number {
+  if (cursor === undefined) return 0;
+  const parsed = Number.parseInt(cursor, 10);
+  if (!Number.isInteger(parsed) || parsed < 0 || String(parsed) !== cursor) {
+    throw new TrajectoryStoreError(
+      'invalid-query',
+      'Trajectory query cursor must be a non-negative integer string',
+    );
+  }
+  return parsed;
+}
+
+function compareSegments(a: TrajectorySegment, b: TrajectorySegment): number {
+  const ts = a.ts.localeCompare(b.ts);
+  if (ts !== 0) return ts;
+  return a.sequence - b.sequence;
+}
+
+function assertManagedContentRef(contentRef: string): void {
+  if (containsParentTraversal(contentRef)) {
+    throw new TrajectoryStoreError(
+      'invalid-content-ref',
+      `Trajectory contentRef must not contain parent traversal: ${contentRef}`,
+    );
+  }
+  if (
+    contentRef.startsWith('trajectory/imports/') ||
+    contentRef.startsWith('trajectory/provider-calls/') ||
+    contentRef.startsWith('transcripts/')
+  ) {
+    return;
+  }
+  throw new TrajectoryStoreError(
+    'invalid-content-ref',
+    `Trajectory contentRef must point to Nexus-managed storage: ${contentRef}`,
+  );
+}
+
+function assertManagedProviderRef(ref: string): void {
+  if (containsParentTraversal(ref)) {
+    throw new TrajectoryStoreError(
+      'invalid-content-ref',
+      `Provider observation ref must not contain parent traversal: ${ref}`,
+    );
+  }
+  if (ref.startsWith('trajectory/provider-calls/')) return;
+  throw new TrajectoryStoreError(
+    'invalid-content-ref',
+    `Provider observation ref must point to Nexus-managed storage: ${ref}`,
+  );
+}
+
+function containsParentTraversal(ref: string): boolean {
+  return ref.split(/[\\/]+/).includes('..');
+}


### PR DESCRIPTION
## Summary

本 PR：

- Adds an in-memory daemon-owned trajectory store scaffold and public daemon exports.
- Adds contract tests for confidence filtering, external import redaction, direct native resume linking, invalid import-state guarding, managed content refs, provider payload dropping, and stable query ordering.
- Keeps P3 scoped to scaffold only: no source adapters, provider proxy/capture, SQLite migrations, CLI/Engine integration, or UI.

## Why

P2 defined the trajectory read model contract. P3 needs a minimal tested daemon scaffold before P4 can attach source adapters, persistence, and runtime callers without inventing state semantics in integration code.

ADR: `docs/dev/adr/0018-trajectory-observability-read-model.md`
Spec: `docs/dev/spec/infra/trajectory-observability.md`

## Test plan

- [x] Red: `corepack pnpm test -- packages/daemon/src/trajectory-store.test.ts` failed before implementation because `./trajectory-store.js` did not exist.
- [x] Red review fixes: added negative tests for parent traversal refs, rejected import linking, and metadata-only provider refs; they failed before the fix.
- [x] `corepack pnpm test -- packages/daemon/src/trajectory-store.test.ts` - passed.
- [x] `corepack pnpm test` - passed.
- [x] `corepack pnpm typecheck` - passed.
- [x] `git diff --check` - passed.
- [x] `git diff --cached --check` - passed.

## Review notes

- Independent agent review: Claude review saved at `/home/node/.goal/agent-nexus-trajectory-observability/reviews/p3-scaffold-claude-review-20260623.md`; all important findings were fixed.
- Deep review: N/A - this PR is a narrow daemon scaffold implementation, not an architecture/spec/security decision PR. Claude re-review saved at `/home/node/.goal/agent-nexus-trajectory-observability/reviews/p3-scaffold-claude-rereview-20260623.md`; conclusion `APPROVE`.

## Out of scope

- External source adapters and transcript parsers.
- Provider proxy/capture implementation.
- SQLite migrations or durable Store implementation.
- CLI config parsing for `daemon.trajectory`.
- Engine/session-store integration and user-facing resume commands.