### PR TITLE
feat(daemon): persist trajectory read model

### DIFF
--- a/docs/dev/spec/infra/persistence.md
+++ b/docs/dev/spec/infra/persistence.md
@@ -192,7 +192,7 @@ contracts:
 | `ts` | TEXT NOT NULL | RFC3339 |
 | `summary` | TEXT NOT NULL | 脱敏摘要 |
 | `content_ref` | TEXT | 指向 `<home>/trajectory/imports/` 或 transcript 内受管内容 |
-| `usage_event_id` | INTEGER | 关联 usage_events |
+| `usage_event_id` | TEXT | 关联 usage_events；存储 `usage_events.id` 的字符串投影，对齐 trajectory read model 的 `usageEventId` opaque id |
 | `log_anchor_json` | TEXT | `{logFile,byteOffset,event}`；路径必须相对 `<home>` |
 | `confidence` | TEXT NOT NULL | `high|medium|low|unknown` |
 | `redaction_state` | TEXT NOT NULL | `redacted|metadata-only|dropped` |

--- a/package.json
+++ b/package.json
@@ -7,6 +7,11 @@
     "node": ">=20.10"
   },
   "packageManager": "pnpm@10.33.2",
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "better-sqlite3"
+    ]
+  },
   "scripts": {
     "dev": "corepack pnpm --filter @agent-nexus/cli dev",
     "build": "tsc --build && corepack pnpm --filter @agent-nexus/cli bundle",

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -19,7 +19,11 @@
   },
   "dependencies": {
     "@agent-nexus/protocol": "workspace:*",
+    "better-sqlite3": "^12.11.1",
     "pino": "^9.5.0",
     "pino-pretty": "^11.3.0"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.13"
   }
 }

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -53,6 +53,7 @@ export {
 } from './command-dispatch.js';
 export {
   InMemoryTrajectoryStore,
+  SqliteTrajectoryStore,
   TrajectoryStoreError,
   confidenceMeetsMinimum,
   type ExternalResumeBinding,
@@ -61,6 +62,7 @@ export {
   type LinkExternalSessionInput,
   type ProviderCallObservation,
   type ProviderTurnAlignment,
+  type SqliteTrajectoryStoreInput,
   type TrajectoryConfidence,
   type TrajectoryLogAnchor,
   type TrajectoryPage,

--- a/packages/daemon/src/trajectory-sqlite-store.test.ts
+++ b/packages/daemon/src/trajectory-sqlite-store.test.ts
@@ -1,0 +1,309 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  SqliteTrajectoryStore,
+  TrajectoryStoreError,
+  type ExternalSessionImportRecord,
+  type ProviderCallObservation,
+  type TrajectorySegment,
+} from './trajectory-store.js';
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('SqliteTrajectoryStore', () => {
+  it('persists external imports, trajectory segments, and provider observations across reopen', () => {
+    const dbPath = tempDbPath();
+    const first = new SqliteTrajectoryStore({ path: dbPath });
+
+    first.upsertExternalSessionImport(importRecord());
+    const binding = first.linkExternalSession({
+      importId: 'imp-1',
+      sessionId: 'sess-1',
+      linkedAt: '2026-06-23T09:01:00.000Z',
+    });
+    first.appendTrajectorySegment(segment({ segmentId: 'seg-1' }));
+    first.recordProviderCallObservation(observation());
+    first.close();
+
+    const second = new SqliteTrajectoryStore({ path: dbPath });
+
+    expect(binding).toMatchObject({
+      sessionId: 'sess-1',
+      importId: 'imp-1',
+      nativeSessionRef: 'native-1',
+    });
+    expect(second.getExternalSessionImport('imp-1')).toMatchObject({
+      state: 'linked',
+      linkedSessionId: 'sess-1',
+      linkedAt: '2026-06-23T09:01:00.000Z',
+    });
+    expect(second.queryTrajectory({ sessionId: 'sess-1' }).segments).toHaveLength(
+      1,
+    );
+    expect(second.getProviderCallObservation('obs-1')).toMatchObject({
+      backend: 'codex',
+      requestSummary: 'safe request',
+    });
+    second.close();
+  });
+
+  it('redacts persisted import metadata and error messages at the store boundary', () => {
+    const store = new SqliteTrajectoryStore({ path: tempDbPath() });
+
+    store.upsertExternalSessionImport(
+      importRecord({
+        metadataJson:
+          '{"path":"/home/node/.codex/sessions/raw.jsonl","key":"ANTHROPIC_API_KEY=sk-ant-secret"}',
+        error: {
+          code: 'external-source-unsupported',
+          message: 'failed with sk-ant-secret at /home/node/.claude/projects/a.jsonl',
+          retryable: false,
+        },
+      }),
+    );
+
+    const imported = store.getExternalSessionImport('imp-1');
+    expect(imported?.metadataJson).not.toContain('sk-ant-secret');
+    expect(imported?.metadataJson).not.toContain('/home/node');
+    expect(imported?.metadataJson).toContain('ANTHROPIC_API_KEY=<redacted>');
+    expect(imported?.error?.message).not.toContain('sk-ant-secret');
+    expect(imported?.error?.message).toContain('~/.claude/projects/a.jsonl');
+    store.close();
+  });
+
+  it('fails closed when durable link has no native session ref', () => {
+    const store = new SqliteTrajectoryStore({ path: tempDbPath() });
+    store.upsertExternalSessionImport(
+      importRecord({ nativeSessionRef: undefined }),
+    );
+
+    try {
+      store.linkExternalSession({
+        importId: 'imp-1',
+        sessionId: 'sess-1',
+        linkedAt: '2026-06-23T09:01:00.000Z',
+      });
+      throw new Error('expected linkExternalSession to fail');
+    } catch (error) {
+      expect(error).toBeInstanceOf(TrajectoryStoreError);
+      expect((error as TrajectoryStoreError).code).toBe(
+        'native-resume-unavailable',
+      );
+    }
+    expect(store.getExternalSessionImport('imp-1')).toMatchObject({
+      state: 'registered',
+    });
+    store.close();
+  });
+
+  it('does not mutate durable imports when linking from an invalid state', () => {
+    const store = new SqliteTrajectoryStore({ path: tempDbPath() });
+    store.upsertExternalSessionImport(
+      importRecord({
+        state: 'rejected',
+        linkedSessionId: undefined,
+        linkedAt: undefined,
+      }),
+    );
+
+    try {
+      store.linkExternalSession({
+        importId: 'imp-1',
+        sessionId: 'sess-1',
+        linkedAt: '2026-06-23T09:01:00.000Z',
+      });
+      throw new Error('expected linkExternalSession to fail');
+    } catch (error) {
+      expect(error).toBeInstanceOf(TrajectoryStoreError);
+      expect((error as TrajectoryStoreError).code).toBe('invalid-import-state');
+    }
+    expect(store.getExternalSessionImport('imp-1')).toMatchObject({
+      state: 'rejected',
+    });
+    expect(store.getExternalSessionImport('imp-1')).not.toHaveProperty(
+      'linkedSessionId',
+    );
+    expect(store.getExternalSessionImport('imp-1')).not.toHaveProperty(
+      'linkedAt',
+    );
+    store.close();
+  });
+
+  it('keeps provider payload refs only for redacted managed provider files', () => {
+    const store = new SqliteTrajectoryStore({ path: tempDbPath() });
+
+    store.recordProviderCallObservation(
+      observation({
+        observationId: 'obs-metadata',
+        redactionState: 'metadata-only',
+        requestBodyRef: 'trajectory/provider-calls/request.json',
+        responseBodyRef: 'trajectory/provider-calls/response.json',
+        streamFramesRef: 'trajectory/provider-calls/frames.jsonl',
+      }),
+    );
+    store.recordProviderCallObservation(
+      observation({
+        observationId: 'obs-redacted',
+        redactionState: 'redacted',
+        requestBodyRef: 'trajectory/provider-calls/redacted-request.json',
+      }),
+    );
+
+    expect(store.getProviderCallObservation('obs-metadata')).not.toHaveProperty(
+      'requestBodyRef',
+    );
+    expect(store.getProviderCallObservation('obs-metadata')).not.toHaveProperty(
+      'responseBodyRef',
+    );
+    expect(store.getProviderCallObservation('obs-metadata')).not.toHaveProperty(
+      'streamFramesRef',
+    );
+    expect(store.getProviderCallObservation('obs-redacted')).toMatchObject({
+      requestBodyRef: 'trajectory/provider-calls/redacted-request.json',
+    });
+    expect(() =>
+      store.recordProviderCallObservation(
+        observation({
+          observationId: 'obs-bad',
+          redactionState: 'redacted',
+          requestBodyRef: 'trajectory/provider-calls/../../raw.json',
+        }),
+      ),
+    ).toThrow(TrajectoryStoreError);
+    store.close();
+  });
+
+  it('queries with stable keyset pagination and confidence filtering', () => {
+    const store = new SqliteTrajectoryStore({ path: tempDbPath() });
+
+    store.appendTrajectorySegment(
+      segment({ segmentId: 'seg-1', sequence: 1, confidence: 'high' }),
+    );
+    store.appendTrajectorySegment(
+      segment({ segmentId: 'seg-2', sequence: 2, confidence: 'unknown' }),
+    );
+    store.appendTrajectorySegment(
+      segment({ segmentId: 'seg-3', sequence: 3, confidence: 'medium' }),
+    );
+
+    const firstPage = store.queryTrajectory({
+      sessionId: 'sess-1',
+      minConfidence: 'low',
+      limit: 1,
+    });
+    expect(firstPage.segments.map((s) => s.segmentId)).toEqual(['seg-1']);
+    expect(firstPage.nextCursor).toBeDefined();
+
+    const secondPage = store.queryTrajectory({
+      sessionId: 'sess-1',
+      minConfidence: 'low',
+      limit: 1,
+      cursor: firstPage.nextCursor,
+    });
+    expect(secondPage.segments.map((s) => s.segmentId)).toEqual(['seg-3']);
+    expect(secondPage.nextCursor).toBeUndefined();
+    store.close();
+  });
+
+  it('rejects invalid durable query limits and cursors', () => {
+    const store = new SqliteTrajectoryStore({ path: tempDbPath() });
+
+    expect(() => store.queryTrajectory({ limit: 0 })).toThrow(
+      TrajectoryStoreError,
+    );
+    expect(() => store.queryTrajectory({ cursor: 'not-a-durable-cursor' }))
+      .toThrow(TrajectoryStoreError);
+    store.close();
+  });
+
+  it('fails closed for duplicate segments and unsafe content refs', () => {
+    const store = new SqliteTrajectoryStore({ path: tempDbPath() });
+    store.appendTrajectorySegment(segment({ segmentId: 'seg-1' }));
+
+    expect(() => store.appendTrajectorySegment(segment({ segmentId: 'seg-1' })))
+      .toThrow(TrajectoryStoreError);
+    expect(() =>
+      store.appendTrajectorySegment(
+        segment({
+          segmentId: 'seg-unsafe',
+          contentRef: '/home/node/.codex/sessions/raw.jsonl',
+        }),
+      ),
+    ).toThrow(TrajectoryStoreError);
+    store.close();
+  });
+});
+
+function tempDbPath(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'agent-nexus-trajectory-'));
+  tempDirs.push(dir);
+  return join(dir, 'state.db');
+}
+
+function importRecord(
+  overrides: Partial<ExternalSessionImportRecord> = {},
+): ExternalSessionImportRecord {
+  return {
+    importId: 'imp-1',
+    sourceAdapter: 'codex-cli-jsonl',
+    sourceSessionId: 'source-1',
+    sourcePathHash: 'sha256:path',
+    nativeSessionRef: 'native-1',
+    state: 'registered',
+    confidence: 'high',
+    metadataJson: '{}',
+    discoveredAt: '2026-06-23T09:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function segment(overrides: Partial<TrajectorySegment> = {}): TrajectorySegment {
+  return {
+    segmentId: 'seg-1',
+    sessionId: 'sess-1',
+    importId: 'imp-1',
+    source: 'external-import',
+    kind: 'user-message',
+    sequence: 1,
+    ts: '2026-06-23T09:00:00.000Z',
+    summary: 'safe summary',
+    contentRef: 'trajectory/imports/imp-1/seg-1.json',
+    confidence: 'high',
+    redactionState: 'redacted',
+    metadataJson: '{}',
+    ...overrides,
+  };
+}
+
+function observation(
+  overrides: Partial<ProviderCallObservation> = {},
+): ProviderCallObservation {
+  return {
+    observationId: 'obs-1',
+    sessionId: 'sess-1',
+    traceId: 'trace-1',
+    backend: 'codex',
+    captureMode: 'transcript-only',
+    requestStartedAt: '2026-06-23T09:00:00.000Z',
+    responseFinishedAt: '2026-06-23T09:00:01.000Z',
+    providerHost: 'api.openai.com',
+    model: 'model-1',
+    requestSummary: 'safe request',
+    responseSummary: 'safe response',
+    requestBytes: 10,
+    responseBytes: 20,
+    redactionState: 'metadata-only',
+    alignment: { confidence: 'medium', turnSequence: 1, reasons: ['matched'] },
+    metadataJson: '{}',
+    ...overrides,
+  };
+}

--- a/packages/daemon/src/trajectory-store.ts
+++ b/packages/daemon/src/trajectory-store.ts
@@ -1,4 +1,9 @@
+import { createRequire } from 'node:module';
+import type DatabaseConstructor from 'better-sqlite3';
+import { type Database as BetterSqliteDatabase } from 'better-sqlite3';
 import { BasicRedactor, type Redactor } from './redaction.js';
+
+const require = createRequire(import.meta.url);
 
 export type TrajectoryConfidence = 'high' | 'medium' | 'low' | 'unknown';
 
@@ -355,6 +360,765 @@ export class InMemoryTrajectoryStore {
   private redact(value: string): string {
     return this.redactor.redact(value);
   }
+}
+
+export interface SqliteTrajectoryStoreInput {
+  path?: string;
+  database?: BetterSqliteDatabase;
+  redactor?: Redactor;
+}
+
+export class SqliteTrajectoryStore {
+  private readonly db: BetterSqliteDatabase;
+  private readonly ownsDatabase: boolean;
+  private readonly redactor: Redactor;
+
+  constructor(input: SqliteTrajectoryStoreInput = {}) {
+    this.db = input.database ?? createSqliteDatabase(input.path ?? ':memory:');
+    this.ownsDatabase = input.database === undefined;
+    this.redactor = input.redactor ?? new BasicRedactor();
+    initializeTrajectorySchema(this.db);
+  }
+
+  close(): void {
+    if (this.ownsDatabase && this.db.open) this.db.close();
+  }
+
+  upsertExternalSessionImport(record: ExternalSessionImportRecord): void {
+    const next = this.cloneImport(record);
+    this.db
+      .prepare(
+        `INSERT INTO external_session_imports (
+          import_id,
+          source_adapter,
+          source_session_id,
+          source_path_hash,
+          native_session_ref,
+          linked_session_id,
+          state,
+          confidence,
+          metadata_json,
+          error_json,
+          discovered_at,
+          imported_at,
+          linked_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(import_id) DO UPDATE SET
+          source_adapter = excluded.source_adapter,
+          source_session_id = excluded.source_session_id,
+          source_path_hash = excluded.source_path_hash,
+          native_session_ref = excluded.native_session_ref,
+          linked_session_id = excluded.linked_session_id,
+          state = excluded.state,
+          confidence = excluded.confidence,
+          metadata_json = excluded.metadata_json,
+          error_json = excluded.error_json,
+          discovered_at = excluded.discovered_at,
+          imported_at = excluded.imported_at,
+          linked_at = excluded.linked_at`,
+      )
+      .run(
+        next.importId,
+        next.sourceAdapter,
+        next.sourceSessionId,
+        next.sourcePathHash,
+        next.nativeSessionRef ?? null,
+        next.linkedSessionId ?? null,
+        next.state,
+        next.confidence,
+        next.metadataJson,
+        next.error ? JSON.stringify(next.error) : null,
+        next.discoveredAt,
+        next.importedAt ?? null,
+        next.linkedAt ?? null,
+      );
+  }
+
+  getExternalSessionImport(
+    importId: string,
+  ): ExternalSessionImportRecord | undefined {
+    const row = this.db
+      .prepare('SELECT * FROM external_session_imports WHERE import_id = ?')
+      .get(importId) as ExternalSessionImportRow | undefined;
+    return row ? this.cloneImport(importFromRow(row)) : undefined;
+  }
+
+  linkExternalSession(input: LinkExternalSessionInput): ExternalResumeBinding {
+    return this.db.transaction((linkInput: LinkExternalSessionInput) => {
+      const existing = this.getExternalSessionImport(linkInput.importId);
+      if (!existing) {
+        throw new TrajectoryStoreError(
+          'external-import-not-found',
+          `External import ${linkInput.importId} was not found`,
+        );
+      }
+
+      const nativeSessionRef =
+        linkInput.nativeSessionRef ?? existing.nativeSessionRef;
+      if (!nativeSessionRef) {
+        throw new TrajectoryStoreError(
+          'native-resume-unavailable',
+          `External import ${linkInput.importId} has no native session ref`,
+        );
+      }
+      if (existing.state !== 'registered' && existing.state !== 'imported') {
+        throw new TrajectoryStoreError(
+          'invalid-import-state',
+          `External import ${linkInput.importId} cannot be linked from state ${existing.state}`,
+        );
+      }
+
+      this.db
+        .prepare(
+          `UPDATE external_session_imports
+           SET native_session_ref = ?,
+               linked_session_id = ?,
+               state = 'linked',
+               linked_at = ?
+           WHERE import_id = ?`,
+        )
+        .run(
+          nativeSessionRef,
+          linkInput.sessionId,
+          linkInput.linkedAt,
+          linkInput.importId,
+        );
+
+      return {
+        sessionId: linkInput.sessionId,
+        importId: existing.importId,
+        sourceAdapter: existing.sourceAdapter,
+        sourceSessionId: existing.sourceSessionId,
+        nativeSessionRef,
+        confidence: existing.confidence,
+        linkedAt: linkInput.linkedAt,
+      };
+    })(input);
+  }
+
+  appendTrajectorySegment(segment: TrajectorySegment): void {
+    if (this.hasRecord('trajectory_segments', 'segment_id', segment.segmentId)) {
+      throw new TrajectoryStoreError(
+        'duplicate-record',
+        `Trajectory segment ${segment.segmentId} already exists`,
+      );
+    }
+    if (segment.redactionState === 'dropped' && segment.contentRef) {
+      throw new TrajectoryStoreError(
+        'invalid-content-ref',
+        'Trajectory segment with dropped redaction state cannot keep contentRef',
+      );
+    }
+    if (segment.contentRef) assertManagedContentRef(segment.contentRef);
+
+    const next = this.cloneSegment(segment);
+    this.db
+      .prepare(
+        `INSERT INTO trajectory_segments (
+          segment_id,
+          session_id,
+          import_id,
+          provider_observation_id,
+          source,
+          kind,
+          trace_id,
+          turn_sequence,
+          sequence,
+          ts,
+          summary,
+          content_ref,
+          usage_event_id,
+          log_anchor_json,
+          confidence,
+          redaction_state,
+          metadata_json
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        next.segmentId,
+        next.sessionId ?? null,
+        next.importId ?? null,
+        next.providerObservationId ?? null,
+        next.source,
+        next.kind,
+        next.traceId ?? null,
+        next.turnSequence ?? null,
+        next.sequence,
+        next.ts,
+        next.summary,
+        next.contentRef ?? null,
+        next.usageEventId ?? null,
+        next.logAnchor ? JSON.stringify(next.logAnchor) : null,
+        next.confidence,
+        next.redactionState,
+        next.metadataJson,
+      );
+  }
+
+  recordProviderCallObservation(observation: ProviderCallObservation): void {
+    if (
+      this.hasRecord(
+        'provider_call_observations',
+        'observation_id',
+        observation.observationId,
+      )
+    ) {
+      throw new TrajectoryStoreError(
+        'duplicate-record',
+        `Provider observation ${observation.observationId} already exists`,
+      );
+    }
+
+    const next = this.cloneObservation(observation);
+    if (next.redactionState !== 'redacted') {
+      delete next.requestBodyRef;
+      delete next.responseBodyRef;
+      delete next.streamFramesRef;
+    } else {
+      if (next.requestBodyRef) assertManagedProviderRef(next.requestBodyRef);
+      if (next.responseBodyRef) assertManagedProviderRef(next.responseBodyRef);
+      if (next.streamFramesRef) assertManagedProviderRef(next.streamFramesRef);
+    }
+
+    this.db
+      .prepare(
+        `INSERT INTO provider_call_observations (
+          observation_id,
+          session_id,
+          trace_id,
+          backend,
+          capture_mode,
+          request_started_at,
+          response_finished_at,
+          provider_host,
+          model,
+          request_summary,
+          response_summary,
+          request_body_ref,
+          response_body_ref,
+          stream_frames_ref,
+          request_bytes,
+          response_bytes,
+          redaction_state,
+          alignment_json,
+          error_code,
+          metadata_json
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        next.observationId,
+        next.sessionId ?? null,
+        next.traceId ?? null,
+        next.backend,
+        next.captureMode,
+        next.requestStartedAt,
+        next.responseFinishedAt ?? null,
+        next.providerHost ?? null,
+        next.model ?? null,
+        next.requestSummary,
+        next.responseSummary ?? null,
+        next.requestBodyRef ?? null,
+        next.responseBodyRef ?? null,
+        next.streamFramesRef ?? null,
+        next.requestBytes,
+        next.responseBytes ?? null,
+        next.redactionState,
+        JSON.stringify(next.alignment),
+        next.errorCode ?? null,
+        next.metadataJson,
+      );
+  }
+
+  getProviderCallObservation(
+    observationId: string,
+  ): ProviderCallObservation | undefined {
+    const row = this.db
+      .prepare('SELECT * FROM provider_call_observations WHERE observation_id = ?')
+      .get(observationId) as ProviderCallObservationRow | undefined;
+    return row ? this.cloneObservation(observationFromRow(row)) : undefined;
+  }
+
+  queryTrajectory(query: TrajectoryQuery): TrajectoryPage {
+    const limit = normalizeLimit(query.limit);
+    const cursor = decodeTrajectoryCursor(query.cursor);
+    const { whereSql, values } = buildTrajectoryWhere(query, cursor);
+    // Content dereference stays out of this durable read-model store; callers only get redacted anchors here.
+    void query.includeContent;
+
+    const rows = this.db
+      .prepare(
+        `SELECT * FROM trajectory_segments
+         ${whereSql}
+         ORDER BY ts ASC, sequence ASC, segment_id ASC
+         LIMIT ?`,
+      )
+      .all(...values, limit + 1) as TrajectorySegmentRow[];
+
+    const pageRows = rows.slice(0, limit);
+    const segments = pageRows.map((row) => this.cloneSegment(segmentFromRow(row)));
+    const last = pageRows.at(-1);
+
+    return {
+      segments,
+      nextCursor:
+        rows.length > limit && last
+          ? encodeTrajectoryCursor({
+              ts: last.ts,
+              sequence: last.sequence,
+              segmentId: last.segment_id,
+            })
+          : undefined,
+    };
+  }
+
+  private hasRecord(
+    table: 'trajectory_segments' | 'provider_call_observations',
+    column: 'segment_id' | 'observation_id',
+    id: string,
+  ): boolean {
+    const row = this.db
+      .prepare(`SELECT 1 AS found FROM ${table} WHERE ${column} = ?`)
+      .get(id) as { found: 1 } | undefined;
+    return row !== undefined;
+  }
+
+  private cloneImport(record: ExternalSessionImportRecord): ExternalSessionImportRecord {
+    return {
+      ...record,
+      metadataJson: this.redact(record.metadataJson),
+      error: record.error
+        ? {
+            ...record.error,
+            message: this.redact(record.error.message),
+          }
+        : undefined,
+    };
+  }
+
+  private cloneSegment(segment: TrajectorySegment): TrajectorySegment {
+    return {
+      ...segment,
+      summary: this.redact(segment.summary),
+      logAnchor: segment.logAnchor ? { ...segment.logAnchor } : undefined,
+      metadataJson: this.redact(segment.metadataJson),
+    };
+  }
+
+  private cloneObservation(
+    observation: ProviderCallObservation,
+  ): ProviderCallObservation {
+    return {
+      ...observation,
+      requestSummary: this.redact(observation.requestSummary),
+      responseSummary: observation.responseSummary
+        ? this.redact(observation.responseSummary)
+        : undefined,
+      alignment: {
+        ...observation.alignment,
+        reasons: [...observation.alignment.reasons],
+      },
+      metadataJson: this.redact(observation.metadataJson),
+    };
+  }
+
+  private redact(value: string): string {
+    return this.redactor.redact(value);
+  }
+}
+
+function createSqliteDatabase(path: string): BetterSqliteDatabase {
+  const Database = require('better-sqlite3') as typeof DatabaseConstructor;
+  return new Database(path);
+}
+
+interface ExternalSessionImportRow {
+  import_id: string;
+  source_adapter: string;
+  source_session_id: string;
+  source_path_hash: string;
+  native_session_ref: string | null;
+  linked_session_id: string | null;
+  state: ExternalSessionImportState;
+  confidence: TrajectoryConfidence;
+  metadata_json: string;
+  error_json: string | null;
+  discovered_at: string;
+  imported_at: string | null;
+  linked_at: string | null;
+}
+
+interface TrajectorySegmentRow {
+  segment_id: string;
+  session_id: string | null;
+  import_id: string | null;
+  provider_observation_id: string | null;
+  source: TrajectorySegmentSource;
+  kind: TrajectorySegmentKind;
+  trace_id: string | null;
+  turn_sequence: number | null;
+  sequence: number;
+  ts: string;
+  summary: string;
+  content_ref: string | null;
+  usage_event_id: string | null;
+  log_anchor_json: string | null;
+  confidence: TrajectoryConfidence;
+  redaction_state: TrajectoryRedactionState;
+  metadata_json: string;
+}
+
+interface ProviderCallObservationRow {
+  observation_id: string;
+  session_id: string | null;
+  trace_id: string | null;
+  backend: string;
+  capture_mode: ProviderCallObservation['captureMode'];
+  request_started_at: string;
+  response_finished_at: string | null;
+  provider_host: string | null;
+  model: string | null;
+  request_summary: string;
+  response_summary: string | null;
+  request_body_ref: string | null;
+  response_body_ref: string | null;
+  stream_frames_ref: string | null;
+  request_bytes: number;
+  response_bytes: number | null;
+  redaction_state: TrajectoryRedactionState;
+  alignment_json: string;
+  error_code: string | null;
+  metadata_json: string;
+}
+
+interface SqliteTrajectoryCursor {
+  ts: string;
+  sequence: number;
+  segmentId: string;
+}
+
+function initializeTrajectorySchema(db: BetterSqliteDatabase): void {
+  // The initial trajectory tables keep nullable cross-links application-owned until sessions/usage are durable.
+  db.pragma('foreign_keys = ON');
+  db.pragma('journal_mode = WAL');
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS external_session_imports (
+      import_id TEXT PRIMARY KEY,
+      source_adapter TEXT NOT NULL,
+      source_session_id TEXT NOT NULL,
+      source_path_hash TEXT NOT NULL,
+      native_session_ref TEXT,
+      linked_session_id TEXT,
+      state TEXT NOT NULL,
+      confidence TEXT NOT NULL,
+      metadata_json TEXT NOT NULL,
+      error_json TEXT,
+      discovered_at TEXT NOT NULL,
+      imported_at TEXT,
+      linked_at TEXT
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_external_session_imports_source
+      ON external_session_imports(source_adapter, source_session_id);
+    CREATE INDEX IF NOT EXISTS idx_external_session_imports_linked_session
+      ON external_session_imports(linked_session_id);
+    CREATE INDEX IF NOT EXISTS idx_external_session_imports_state
+      ON external_session_imports(state, discovered_at DESC);
+
+    CREATE TABLE IF NOT EXISTS trajectory_segments (
+      segment_id TEXT PRIMARY KEY,
+      session_id TEXT,
+      import_id TEXT,
+      provider_observation_id TEXT,
+      source TEXT NOT NULL,
+      kind TEXT NOT NULL,
+      trace_id TEXT,
+      turn_sequence INTEGER,
+      sequence INTEGER NOT NULL,
+      ts TEXT NOT NULL,
+      summary TEXT NOT NULL,
+      content_ref TEXT,
+      usage_event_id TEXT,
+      log_anchor_json TEXT,
+      confidence TEXT NOT NULL,
+      redaction_state TEXT NOT NULL,
+      metadata_json TEXT NOT NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_trajectory_segments_session
+      ON trajectory_segments(session_id, ts, sequence);
+    CREATE INDEX IF NOT EXISTS idx_trajectory_segments_import
+      ON trajectory_segments(import_id, ts, sequence);
+    CREATE INDEX IF NOT EXISTS idx_trajectory_segments_source_kind
+      ON trajectory_segments(source, kind);
+
+    CREATE TABLE IF NOT EXISTS provider_call_observations (
+      observation_id TEXT PRIMARY KEY,
+      session_id TEXT,
+      trace_id TEXT,
+      backend TEXT NOT NULL,
+      capture_mode TEXT NOT NULL,
+      request_started_at TEXT NOT NULL,
+      response_finished_at TEXT,
+      provider_host TEXT,
+      model TEXT,
+      request_summary TEXT NOT NULL,
+      response_summary TEXT,
+      request_body_ref TEXT,
+      response_body_ref TEXT,
+      stream_frames_ref TEXT,
+      request_bytes INTEGER NOT NULL,
+      response_bytes INTEGER,
+      redaction_state TEXT NOT NULL,
+      alignment_json TEXT NOT NULL,
+      error_code TEXT,
+      metadata_json TEXT NOT NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_provider_call_observations_session
+      ON provider_call_observations(session_id, request_started_at);
+    CREATE INDEX IF NOT EXISTS idx_provider_call_observations_backend
+      ON provider_call_observations(backend, request_started_at);
+  `);
+}
+
+function importFromRow(row: ExternalSessionImportRow): ExternalSessionImportRecord {
+  const record: ExternalSessionImportRecord = {
+    importId: row.import_id,
+    sourceAdapter: row.source_adapter,
+    sourceSessionId: row.source_session_id,
+    sourcePathHash: row.source_path_hash,
+    state: row.state,
+    confidence: row.confidence,
+    metadataJson: row.metadata_json,
+    discoveredAt: row.discovered_at,
+  };
+  if (row.native_session_ref !== null) record.nativeSessionRef = row.native_session_ref;
+  if (row.linked_session_id !== null) record.linkedSessionId = row.linked_session_id;
+  if (row.error_json !== null) record.error = parseImportError(row.error_json);
+  if (row.imported_at !== null) record.importedAt = row.imported_at;
+  if (row.linked_at !== null) record.linkedAt = row.linked_at;
+  return record;
+}
+
+function segmentFromRow(row: TrajectorySegmentRow): TrajectorySegment {
+  const segment: TrajectorySegment = {
+    segmentId: row.segment_id,
+    source: row.source,
+    kind: row.kind,
+    sequence: row.sequence,
+    ts: row.ts,
+    summary: row.summary,
+    confidence: row.confidence,
+    redactionState: row.redaction_state,
+    metadataJson: row.metadata_json,
+  };
+  if (row.session_id !== null) segment.sessionId = row.session_id;
+  if (row.import_id !== null) segment.importId = row.import_id;
+  if (row.provider_observation_id !== null) {
+    segment.providerObservationId = row.provider_observation_id;
+  }
+  if (row.trace_id !== null) segment.traceId = row.trace_id;
+  if (row.turn_sequence !== null) segment.turnSequence = row.turn_sequence;
+  if (row.content_ref !== null) segment.contentRef = row.content_ref;
+  if (row.usage_event_id !== null) segment.usageEventId = row.usage_event_id;
+  if (row.log_anchor_json !== null) {
+    segment.logAnchor = parseLogAnchor(row.log_anchor_json);
+  }
+  return segment;
+}
+
+function observationFromRow(
+  row: ProviderCallObservationRow,
+): ProviderCallObservation {
+  const observation: ProviderCallObservation = {
+    observationId: row.observation_id,
+    backend: row.backend,
+    captureMode: row.capture_mode,
+    requestStartedAt: row.request_started_at,
+    requestSummary: row.request_summary,
+    requestBytes: row.request_bytes,
+    redactionState: row.redaction_state,
+    alignment: parseProviderAlignment(row.alignment_json),
+    metadataJson: row.metadata_json,
+  };
+  if (row.session_id !== null) observation.sessionId = row.session_id;
+  if (row.trace_id !== null) observation.traceId = row.trace_id;
+  if (row.response_finished_at !== null) {
+    observation.responseFinishedAt = row.response_finished_at;
+  }
+  if (row.provider_host !== null) observation.providerHost = row.provider_host;
+  if (row.model !== null) observation.model = row.model;
+  if (row.response_summary !== null) observation.responseSummary = row.response_summary;
+  if (row.request_body_ref !== null) observation.requestBodyRef = row.request_body_ref;
+  if (row.response_body_ref !== null) observation.responseBodyRef = row.response_body_ref;
+  if (row.stream_frames_ref !== null) observation.streamFramesRef = row.stream_frames_ref;
+  if (row.response_bytes !== null) observation.responseBytes = row.response_bytes;
+  if (row.error_code !== null) observation.errorCode = row.error_code;
+  return observation;
+}
+
+function buildTrajectoryWhere(
+  query: TrajectoryQuery,
+  cursor: SqliteTrajectoryCursor | undefined,
+): { whereSql: string; values: Array<string | number> } {
+  const predicates: string[] = [];
+  const values: Array<string | number> = [];
+  const kinds = query.kinds;
+
+  if (query.sessionId) addPredicate('session_id = ?', query.sessionId);
+  if (query.importId) addPredicate('import_id = ?', query.importId);
+  if (query.source) addPredicate('source = ?', query.source);
+  if (kinds && kinds.length > 0) {
+    predicates.push(`kind IN (${kinds.map(() => '?').join(', ')})`);
+    values.push(...kinds);
+  }
+  if (kinds && kinds.length === 0) predicates.push('0 = 1');
+  if (query.since) addPredicate('ts >= ?', query.since);
+  if (query.until) addPredicate('ts <= ?', query.until);
+  if (query.minConfidence !== undefined) {
+    const allowed = confidenceValuesAtLeast(query.minConfidence);
+    predicates.push(`confidence IN (${allowed.map(() => '?').join(', ')})`);
+    values.push(...allowed);
+  }
+  if (cursor) {
+    predicates.push(
+      '(ts > ? OR (ts = ? AND sequence > ?) OR (ts = ? AND sequence = ? AND segment_id > ?))',
+    );
+    values.push(
+      cursor.ts,
+      cursor.ts,
+      cursor.sequence,
+      cursor.ts,
+      cursor.sequence,
+      cursor.segmentId,
+    );
+  }
+
+  return {
+    whereSql: predicates.length > 0 ? `WHERE ${predicates.join(' AND ')}` : '',
+    values,
+  };
+
+  function addPredicate(sql: string, value: string): void {
+    predicates.push(sql);
+    values.push(value);
+  }
+}
+
+function confidenceValuesAtLeast(
+  minimum: TrajectoryConfidence,
+): TrajectoryConfidence[] {
+  return (['high', 'medium', 'low'] as const).filter((confidence) =>
+    confidenceMeetsMinimum(confidence, minimum),
+  );
+}
+
+function encodeTrajectoryCursor(cursor: SqliteTrajectoryCursor): string {
+  return Buffer.from(JSON.stringify(cursor), 'utf8').toString('base64url');
+}
+
+function decodeTrajectoryCursor(
+  cursor: string | undefined,
+): SqliteTrajectoryCursor | undefined {
+  if (cursor === undefined) return undefined;
+  try {
+    const parsed = JSON.parse(
+      Buffer.from(cursor, 'base64url').toString('utf8'),
+    ) as Partial<SqliteTrajectoryCursor>;
+    if (
+      typeof parsed.ts === 'string' &&
+      typeof parsed.sequence === 'number' &&
+      Number.isInteger(parsed.sequence) &&
+      typeof parsed.segmentId === 'string'
+    ) {
+      return {
+        ts: parsed.ts,
+        sequence: parsed.sequence,
+        segmentId: parsed.segmentId,
+      };
+    }
+  } catch {
+    // Fall through to the stable store error below.
+  }
+  throw new TrajectoryStoreError(
+    'invalid-query',
+    'Trajectory query cursor is not a valid durable cursor',
+  );
+}
+
+function parseImportError(value: string): TrajectoryImportError {
+  const parsed = parseJsonObject(value, 'import error');
+  if (
+    typeof parsed.code === 'string' &&
+    typeof parsed.message === 'string' &&
+    typeof parsed.retryable === 'boolean'
+  ) {
+    return {
+      code: parsed.code,
+      message: parsed.message,
+      retryable: parsed.retryable,
+    };
+  }
+  throw invalidStoredJson('import error');
+}
+
+function parseLogAnchor(value: string): TrajectoryLogAnchor {
+  const parsed = parseJsonObject(value, 'trajectory log anchor');
+  const anchor: TrajectoryLogAnchor = {};
+  if (typeof parsed.logFile === 'string') anchor.logFile = parsed.logFile;
+  if (typeof parsed.byteOffset === 'number') anchor.byteOffset = parsed.byteOffset;
+  if (typeof parsed.event === 'string') anchor.event = parsed.event;
+  return anchor;
+}
+
+function parseProviderAlignment(value: string): ProviderTurnAlignment {
+  const parsed = parseJsonObject(value, 'provider alignment');
+  if (
+    isTrajectoryConfidence(parsed.confidence) &&
+    Array.isArray(parsed.reasons) &&
+    parsed.reasons.every((reason) => typeof reason === 'string')
+  ) {
+    const alignment: ProviderTurnAlignment = {
+      confidence: parsed.confidence,
+      reasons: parsed.reasons,
+    };
+    if (typeof parsed.turnSequence === 'number') {
+      alignment.turnSequence = parsed.turnSequence;
+    }
+    if (typeof parsed.agentEventSequence === 'number') {
+      alignment.agentEventSequence = parsed.agentEventSequence;
+    }
+    return alignment;
+  }
+  throw invalidStoredJson('provider alignment');
+}
+
+function parseJsonObject(value: string, label: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    // Fall through to the stable store error below.
+  }
+  throw invalidStoredJson(label);
+}
+
+function invalidStoredJson(label: string): TrajectoryStoreError {
+  return new TrajectoryStoreError(
+    'invalid-query',
+    `Stored ${label} JSON is invalid`,
+  );
+}
+
+function isTrajectoryConfidence(value: unknown): value is TrajectoryConfidence {
+  return (
+    value === 'high' ||
+    value === 'medium' ||
+    value === 'low' ||
+    value === 'unknown'
+  );
 }
 
 function confidenceRank(confidence: TrajectoryConfidence): number {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,12 +84,19 @@ importers:
       '@agent-nexus/protocol':
         specifier: workspace:*
         version: link:../protocol
+      better-sqlite3:
+        specifier: ^12.11.1
+        version: 12.11.1
       pino:
         specifier: ^9.5.0
         version: 9.14.0
       pino-pretty:
         specifier: ^11.3.0
         version: 11.3.0
+    devDependencies:
+      '@types/better-sqlite3':
+        specifier: ^7.6.13
+        version: 7.6.13
 
   packages/platform/discord:
     dependencies:
@@ -596,6 +603,9 @@ packages:
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
+  '@types/better-sqlite3@7.6.13':
+    resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -653,6 +663,19 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
+  better-sqlite3@12.11.1:
+    resolution: {integrity: sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==}
+    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x || 26.x}
+
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
@@ -667,6 +690,9 @@ packages:
   check-error@2.1.3:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
+
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
@@ -687,9 +713,21 @@ packages:
       supports-color:
         optional: true
 
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
+
+  deep-extend@0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
 
   discord-api-types@0.38.47:
     resolution: {integrity: sha512-XgXQodHQBAE6kfD7kMvVo30863iHX1LHSqNq6MGUTDwIFCCvHva13+rwxyxVXDqudyApMNAd32PGjgVETi5rjA==}
@@ -729,6 +767,10 @@ packages:
     resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
     engines: {node: ^18.19.0 || >=20.5.0}
 
+  expand-template@2.0.3:
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
+    engines: {node: '>=6'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -746,6 +788,12 @@ packages:
     resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
     engines: {node: '>=18'}
 
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -758,6 +806,9 @@ packages:
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
 
+  github-from-package@0.0.0:
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
+
   help-me@5.0.0:
     resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
 
@@ -767,6 +818,12 @@ packages:
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
@@ -802,8 +859,15 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -812,6 +876,13 @@ packages:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  napi-build-utils@2.0.0:
+    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
+
+  node-abi@3.92.0:
+    resolution: {integrity: sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==}
+    engines: {node: '>=10'}
 
   npm-run-path@6.0.0:
     resolution: {integrity: sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==}
@@ -864,6 +935,12 @@ packages:
     resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
     engines: {node: ^10 || ^12 || >=14}
 
+  prebuild-install@7.1.3:
+    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
+    engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
+    hasBin: true
+
   pretty-ms@9.3.0:
     resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
     engines: {node: '>=18'}
@@ -880,6 +957,14 @@ packages:
 
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
+
+  rc@1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
+
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
 
   readable-stream@4.7.0:
     resolution: {integrity: sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==}
@@ -907,6 +992,11 @@ packages:
   secure-json-parse@2.7.0:
     resolution: {integrity: sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==}
 
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -921,6 +1011,12 @@ packages:
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+
+  simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+
+  simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
 
   sonic-boom@4.2.1:
     resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
@@ -946,9 +1042,20 @@ packages:
     resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
     engines: {node: '>=18'}
 
+  strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
+
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  tar-fs@2.1.4:
+    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
+
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
 
   thread-stream@3.1.0:
     resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
@@ -982,6 +1089,9 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
+  tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -997,6 +1107,9 @@ packages:
   unicorn-magic@0.3.0:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
     engines: {node: '>=18'}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   vite-node@2.1.9:
     resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
@@ -1380,6 +1493,10 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
+  '@types/better-sqlite3@7.6.13':
+    dependencies:
+      '@types/node': 22.19.17
+
   '@types/estree@1.0.8': {}
 
   '@types/node@22.19.17':
@@ -1442,6 +1559,26 @@ snapshots:
 
   base64-js@1.5.1: {}
 
+  better-sqlite3@12.11.1:
+    dependencies:
+      bindings: 1.5.0
+      prebuild-install: 7.1.3
+
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
+
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
   buffer@6.0.3:
     dependencies:
       base64-js: 1.5.1
@@ -1459,6 +1596,8 @@ snapshots:
 
   check-error@2.1.3: {}
 
+  chownr@1.1.4: {}
+
   colorette@2.0.20: {}
 
   cross-spawn@7.0.6:
@@ -1473,7 +1612,15 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
   deep-eql@5.0.2: {}
+
+  deep-extend@0.6.0: {}
+
+  detect-libc@2.1.2: {}
 
   discord-api-types@0.38.47: {}
 
@@ -1580,6 +1727,8 @@ snapshots:
       strip-final-newline: 4.0.0
       yoctocolors: 2.1.2
 
+  expand-template@2.0.3: {}
+
   expect-type@1.3.0: {}
 
   fast-copy@3.0.2: {}
@@ -1591,6 +1740,10 @@ snapshots:
   figures@6.1.0:
     dependencies:
       is-unicode-supported: 2.1.0
+
+  file-uri-to-path@1.0.0: {}
+
+  fs-constants@1.0.0: {}
 
   fsevents@2.3.3:
     optional: true
@@ -1604,11 +1757,17 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
+  github-from-package@0.0.0: {}
+
   help-me@5.0.0: {}
 
   human-signals@8.0.1: {}
 
   ieee754@1.2.1: {}
+
+  inherits@2.0.4: {}
+
+  ini@1.3.8: {}
 
   is-plain-obj@4.1.0: {}
 
@@ -1632,11 +1791,21 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  mimic-response@3.1.0: {}
+
   minimist@1.2.8: {}
+
+  mkdirp-classic@0.5.3: {}
 
   ms@2.1.3: {}
 
   nanoid@3.3.11: {}
+
+  napi-build-utils@2.0.0: {}
+
+  node-abi@3.92.0:
+    dependencies:
+      semver: 7.8.5
 
   npm-run-path@6.0.0:
     dependencies:
@@ -1704,6 +1873,21 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  prebuild-install@7.1.3:
+    dependencies:
+      detect-libc: 2.1.2
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 2.0.0
+      node-abi: 3.92.0
+      pump: 3.0.4
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.4
+      tunnel-agent: 0.6.0
+
   pretty-ms@9.3.0:
     dependencies:
       parse-ms: 4.0.0
@@ -1718,6 +1902,19 @@ snapshots:
       once: 1.4.0
 
   quick-format-unescaped@4.0.4: {}
+
+  rc@1.2.8:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
 
   readable-stream@4.7.0:
     dependencies:
@@ -1768,6 +1965,8 @@ snapshots:
 
   secure-json-parse@2.7.0: {}
 
+  semver@7.8.5: {}
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
@@ -1777,6 +1976,14 @@ snapshots:
   siginfo@2.0.0: {}
 
   signal-exit@4.1.0: {}
+
+  simple-concat@1.0.1: {}
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
 
   sonic-boom@4.2.1:
     dependencies:
@@ -1796,7 +2003,24 @@ snapshots:
 
   strip-final-newline@4.0.0: {}
 
+  strip-json-comments@2.0.1: {}
+
   strip-json-comments@3.1.1: {}
+
+  tar-fs@2.1.4:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.4
+      tar-stream: 2.2.0
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   thread-stream@3.1.0:
     dependencies:
@@ -1823,6 +2047,10 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
   typescript@5.9.3: {}
 
   undici-types@6.21.0: {}
@@ -1830,6 +2058,8 @@ snapshots:
   undici@6.24.1: {}
 
   unicorn-magic@0.3.0: {}
+
+  util-deprecate@1.0.2: {}
 
   vite-node@2.1.9(@types/node@22.19.17):
     dependencies:


### PR DESCRIPTION
## Summary

This PR implements the P4 durable trajectory read model core for Agent Nexus. It keeps the work inside daemon storage boundaries and does not wire the read model into engine/router/session callers yet.

本 PR：
- Adds `SqliteTrajectoryStore` with schema initialization for `external_session_imports`, `trajectory_segments`, and `provider_call_observations`.
- Persists external import records, native resume links, trajectory segments, provider-call observations, redaction-safe summaries/metadata, and managed payload refs.
- Adds keyset pagination, confidence filtering, duplicate detection, unsafe ref rejection, and fail-closed durable link/query error tests.
- Adds `better-sqlite3` as the daemon SQLite dependency with a pnpm build-script allowlist and lazy runtime loading.
- Updates persistence spec text so `trajectory_segments.usage_event_id` is documented as the string projection of `usage_events.id`.

## Why

P3 created the in-memory scaffold for the trajectory read model. P4 needs a durable daemon-owned implementation before later phases can discover/import external sessions and integrate callers/configuration.

`better-sqlite3` is used because SQLite is an approved daemon dependency category and ADR-0004 already names it as the expected Node native SQLite dependency. Alternatives considered: `node:sqlite` is not viable for the current Node >=20.10 contract, and ad hoc JSON storage would not match the persistence spec indexes/query contract.

ADR: `docs/dev/adr/0018-trajectory-observability-read-model.md`
Spec: `docs/dev/spec/infra/trajectory-observability.md`, `docs/dev/spec/infra/persistence.md`

## Test plan

- [x] Tests: `packages/daemon/src/trajectory-sqlite-store.test.ts` covers durable reopen, redaction, provider refs, link fail-closed states, invalid query input, keyset pagination, duplicate records, and unsafe content refs.
- [x] `corepack pnpm test -- packages/daemon/src/trajectory-sqlite-store.test.ts` — passed, 34 files / 529 tests.
- [x] `corepack pnpm test` — passed, 34 files / 529 tests.
- [x] `corepack pnpm typecheck` — passed.
- [x] `corepack pnpm build` — passed.
- [x] `corepack pnpm install --frozen-lockfile` — passed.
- [x] `git diff --check` — passed.
- [x] `git diff --cached --check` — passed before commit.
- [ ] Manual: not run; this PR does not expose a CLI/user path yet, and caller integration is intentionally deferred to P5.

## Review notes

- Independent agent review: `/home/node/.goal/agent-nexus-trajectory-observability/reviews/p4-durable-store-claude-review-20260623.md` and re-review `/home/node/.goal/agent-nexus-trajectory-observability/reviews/p4-durable-store-claude-rereview-20260623.md`; final re-review conclusion: APPROVE.
- Deep review: N/A - this is a scoped implementation PR for the accepted P2 spec/ADR; broad architecture/spec review was completed in P2.

## Out of scope

- Calling `SqliteTrajectoryStore` from engine/router/session code.
- External source adapters and transcript discovery/import scanning.
- Provider proxy/capture implementation.
- Content dereference for `includeContent=true`.
- Full migration/version framework for the broader daemon SQLite store.
- End-to-end runtime verification.