### PR TITLE
feat(daemon): wire trajectory read model into engine

### DIFF
--- a/docs/dev/spec/config-routing.md
+++ b/docs/dev/spec/config-routing.md
@@ -363,7 +363,7 @@ platformName + platform + channelId + initiatorUserId
 - `platforms[].auth` 的热应用以**重启等价**为准：成功 reload 后 daemon engine 鉴权（全维度 allowlist）与 platform adapter 内部授权数据（inbound guard、`/discord-reply-mode` 的 userIds 列表）必须与用新配置重启进程后一致；只换其一视为违反本 spec。
 - 已知限制（重启路径同样受限）：adapter 内部命令（`/discord-reply-mode`）的授权仅基于 `userIds` 维度；role / guild / channel 维度待 platform command 经 daemon dispatch 统一鉴权后覆盖。
 - `ui.toolMessages` 与 `textPrefixes` 在 turn 边界生效：进行中的 turn 沿用其开始时的值，不得中途混合渲染。
-- 仅重启生效字段：`platforms[]` 其余字段、`agents[]`、`log`、`daemon.commandRegistry` 其余字段。这些 section 有变化时，成功响应必须提示重启后才生效。
+- 仅重启生效字段：`platforms[]` 其余字段、`agents[]`、`log`、`daemon.commandRegistry` 其余字段、`daemon.trajectory`。这些 section 有变化时，成功响应必须提示重启后才生效。
 
 并发与时序：
 

--- a/docs/dev/spec/infra/trajectory-observability.md
+++ b/docs/dev/spec/infra/trajectory-observability.md
@@ -81,7 +81,7 @@ ExternalImportSourceConfig {
 
 ProviderCaptureConfig {
     enabled: boolean = false
-    mode: "reverse-proxy" | "forward-proxy" | "transcript-only"
+    mode: "reverse-proxy" | "forward-proxy" | "transcript-only" = "transcript-only"
     bindHost: string = "127.0.0.1"
     port: integer? = null
     storeRawStreams: boolean = false

--- a/packages/cli/src/config-reload.test.ts
+++ b/packages/cli/src/config-reload.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
-import { createLogger, type EngineRuntimeUpdate } from '@agent-nexus/daemon';
+import {
+  DEFAULT_DAEMON_RUNTIME_CONFIG,
+  createLogger,
+  type EngineRuntimeUpdate,
+} from '@agent-nexus/daemon';
 import { ConfigError, type AgentConfig, type AgentNexusConfig } from './config.js';
 import { createConfigReloader } from './config-reload.js';
 
@@ -60,20 +64,7 @@ function baseConfig(overrides: Partial<AgentNexusConfig> = {}): AgentNexusConfig
         match: { discord: { channelIds: ['C1'] } },
       },
     ],
-    daemon: {
-      commandRegistry: {
-        registration: {
-          enabled: true,
-          applyTimeoutMs: 30000,
-          retry: { maxAttempts: 1, backoffMs: 0 },
-        },
-        aliases: {
-          singleAgent: { enabled: true },
-          legacy: { replyMode: true },
-        },
-        textPrefixes: { newSession: true },
-      },
-    },
+    daemon: structuredClone(DEFAULT_DAEMON_RUNTIME_CONFIG),
     ui: { toolMessages: 'append' },
     log: { level: 'info' },
     ...overrides,
@@ -259,5 +250,28 @@ describe('createConfigReloader', () => {
     expect(result.message).toContain('restart required');
     expect(result.message).toContain('agents');
     expect(result.message).toContain('log');
+  });
+
+  it('daemon.trajectory 变化时成功响应带重启提示但不热更新 trajectory', async () => {
+    const target = makeTarget('discord-main');
+    const next = baseConfig();
+    next.daemon.trajectory.enabled = false;
+
+    const reload = createConfigReloader({
+      initialConfig: baseConfig(),
+      load: async () => next,
+      targets: [target],
+      runningAgentNames: ['codex-dev'],
+      logger: SILENT_LOGGER,
+    });
+
+    const result = await reload();
+
+    expect(result.status).toBe('reloaded');
+    expect(target.applyRuntimeUpdate).toHaveBeenCalledTimes(1);
+    const update = target.applyRuntimeUpdate.mock.calls[0]![0] as EngineRuntimeUpdate;
+    expect(update).not.toHaveProperty('trajectoryEnabled');
+    expect(result.message).toContain('restart required');
+    expect(result.message).toContain('daemon');
   });
 });

--- a/packages/cli/src/config.test.ts
+++ b/packages/cli/src/config.test.ts
@@ -134,6 +134,9 @@ describe('config loader', () => {
     expect(configText).toMatch(/"daemon"/);
     expect(configText).toMatch(/"commandRegistry"/);
     expect(configText).toMatch(/"applyTimeoutMs": 30000/);
+    expect(configText).toMatch(/"trajectory"/);
+    expect(configText).toMatch(/"externalImport"/);
+    expect(configText).toMatch(/"providerCapture"/);
     expect(configText).not.toMatch(/"agent"\s*:/);
     expect(
       Object.prototype.hasOwnProperty.call(JSON.parse(configText), 'discord'),
@@ -303,6 +306,9 @@ describe('config loader', () => {
     const persisted = JSON.parse(await readFile(path, 'utf8')) as Record<string, unknown>;
 
     expect(cfg.daemon.commandRegistry.registration.applyTimeoutMs).toBe(30000);
+    expect(cfg.daemon.trajectory.enabled).toBe(true);
+    expect(cfg.daemon.trajectory.externalImport.enabled).toBe(false);
+    expect(cfg.daemon.trajectory.providerCapture.enabled).toBe(false);
     expect(persisted).toMatchObject({
       daemon: {
         commandRegistry: {
@@ -320,6 +326,75 @@ describe('config loader', () => {
           },
           textPrefixes: { newSession: true },
         },
+        trajectory: {
+          enabled: true,
+          externalImport: {
+            enabled: false,
+            sources: [],
+            metadataOnlyDiscovery: true,
+            importContent: false,
+          },
+          providerCapture: {
+            enabled: false,
+            mode: 'transcript-only',
+          },
+          retention: {
+            importedSegmentsDays: 90,
+            providerObservationsDays: 30,
+          },
+        },
+      },
+    });
+  });
+
+  it('loadConfig 解析显式 daemon.trajectory 配置', async () => {
+    await writeFile(
+      join(tmp, '.agent-nexus', 'config.json'),
+      JSON.stringify(
+        validConfig({
+          daemon: {
+            trajectory: {
+              enabled: false,
+              externalImport: {
+                enabled: true,
+                sources: [
+                  {
+                    adapter: 'claude-code-jsonl',
+                    root: '/workspace/project/.claude',
+                  },
+                ],
+              },
+              providerCapture: {
+                enabled: true,
+                mode: 'forward-proxy',
+                port: 7005,
+              },
+            },
+          },
+        }),
+      ),
+    );
+
+    const cfg = await loadConfig();
+
+    expect(cfg.daemon.trajectory).toMatchObject({
+      enabled: false,
+      externalImport: {
+        enabled: true,
+        sources: [
+          {
+            adapter: 'claude-code-jsonl',
+            root: '/workspace/project/.claude',
+            projectPathAllowlist: [],
+          },
+        ],
+        importContent: false,
+      },
+      providerCapture: {
+        enabled: true,
+        mode: 'forward-proxy',
+        bindHost: '127.0.0.1',
+        port: 7005,
       },
     });
   });

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -262,6 +262,32 @@ const DEFAULT_CONFIG_TEMPLATE = `\
       "textPrefixes": {
         "newSession": true
       }
+    },
+    "trajectory": {
+      "enabled": true,
+      "externalImport": {
+        "enabled": false,
+        "sources": [],
+        "metadataOnlyDiscovery": true,
+        "importContent": false,
+        "maxFileBytes": 10485760,
+        "maxRecordsPerSession": 20000,
+        "maxAgeDays": null
+      },
+      "providerCapture": {
+        "enabled": false,
+        "mode": "transcript-only",
+        "bindHost": "127.0.0.1",
+        "port": null,
+        "storeRawStreams": false,
+        "maxRequestBytes": 1048576,
+        "maxResponseBytes": 4194304,
+        "retentionDays": 30
+      },
+      "retention": {
+        "importedSegmentsDays": 90,
+        "providerObservationsDays": 30
+      }
     }
   },
   "log": {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,11 +1,12 @@
 #!/usr/bin/env node
 import { mkdir } from 'node:fs/promises';
-import { dirname } from 'node:path';
+import { dirname, join } from 'node:path';
 import {
   ActiveCommandRegistry,
   Engine,
   InMemoryIdempotencyStore,
   SessionStore,
+  SqliteTrajectoryStore,
   createLogger,
   daemonCommandDescriptors,
   type RoutingEntry,
@@ -25,6 +26,7 @@ import {
   ConfigError,
   SecretsPermissionError,
   buildRoutingTable,
+  configRoot,
   loadConfig,
   loadSecret,
 } from './config.js';
@@ -84,6 +86,20 @@ async function main(): Promise<void> {
   const sessionStore = new SessionStore();
   const commandRegistry = new ActiveCommandRegistry();
   const idempotencyStore = new InMemoryIdempotencyStore();
+  let trajectoryStore: SqliteTrajectoryStore | undefined;
+  if (config.daemon.trajectory.enabled) {
+    const trajectoryDbPath = join(configRoot(), 'state.db');
+    try {
+      trajectoryStore = new SqliteTrajectoryStore({ path: trajectoryDbPath });
+    } catch (err) {
+      logger.error(
+        { err, path: trajectoryDbPath },
+        'trajectory_store_open_failed',
+      );
+    }
+  }
+  const trajectoryWriteEnabled =
+    config.daemon.trajectory.enabled && trajectoryStore !== undefined;
   const engines: Engine[] = [];
   // targets 在下面循环里随 engine 创建逐个填充；reloader 调用时才读取
   const configReloadTargets: ConfigReloadTarget[] = [];
@@ -181,6 +197,10 @@ async function main(): Promise<void> {
       textPrefixes: {
         newSession: config.daemon.commandRegistry.textPrefixes.newSession,
       },
+      trajectory: {
+        enabled: trajectoryWriteEnabled,
+        store: trajectoryStore,
+      },
     });
     engines.push(engine);
     configReloadTargets.push({
@@ -206,6 +226,8 @@ async function main(): Promise<void> {
       await Promise.all(engines.map((engine) => engine.stop()));
     } catch (err) {
       logger.error({ err }, 'shutdown_error');
+    } finally {
+      trajectoryStore?.close();
     }
     process.exit(0);
   };

--- a/packages/daemon/src/config.test.ts
+++ b/packages/daemon/src/config.test.ts
@@ -35,6 +35,35 @@ describe('daemon runtime config', () => {
     expect(parseDaemonRuntimeConfig({})).toEqual(DEFAULT_DAEMON_RUNTIME_CONFIG);
   });
 
+  it('缺省 trajectory 配置按安全默认值补齐', () => {
+    expect(parseDaemonRuntimeConfig(undefined).trajectory).toEqual({
+      enabled: true,
+      externalImport: {
+        enabled: false,
+        sources: [],
+        metadataOnlyDiscovery: true,
+        importContent: false,
+        maxFileBytes: 10485760,
+        maxRecordsPerSession: 20000,
+        maxAgeDays: null,
+      },
+      providerCapture: {
+        enabled: false,
+        mode: 'transcript-only',
+        bindHost: '127.0.0.1',
+        port: null,
+        storeRawStreams: false,
+        maxRequestBytes: 1048576,
+        maxResponseBytes: 4194304,
+        retentionDays: 30,
+      },
+      retention: {
+        importedSegmentsDays: 90,
+        providerObservationsDays: 30,
+      },
+    });
+  });
+
   it('解析 commandRegistry 显式配置并补齐未写字段', () => {
     expect(
       parseDaemonRuntimeConfig({
@@ -51,7 +80,7 @@ describe('daemon runtime config', () => {
           textPrefixes: { newSession: false },
         },
       }),
-    ).toEqual({
+    ).toMatchObject({
       commandRegistry: {
         registration: {
           enabled: false,
@@ -63,6 +92,66 @@ describe('daemon runtime config', () => {
           legacy: { replyMode: false },
         },
         textPrefixes: { newSession: false },
+      },
+    });
+  });
+
+  it('解析 trajectory 显式配置并补齐未写字段', () => {
+    expect(
+      parseDaemonRuntimeConfig({
+        trajectory: {
+          enabled: false,
+          externalImport: {
+            enabled: true,
+            sources: [
+              {
+                adapter: 'codex-cli-jsonl',
+                root: '/workspace/project/.codex/sessions',
+                projectPathAllowlist: ['/workspace/project'],
+              },
+            ],
+            maxAgeDays: 30,
+          },
+          providerCapture: {
+            enabled: true,
+            mode: 'reverse-proxy',
+            port: 7010,
+          },
+          retention: {
+            importedSegmentsDays: null,
+          },
+        },
+      }).trajectory,
+    ).toEqual({
+      enabled: false,
+      externalImport: {
+        enabled: true,
+        sources: [
+          {
+            adapter: 'codex-cli-jsonl',
+            root: '/workspace/project/.codex/sessions',
+            projectPathAllowlist: ['/workspace/project'],
+          },
+        ],
+        metadataOnlyDiscovery: true,
+        importContent: false,
+        maxFileBytes: 10485760,
+        maxRecordsPerSession: 20000,
+        maxAgeDays: 30,
+      },
+      providerCapture: {
+        enabled: true,
+        mode: 'reverse-proxy',
+        bindHost: '127.0.0.1',
+        port: 7010,
+        storeRawStreams: false,
+        maxRequestBytes: 1048576,
+        maxResponseBytes: 4194304,
+        retentionDays: 30,
+      },
+      retention: {
+        importedSegmentsDays: null,
+        providerObservationsDays: 30,
       },
     });
   });
@@ -85,6 +174,70 @@ describe('daemon runtime config', () => {
         },
       }),
     ).toThrow(/daemon\.commandRegistry\.aliases\.singleAgent\.mode/);
+  });
+
+  it('trajectory 未知字段、未知 adapter、非 loopback capture 绑定 fail-closed', () => {
+    expect(() =>
+      parseDaemonRuntimeConfig({
+        trajectory: { providerCapture: { stream: true } },
+      }),
+    ).toThrow(/daemon\.trajectory\.providerCapture\.stream/);
+
+    expect(() =>
+      parseDaemonRuntimeConfig({
+        trajectory: {
+          externalImport: {
+            sources: [{ adapter: 'unknown-jsonl', root: '/workspace/project' }],
+          },
+        },
+      }),
+    ).toThrow(/daemon\.trajectory\.externalImport\.sources\[0\]\.adapter/);
+
+    expect(() =>
+      parseDaemonRuntimeConfig({
+        trajectory: {
+          externalImport: {
+            sources: [{ root: '/workspace/project' }],
+          },
+        },
+      }),
+    ).toThrow(/daemon\.trajectory\.externalImport\.sources\[0\]\.adapter/);
+
+    expect(() =>
+      parseDaemonRuntimeConfig({
+        trajectory: {
+          providerCapture: {
+            enabled: true,
+            mode: 'reverse-proxy',
+            bindHost: '0.0.0.0',
+          },
+        },
+      }),
+    ).toThrow(/daemon\.trajectory\.providerCapture\.bindHost/);
+
+    expect(() =>
+      parseDaemonRuntimeConfig({
+        trajectory: {
+          providerCapture: { mode: 'mirror' },
+        },
+      }),
+    ).toThrow(/daemon\.trajectory\.providerCapture\.mode/);
+
+    expect(() =>
+      parseDaemonRuntimeConfig({
+        trajectory: {
+          providerCapture: { port: 70000 },
+        },
+      }),
+    ).toThrow(/daemon\.trajectory\.providerCapture\.port/);
+
+    expect(() =>
+      parseDaemonRuntimeConfig({
+        trajectory: {
+          externalImport: { maxFileBytes: 0 },
+        },
+      }),
+    ).toThrow(/daemon\.trajectory\.externalImport\.maxFileBytes/);
   });
 });
 

--- a/packages/daemon/src/config.ts
+++ b/packages/daemon/src/config.ts
@@ -29,8 +29,63 @@ export interface DaemonCommandRegistryConfig {
   };
 }
 
+export const TRAJECTORY_SOURCE_ADAPTERS = [
+  'codex-cli-jsonl',
+  'codex-app-jsonl',
+  'claude-code-jsonl',
+] as const;
+export type TrajectorySourceAdapter =
+  (typeof TRAJECTORY_SOURCE_ADAPTERS)[number];
+
+export const PROVIDER_CAPTURE_MODES = [
+  'reverse-proxy',
+  'forward-proxy',
+  'transcript-only',
+] as const;
+export type ProviderCaptureMode = (typeof PROVIDER_CAPTURE_MODES)[number];
+
+export interface ExternalImportSourceConfig {
+  adapter: TrajectorySourceAdapter;
+  root: string;
+  projectPathAllowlist: string[];
+}
+
+export interface ExternalImportConfig {
+  enabled: boolean;
+  sources: ExternalImportSourceConfig[];
+  metadataOnlyDiscovery: boolean;
+  importContent: boolean;
+  maxFileBytes: number;
+  maxRecordsPerSession: number;
+  maxAgeDays: number | null;
+}
+
+export interface ProviderCaptureConfig {
+  enabled: boolean;
+  mode: ProviderCaptureMode;
+  bindHost: string;
+  port: number | null;
+  storeRawStreams: boolean;
+  maxRequestBytes: number;
+  maxResponseBytes: number;
+  retentionDays: number;
+}
+
+export interface TrajectoryRetentionConfig {
+  importedSegmentsDays: number | null;
+  providerObservationsDays: number | null;
+}
+
+export interface TrajectoryObservabilityConfig {
+  enabled: boolean;
+  externalImport: ExternalImportConfig;
+  providerCapture: ProviderCaptureConfig;
+  retention: TrajectoryRetentionConfig;
+}
+
 export interface DaemonRuntimeConfig {
   commandRegistry: DaemonCommandRegistryConfig;
+  trajectory: TrajectoryObservabilityConfig;
 }
 
 export const DEFAULT_DAEMON_RUNTIME_CONFIG: DaemonRuntimeConfig = {
@@ -53,6 +108,32 @@ export const DEFAULT_DAEMON_RUNTIME_CONFIG: DaemonRuntimeConfig = {
     },
     textPrefixes: {
       newSession: true,
+    },
+  },
+  trajectory: {
+    enabled: true,
+    externalImport: {
+      enabled: false,
+      sources: [],
+      metadataOnlyDiscovery: true,
+      importContent: false,
+      maxFileBytes: 10485760,
+      maxRecordsPerSession: 20000,
+      maxAgeDays: null,
+    },
+    providerCapture: {
+      enabled: false,
+      mode: 'transcript-only',
+      bindHost: '127.0.0.1',
+      port: null,
+      storeRawStreams: false,
+      maxRequestBytes: 1048576,
+      maxResponseBytes: 4194304,
+      retentionDays: 30,
+    },
+    retention: {
+      importedSegmentsDays: 90,
+      providerObservationsDays: 30,
     },
   },
 };
@@ -113,6 +194,20 @@ function parseStringArray(
   return [...value];
 }
 
+function parseNonEmptyString(
+  raw: Record<string, unknown>,
+  key: string,
+  path: string,
+  defaultValue?: string,
+): string {
+  const value = raw[key];
+  if (value === undefined && defaultValue !== undefined) return defaultValue;
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new DaemonConfigError(`字段 ${path}.${key} 必须是非空字符串`);
+  }
+  return value;
+}
+
 function parseBoolean(
   raw: Record<string, unknown>,
   key: string,
@@ -140,6 +235,58 @@ function parseInteger(
     throw new DaemonConfigError(`字段 ${path}.${key} 必须是 >= ${min} 的整数`);
   }
   return value;
+}
+
+function parseNullableInteger(
+  raw: Record<string, unknown>,
+  key: string,
+  path: string,
+  defaultValue: number | null,
+  min: number,
+): number | null {
+  const value = raw[key];
+  if (value === undefined) return defaultValue;
+  if (value === null) return null;
+  if (typeof value !== 'number' || !Number.isInteger(value) || value < min) {
+    throw new DaemonConfigError(`字段 ${path}.${key} 必须是 null 或 >= ${min} 的整数`);
+  }
+  return value;
+}
+
+function parseEnum<T extends readonly string[]>(
+  raw: Record<string, unknown>,
+  key: string,
+  path: string,
+  allowed: T,
+  defaultValue: T[number],
+): T[number] {
+  const value = raw[key];
+  if (value === undefined) return defaultValue;
+  if (typeof value !== 'string' || !allowed.includes(value)) {
+    throw new DaemonConfigError(
+      `字段 ${path}.${key} 必须是 ${allowed.map((v) => `"${v}"`).join(' / ')}`,
+    );
+  }
+  return value;
+}
+
+function parseRequiredEnum<T extends readonly string[]>(
+  raw: Record<string, unknown>,
+  key: string,
+  path: string,
+  allowed: T,
+): T[number] {
+  const value = raw[key];
+  if (typeof value !== 'string' || !allowed.includes(value)) {
+    throw new DaemonConfigError(
+      `字段 ${path}.${key} 必须是 ${allowed.map((v) => `"${v}"`).join(' / ')}`,
+    );
+  }
+  return value;
+}
+
+function isLoopbackHost(host: string): boolean {
+  return host === '127.0.0.1' || host === 'localhost' || host === '::1' || host === '[::1]';
 }
 
 export function parsePlatformAuthConfig(
@@ -222,13 +369,251 @@ export function parseDaemonConfig(raw: unknown): DaemonConfig {
   };
 }
 
+function parseExternalImportSource(
+  raw: unknown,
+  index: number,
+): ExternalImportSourceConfig {
+  const path = `daemon.trajectory.externalImport.sources[${index}]`;
+  if (!isRecord(raw)) {
+    throw new DaemonConfigError(`字段 ${path} 必须是对象`);
+  }
+  assertNoUnknownKeys(raw, ['adapter', 'root', 'projectPathAllowlist'], path);
+  return {
+    adapter: parseRequiredEnum(
+      raw,
+      'adapter',
+      path,
+      TRAJECTORY_SOURCE_ADAPTERS,
+    ),
+    root: parseNonEmptyString(raw, 'root', path),
+    projectPathAllowlist: parseStringArray(
+      raw,
+      'projectPathAllowlist',
+      path,
+    ),
+  };
+}
+
+function parseExternalImportConfig(raw: unknown): ExternalImportConfig {
+  const path = 'daemon.trajectory.externalImport';
+  if (raw !== undefined && !isRecord(raw)) {
+    throw new DaemonConfigError(`字段 ${path} 必须是对象`);
+  }
+  const externalImport = (raw ?? {}) as Record<string, unknown>;
+  assertNoUnknownKeys(
+    externalImport,
+    [
+      'enabled',
+      'sources',
+      'metadataOnlyDiscovery',
+      'importContent',
+      'maxFileBytes',
+      'maxRecordsPerSession',
+      'maxAgeDays',
+    ],
+    path,
+  );
+
+  const sourcesRaw = externalImport['sources'];
+  if (sourcesRaw !== undefined && !Array.isArray(sourcesRaw)) {
+    throw new DaemonConfigError(`字段 ${path}.sources 必须是对象数组`);
+  }
+
+  return {
+    enabled: parseBoolean(
+      externalImport,
+      'enabled',
+      path,
+      DEFAULT_DAEMON_RUNTIME_CONFIG.trajectory.externalImport.enabled,
+    ),
+    sources: (sourcesRaw ?? []).map((source, index) =>
+      parseExternalImportSource(source, index),
+    ),
+    metadataOnlyDiscovery: parseBoolean(
+      externalImport,
+      'metadataOnlyDiscovery',
+      path,
+      DEFAULT_DAEMON_RUNTIME_CONFIG.trajectory.externalImport.metadataOnlyDiscovery,
+    ),
+    importContent: parseBoolean(
+      externalImport,
+      'importContent',
+      path,
+      DEFAULT_DAEMON_RUNTIME_CONFIG.trajectory.externalImport.importContent,
+    ),
+    maxFileBytes: parseInteger(
+      externalImport,
+      'maxFileBytes',
+      path,
+      DEFAULT_DAEMON_RUNTIME_CONFIG.trajectory.externalImport.maxFileBytes,
+      1,
+    ),
+    maxRecordsPerSession: parseInteger(
+      externalImport,
+      'maxRecordsPerSession',
+      path,
+      DEFAULT_DAEMON_RUNTIME_CONFIG.trajectory.externalImport.maxRecordsPerSession,
+      1,
+    ),
+    maxAgeDays: parseNullableInteger(
+      externalImport,
+      'maxAgeDays',
+      path,
+      DEFAULT_DAEMON_RUNTIME_CONFIG.trajectory.externalImport.maxAgeDays,
+      1,
+    ),
+  };
+}
+
+function parseProviderCaptureConfig(raw: unknown): ProviderCaptureConfig {
+  const path = 'daemon.trajectory.providerCapture';
+  if (raw !== undefined && !isRecord(raw)) {
+    throw new DaemonConfigError(`字段 ${path} 必须是对象`);
+  }
+  const providerCapture = (raw ?? {}) as Record<string, unknown>;
+  assertNoUnknownKeys(
+    providerCapture,
+    [
+      'enabled',
+      'mode',
+      'bindHost',
+      'port',
+      'storeRawStreams',
+      'maxRequestBytes',
+      'maxResponseBytes',
+      'retentionDays',
+    ],
+    path,
+  );
+
+  const bindHost = parseNonEmptyString(
+    providerCapture,
+    'bindHost',
+    path,
+    DEFAULT_DAEMON_RUNTIME_CONFIG.trajectory.providerCapture.bindHost,
+  );
+  if (!isLoopbackHost(bindHost)) {
+    throw new DaemonConfigError(`字段 ${path}.bindHost 必须是 loopback host`);
+  }
+  const port = parseNullableInteger(
+    providerCapture,
+    'port',
+    path,
+    DEFAULT_DAEMON_RUNTIME_CONFIG.trajectory.providerCapture.port,
+    1,
+  );
+  if (port !== null && port > 65535) {
+    throw new DaemonConfigError(`字段 ${path}.port 必须是 null 或 1..65535 的整数`);
+  }
+
+  return {
+    enabled: parseBoolean(
+      providerCapture,
+      'enabled',
+      path,
+      DEFAULT_DAEMON_RUNTIME_CONFIG.trajectory.providerCapture.enabled,
+    ),
+    mode: parseEnum(
+      providerCapture,
+      'mode',
+      path,
+      PROVIDER_CAPTURE_MODES,
+      DEFAULT_DAEMON_RUNTIME_CONFIG.trajectory.providerCapture.mode,
+    ),
+    bindHost,
+    port,
+    storeRawStreams: parseBoolean(
+      providerCapture,
+      'storeRawStreams',
+      path,
+      DEFAULT_DAEMON_RUNTIME_CONFIG.trajectory.providerCapture.storeRawStreams,
+    ),
+    maxRequestBytes: parseInteger(
+      providerCapture,
+      'maxRequestBytes',
+      path,
+      DEFAULT_DAEMON_RUNTIME_CONFIG.trajectory.providerCapture.maxRequestBytes,
+      1,
+    ),
+    maxResponseBytes: parseInteger(
+      providerCapture,
+      'maxResponseBytes',
+      path,
+      DEFAULT_DAEMON_RUNTIME_CONFIG.trajectory.providerCapture.maxResponseBytes,
+      1,
+    ),
+    retentionDays: parseInteger(
+      providerCapture,
+      'retentionDays',
+      path,
+      DEFAULT_DAEMON_RUNTIME_CONFIG.trajectory.providerCapture.retentionDays,
+      1,
+    ),
+  };
+}
+
+function parseTrajectoryRetentionConfig(raw: unknown): TrajectoryRetentionConfig {
+  const path = 'daemon.trajectory.retention';
+  if (raw !== undefined && !isRecord(raw)) {
+    throw new DaemonConfigError(`字段 ${path} 必须是对象`);
+  }
+  const retention = (raw ?? {}) as Record<string, unknown>;
+  assertNoUnknownKeys(
+    retention,
+    ['importedSegmentsDays', 'providerObservationsDays'],
+    path,
+  );
+  return {
+    importedSegmentsDays: parseNullableInteger(
+      retention,
+      'importedSegmentsDays',
+      path,
+      DEFAULT_DAEMON_RUNTIME_CONFIG.trajectory.retention.importedSegmentsDays,
+      1,
+    ),
+    providerObservationsDays: parseNullableInteger(
+      retention,
+      'providerObservationsDays',
+      path,
+      DEFAULT_DAEMON_RUNTIME_CONFIG.trajectory.retention.providerObservationsDays,
+      1,
+    ),
+  };
+}
+
+function parseTrajectoryObservabilityConfig(
+  raw: unknown,
+): TrajectoryObservabilityConfig {
+  const path = 'daemon.trajectory';
+  if (raw !== undefined && !isRecord(raw)) {
+    throw new DaemonConfigError(`字段 ${path} 必须是对象`);
+  }
+  const trajectory = (raw ?? {}) as Record<string, unknown>;
+  assertNoUnknownKeys(
+    trajectory,
+    ['enabled', 'externalImport', 'providerCapture', 'retention'],
+    path,
+  );
+  return {
+    enabled: parseBoolean(
+      trajectory,
+      'enabled',
+      path,
+      DEFAULT_DAEMON_RUNTIME_CONFIG.trajectory.enabled,
+    ),
+    externalImport: parseExternalImportConfig(trajectory['externalImport']),
+    providerCapture: parseProviderCaptureConfig(trajectory['providerCapture']),
+    retention: parseTrajectoryRetentionConfig(trajectory['retention']),
+  };
+}
+
 export function parseDaemonRuntimeConfig(raw: unknown): DaemonRuntimeConfig {
   const path = 'daemon';
   if (raw !== undefined && !isRecord(raw)) {
     throw new DaemonConfigError(`字段 ${path} 必须是对象`);
   }
   const daemon = (raw ?? {}) as Record<string, unknown>;
-  assertNoUnknownKeys(daemon, ['commandRegistry'], path);
+  assertNoUnknownKeys(daemon, ['commandRegistry', 'trajectory'], path);
 
   const commandRegistryPath = `${path}.commandRegistry`;
   const commandRegistry = isRecord(daemon['commandRegistry'])
@@ -366,5 +751,6 @@ export function parseDaemonRuntimeConfig(raw: unknown): DaemonRuntimeConfig {
         ),
       },
     },
+    trajectory: parseTrajectoryObservabilityConfig(daemon['trajectory']),
   };
 }

--- a/packages/daemon/src/engine.test.ts
+++ b/packages/daemon/src/engine.test.ts
@@ -31,6 +31,10 @@ import { InMemoryIdempotencyStore } from './idempotency.js';
 import { createLogger, type Logger } from './logger.js';
 import type { RoutingEntry } from './router.js';
 import { SessionStore } from './session-store.js';
+import {
+  InMemoryTrajectoryStore,
+  type TrajectoryStore,
+} from './trajectory-store.js';
 
 // ----- mocks -----
 
@@ -528,6 +532,24 @@ function makeActiveRegistry(
   return registry;
 }
 
+function makeThrowingTrajectoryStore(): TrajectoryStore & {
+  appendTrajectorySegment: ReturnType<typeof vi.fn>;
+} {
+  return {
+    upsertExternalSessionImport: vi.fn(),
+    getExternalSessionImport: vi.fn(() => undefined),
+    linkExternalSession: vi.fn(() => {
+      throw new Error('not implemented');
+    }),
+    appendTrajectorySegment: vi.fn(() => {
+      throw new Error('trajectory append failed');
+    }),
+    recordProviderCallObservation: vi.fn(),
+    getProviderCallObservation: vi.fn(() => undefined),
+    queryTrajectory: vi.fn(() => ({ segments: [] })),
+  };
+}
+
 // ----- tests -----
 
 describe('Engine', () => {
@@ -569,6 +591,159 @@ describe('Engine', () => {
     expect(out.text).toBe('hi from agent');
 
     expect(agent.stopSession).not.toHaveBeenCalled();
+  });
+
+  it('trajectory enabled 时把路由输入和 AgentEvent 写入同一个 runtime sessionId', async () => {
+    const platform = makePlatform();
+    const agent = makeAgent();
+    const store = new SessionStore();
+    const trajectoryStore = new InMemoryTrajectoryStore();
+    const engine = new Engine({
+      platform,
+      agent: agent.runtime,
+      logger: SILENT_LOGGER,
+      sessionStore: store,
+      defaultSessionConfig: DEFAULT_CFG,
+      trajectory: { enabled: true, store: trajectoryStore },
+    });
+
+    agent.queueEvents([
+      ev('session_started', { agentSessionId: 'sid-123' }, 1),
+      ev('thinking', { text: 'checking context' }, 2),
+      ev(
+        'tool_call_started',
+        { callId: 'call-1', toolName: 'Bash', inputSummary: 'echo hi' },
+        3,
+      ),
+      ev(
+        'tool_result',
+        {
+          callId: 'call-1',
+          resultSequence: 1,
+          content: { kind: 'text', text: 'ok from tool' },
+          isError: false,
+        },
+        4,
+      ),
+      ev(
+        'usage',
+        {
+          model: 'gpt-5',
+          inputTokens: 10,
+          outputTokens: 5,
+          cacheReadTokens: 1,
+          cacheWriteTokens: 2,
+          costUsd: 0.01,
+          turnSequence: 1,
+          toolCallsThisTurn: 1,
+          wallClockMs: 1200,
+          completeness: 'complete',
+        },
+        5,
+      ),
+      ev('text_final', { text: 'answer with sk-ant-secret' }, 6),
+      ev('turn_finished', { reason: 'stop', turnSequence: 1 }, 7),
+    ]);
+
+    await engine.start();
+    const dispatchHandler = (platform.start as ReturnType<typeof vi.fn>).mock.calls[0]![0] as EventHandler;
+    await dispatchHandler(makeEvent('inspect /home/node/private'));
+
+    const sessionId = (agent.startSession.mock.calls[0]![1] as SessionConfig)
+      .sessionId;
+    expect(
+      store.listForUser({
+        platformName: 'mock-platform',
+        platform: 'discord',
+        initiatorUserId: 'U1',
+        limit: 1,
+      })[0]?.sessionId,
+    ).toBe(sessionId);
+    const segments = trajectoryStore.queryTrajectory({ sessionId }).segments;
+
+    expect(segments.map((segment) => segment.kind)).toEqual([
+      'user-message',
+      'state-change',
+      'reasoning',
+      'tool-call',
+      'tool-result',
+      'usage',
+      'agent-message',
+      'state-change',
+    ]);
+    expect(segments.every((segment) => segment.source === 'nexus-agent-event')).toBe(
+      true,
+    );
+    expect(segments.every((segment) => segment.traceId === 't-1')).toBe(true);
+    expect(segments.every((segment) => segment.redactionState === 'redacted')).toBe(
+      true,
+    );
+    expect(segments.map((segment) => segment.sequence)).toEqual([
+      1, 2, 3, 4, 5, 6, 7, 8,
+    ]);
+    expect(segments[0]?.summary).toBe('inspect ~/private');
+    expect(segments[6]?.summary).toBe('answer with <redacted:secret>');
+    expect(segments[5]).toMatchObject({
+      kind: 'usage',
+      turnSequence: 1,
+      usageEventId: expect.any(String),
+    });
+  });
+
+  it('trajectory enabled=false 时不写 read model', async () => {
+    const platform = makePlatform();
+    const agent = makeAgent();
+    const trajectoryStore = new InMemoryTrajectoryStore();
+    const engine = new Engine({
+      platform,
+      agent: agent.runtime,
+      logger: SILENT_LOGGER,
+      sessionStore: new SessionStore(),
+      defaultSessionConfig: DEFAULT_CFG,
+      trajectory: { enabled: false, store: trajectoryStore },
+    });
+
+    agent.queueEvents([
+      ev('session_started', { agentSessionId: 'sid-123' }, 1),
+      ev('text_final', { text: 'hi from agent' }, 2),
+      ev('turn_finished', { reason: 'stop', turnSequence: 1 }, 3),
+    ]);
+
+    await engine.start();
+    const dispatchHandler = (platform.start as ReturnType<typeof vi.fn>).mock.calls[0]![0] as EventHandler;
+    await dispatchHandler(makeEvent('hello'));
+
+    expect(trajectoryStore.queryTrajectory({}).segments).toEqual([]);
+  });
+
+  it('trajectory store 写入失败不阻断 agent 输出投递', async () => {
+    const platform = makePlatform();
+    const agent = makeAgent();
+    const trajectoryStore = makeThrowingTrajectoryStore();
+    const engine = new Engine({
+      platform,
+      agent: agent.runtime,
+      logger: SILENT_LOGGER,
+      sessionStore: new SessionStore(),
+      defaultSessionConfig: DEFAULT_CFG,
+      trajectory: { enabled: true, store: trajectoryStore },
+    });
+
+    agent.queueEvents([
+      ev('session_started', { agentSessionId: 'sid-123' }, 1),
+      ev('text_final', { text: 'still delivered' }, 2),
+      ev('turn_finished', { reason: 'stop', turnSequence: 1 }, 3),
+    ]);
+
+    await engine.start();
+    const dispatchHandler = (platform.start as ReturnType<typeof vi.fn>).mock.calls[0]![0] as EventHandler;
+    await dispatchHandler(makeEvent('hello'));
+
+    expect(trajectoryStore.appendTrajectorySegment).toHaveBeenCalled();
+    expect(platform.send).toHaveBeenCalledTimes(1);
+    expect((platform.send.mock.calls[0]![1] as OutboundMessage).text).toBe(
+      'still delivered',
+    );
   });
 
   it('第二轮：复用同 sessionKey 的活跃 AgentSession，不重新 startSession', async () => {

--- a/packages/daemon/src/engine.ts
+++ b/packages/daemon/src/engine.ts
@@ -18,6 +18,8 @@ import type {
   SessionConfig,
   SessionKey,
   SettingsSnapshotItem,
+  ToolResultContent,
+  UsageRecord,
 } from '@agent-nexus/protocol';
 import { serializeSessionKey, withPlatformName } from '@agent-nexus/protocol';
 import { checkPlatformAuth } from './auth.js';
@@ -42,6 +44,11 @@ import {
 import { BasicRedactor, type Redactor } from './redaction.js';
 import { RouteError, selectRoute, type RoutingEntry } from './router.js';
 import type { SessionStore } from './session-store.js';
+import type {
+  TrajectorySegment,
+  TrajectorySegmentKind,
+  TrajectoryStore,
+} from './trajectory-store.js';
 
 export interface EngineAgent {
   agent: AgentRuntime;
@@ -99,6 +106,10 @@ export interface EngineDeps {
   textPrefixes?: {
     newSession?: boolean;
   };
+  trajectory?: {
+    enabled?: boolean;
+    store?: TrajectoryStore;
+  };
 }
 
 const DEFAULT_STREAM_EDIT_THROTTLE_MS = 1500;
@@ -138,6 +149,7 @@ interface ActiveAgentSession {
   agent: AgentRuntime;
   agentName: string;
   session: AgentSession;
+  sessionId: string;
   currentTurn?: {
     eventId: string;
     traceId: string;
@@ -175,6 +187,40 @@ function renderToolStart(toolName: string, inputSummary: string): string {
     return `Bash:\n${codeBlock('bash', summary)}`;
   }
   return `${toolName}: ${summary}`;
+}
+
+function summarizeToolResultContent(content: ToolResultContent): string {
+  switch (content.kind) {
+    case 'empty':
+      return '(empty result)';
+    case 'text':
+      return content.text;
+    case 'blocks':
+      return `${content.blocks.length} content block(s)`;
+    case 'object':
+      return safeJson(content.object);
+    case 'unknown':
+      return content.raw;
+  }
+}
+
+function summarizeUsageRecord(usage: UsageRecord): string {
+  const cost =
+    usage.costUsd === null ? 'cost unknown' : `cost $${usage.costUsd.toFixed(6)}`;
+  return [
+    usage.model,
+    `input ${usage.inputTokens}`,
+    `output ${usage.outputTokens}`,
+    cost,
+  ].join(', ');
+}
+
+function safeJson(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return '{"serialization":"failed"}';
+  }
 }
 
 function sessionTitleFromPrompt(prompt: string): string | undefined {
@@ -256,6 +302,8 @@ export class Engine {
   private readonly agents: Map<string, EngineAgent>;
   private readonly logger: Logger;
   private readonly sessionStore: SessionStore;
+  private readonly trajectoryEnabled: boolean;
+  private readonly trajectoryStore?: TrajectoryStore;
   private readonly streamEditThrottleMs: number;
   private readonly typingRefreshMs: number;
   private readonly agentSessions = new Map<string, ActiveAgentSession>();
@@ -305,6 +353,8 @@ export class Engine {
     }
     this.logger = deps.logger;
     this.sessionStore = deps.sessionStore;
+    this.trajectoryEnabled = deps.trajectory?.enabled ?? true;
+    this.trajectoryStore = deps.trajectory?.store;
     this.streamEditThrottleMs =
       deps.streaming?.streamEditThrottleMs ?? DEFAULT_STREAM_EDIT_THROTTLE_MS;
     this.typingRefreshMs =
@@ -2256,6 +2306,252 @@ export class Engine {
     }
   }
 
+  private appendNexusTrajectorySegment(
+    active: ActiveAgentSession,
+    input: {
+      kind: TrajectorySegmentKind;
+      traceId?: string;
+      turnSequence?: number;
+      ts: string;
+      summary: string;
+      usageEventId?: string;
+      metadata: Record<string, unknown>;
+    },
+  ): void {
+    if (!this.trajectoryEnabled || !this.trajectoryStore) return;
+    const segment: TrajectorySegment = {
+      segmentId: randomUUID(),
+      sessionId: active.sessionId,
+      source: 'nexus-agent-event',
+      kind: input.kind,
+      sequence: this.sessionStore.nextTrajectorySequence(active.sessionId),
+      ts: input.ts,
+      summary: input.summary,
+      confidence: 'high',
+      redactionState: 'redacted',
+      metadataJson: safeJson(input.metadata),
+    };
+    if (input.traceId) segment.traceId = input.traceId;
+    if (input.turnSequence !== undefined) {
+      segment.turnSequence = input.turnSequence;
+    }
+    if (input.usageEventId) segment.usageEventId = input.usageEventId;
+
+    try {
+      this.trajectoryStore.appendTrajectorySegment(segment);
+    } catch (err) {
+      this.logger.warn(
+        {
+          traceId: input.traceId,
+          sessionId: active.sessionId,
+          kind: input.kind,
+          err,
+        },
+        'trajectory_segment_append_failed',
+      );
+    }
+  }
+
+  private appendInboundTrajectorySegment(
+    active: ActiveAgentSession,
+    event: NormalizedEvent & { sessionKey: SessionKey },
+    prompt: string,
+    sessionKeyStr: string,
+    agentName: string,
+  ): void {
+    this.appendNexusTrajectorySegment(active, {
+      kind: 'user-message',
+      traceId: event.traceId,
+      ts: event.receivedAt.toISOString(),
+      summary: prompt,
+      metadata: {
+        eventId: event.eventId,
+        messageId: event.messageId,
+        platform: event.platform,
+        rawContentType: event.rawContentType,
+        sessionKey: sessionKeyStr,
+        agentName,
+      },
+    });
+  }
+
+  private appendAgentEventTrajectorySegment(
+    active: ActiveAgentSession,
+    event: AgentEvent,
+    sessionKeyStr: string,
+  ): void {
+    const baseMetadata = {
+      eventType: event.type,
+      agentEventSequence: event.sequence,
+      sessionKey: sessionKeyStr,
+    };
+    switch (event.type) {
+      case 'session_started':
+        this.appendNexusTrajectorySegment(active, {
+          kind: 'state-change',
+          traceId: event.traceId,
+          ts: event.timestamp.toISOString(),
+          summary: event.payload.agentSessionId
+            ? `session started: ${event.payload.agentSessionId}`
+            : 'session started',
+          metadata: {
+            ...baseMetadata,
+            agentSessionId: event.payload.agentSessionId,
+            workingDir: event.payload.workingDir,
+          },
+        });
+        return;
+      case 'thinking':
+        this.appendNexusTrajectorySegment(active, {
+          kind: 'reasoning',
+          traceId: event.traceId,
+          ts: event.timestamp.toISOString(),
+          summary: event.payload.text,
+          metadata: baseMetadata,
+        });
+        return;
+      case 'text_delta':
+        return;
+      case 'text_final':
+        this.appendNexusTrajectorySegment(active, {
+          kind: 'agent-message',
+          traceId: event.traceId,
+          ts: event.timestamp.toISOString(),
+          summary: event.payload.text,
+          metadata: baseMetadata,
+        });
+        return;
+      case 'tool_call_started':
+        this.appendNexusTrajectorySegment(active, {
+          kind: 'tool-call',
+          traceId: event.traceId,
+          ts: event.timestamp.toISOString(),
+          summary: `${event.payload.toolName}: ${event.payload.inputSummary}`,
+          metadata: {
+            ...baseMetadata,
+            callId: event.payload.callId,
+            toolName: event.payload.toolName,
+          },
+        });
+        return;
+      case 'tool_call_progress':
+        this.appendNexusTrajectorySegment(active, {
+          kind: 'state-change',
+          traceId: event.traceId,
+          ts: event.timestamp.toISOString(),
+          summary: `[tool: ${event.payload.callId}] ${event.payload.note}`,
+          metadata: {
+            ...baseMetadata,
+            callId: event.payload.callId,
+          },
+        });
+        return;
+      case 'tool_result':
+        this.appendNexusTrajectorySegment(active, {
+          kind: 'tool-result',
+          traceId: event.traceId,
+          ts: event.timestamp.toISOString(),
+          summary: summarizeToolResultContent(event.payload.content),
+          metadata: {
+            ...baseMetadata,
+            callId: event.payload.callId,
+            resultSequence: event.payload.resultSequence,
+            isError: event.payload.isError,
+            contentKind: event.payload.content.kind,
+          },
+        });
+        return;
+      case 'tool_call_finished':
+        this.appendNexusTrajectorySegment(active, {
+          kind: 'state-change',
+          traceId: event.traceId,
+          ts: event.timestamp.toISOString(),
+          summary: `${event.payload.toolName}: ${event.payload.status}`,
+          metadata: {
+            ...baseMetadata,
+            callId: event.payload.callId,
+            toolName: event.payload.toolName,
+            status: event.payload.status,
+            errorSummary: event.payload.errorSummary,
+          },
+        });
+        return;
+      case 'usage':
+        this.appendNexusTrajectorySegment(active, {
+          kind: 'usage',
+          traceId: event.traceId,
+          turnSequence: event.payload.turnSequence,
+          ts: event.timestamp.toISOString(),
+          summary: summarizeUsageRecord(event.payload),
+          usageEventId: `${active.sessionId}:usage:${event.sequence}`,
+          metadata: {
+            ...baseMetadata,
+            usage: event.payload,
+          },
+        });
+        return;
+      case 'turn_finished':
+        this.appendNexusTrajectorySegment(active, {
+          kind: 'state-change',
+          traceId: event.traceId,
+          turnSequence: event.payload.turnSequence,
+          ts: event.timestamp.toISOString(),
+          summary: `turn finished: ${event.payload.reason}`,
+          metadata: {
+            ...baseMetadata,
+            reason: event.payload.reason,
+            source: event.payload.source,
+          },
+        });
+        return;
+      case 'error':
+        this.appendNexusTrajectorySegment(active, {
+          kind: 'state-change',
+          traceId: event.traceId,
+          ts: event.timestamp.toISOString(),
+          summary: `[agent error: ${event.payload.errorKind}] ${event.payload.message}`,
+          metadata: {
+            ...baseMetadata,
+            errorKind: event.payload.errorKind,
+            code: event.payload.code,
+          },
+        });
+        return;
+      case 'session_stopped':
+        this.appendNexusTrajectorySegment(active, {
+          kind: 'state-change',
+          traceId: event.traceId,
+          ts: event.timestamp.toISOString(),
+          summary: `session stopped: ${event.payload.reason}`,
+          metadata: {
+            ...baseMetadata,
+            reason: event.payload.reason,
+          },
+        });
+        return;
+    }
+  }
+
+  private appendAgentEventTrajectoryBestEffort(
+    active: ActiveAgentSession,
+    event: AgentEvent,
+    sessionKeyStr: string,
+  ): void {
+    try {
+      this.appendAgentEventTrajectorySegment(active, event, sessionKeyStr);
+    } catch (err) {
+      this.logger.warn(
+        {
+          traceId: event.traceId,
+          sessionId: active.sessionId,
+          eventType: event.type,
+          err,
+        },
+        'trajectory_event_mapping_failed',
+      );
+    }
+  }
+
   private async dispatchImpl(
     event: NormalizedEvent & { sessionKey: SessionKey },
     agentSlot: EngineAgent,
@@ -2349,6 +2645,7 @@ export class Engine {
       let toolStatus: string | undefined;
       const toolCallStartedAt = new Map<string, number>();
       const toolMessages = new Map<string, ToolMessageState>();
+      let activeSessionForTrajectory: ActiveAgentSession | undefined;
 
       const safeSend = async (text: string): Promise<MessageRef | undefined> => {
         try {
@@ -2619,6 +2916,13 @@ export class Engine {
 
       const handler = async (e: AgentEvent): Promise<void> => {
         try {
+          if (activeSessionForTrajectory) {
+            this.appendAgentEventTrajectoryBestEffort(
+              activeSessionForTrajectory,
+              e,
+              sessionKeyStr,
+            );
+          }
           if (e.type === 'session_started') {
             const agentSessionId = e.payload.agentSessionId;
             if (agentSessionId) {
@@ -2807,6 +3111,7 @@ export class Engine {
         sessionKeyStr,
         agentSlot,
       );
+      activeSessionForTrajectory = activeSession;
       session = activeSession.session;
       activeSession.currentTurn = {
         eventId: event.eventId,
@@ -2816,6 +3121,13 @@ export class Engine {
         handle: handler,
       };
       const turnState = activeSession.currentTurn;
+      this.appendInboundTrajectorySegment(
+        activeSession,
+        event,
+        prompt,
+        sessionKeyStr,
+        agentSlot.agentName,
+      );
 
       startTyping();
       let sendInputErr: unknown;
@@ -2896,7 +3208,7 @@ export class Engine {
     const config: SessionConfig = {
       ...agentSlot.defaultSessionConfig,
       workingDir,
-      sessionId: randomUUID(),
+      sessionId: this.sessionStore.ensureSessionId(event.sessionKey),
       resumeFromAgentSessionId: prevAgentSessionId,
     };
     const session = agentSlot.agent.startSession(event.sessionKey, config);
@@ -2904,6 +3216,7 @@ export class Engine {
       agent: agentSlot.agent,
       agentName: agentSlot.agentName,
       session,
+      sessionId: config.sessionId,
     };
     this.agentSessions.set(sessionKeyStr, activeSession);
     agentSlot.agent.onEvent(session, async (agentEvent) => {

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -71,6 +71,7 @@ export {
   type TrajectorySegment,
   type TrajectorySegmentKind,
   type TrajectorySegmentSource,
+  type TrajectoryStore,
   type TrajectoryStoreErrorCode,
 } from './trajectory-store.js';
 export {

--- a/packages/daemon/src/session-store.test.ts
+++ b/packages/daemon/src/session-store.test.ts
@@ -26,6 +26,34 @@ describe('SessionStore', () => {
     expect(store.size).toBe(1);
   });
 
+  it('ensureSessionId reuses a key-bound Nexus sessionId until delete', () => {
+    const store = new SessionStore();
+    const key = makeKey();
+
+    const first = store.ensureSessionId(key);
+    expect(first).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
+    expect(store.ensureSessionId(key)).toBe(first);
+    expect(store.nextTrajectorySequence(first)).toBe(1);
+    expect(store.nextTrajectorySequence(first)).toBe(2);
+
+    store.set(key, { agentSessionId: 'sid-1', lastTurnAt: new Date(0) });
+    expect(
+      store.listForUser({
+        platformName: 'discord-main',
+        platform: 'discord',
+        initiatorUserId: 'U1',
+        limit: 1,
+      })[0]?.sessionId,
+    ).toBe(first);
+
+    store.delete(key);
+    const next = store.ensureSessionId(key);
+    expect(next).not.toBe(first);
+    expect(store.nextTrajectorySequence(next)).toBe(1);
+  });
+
   it('different platformName/platform/channel/user produce different map keys', () => {
     const store = new SessionStore();
     const k1 = makeKey({ platformName: 'discord-main' });

--- a/packages/daemon/src/session-store.ts
+++ b/packages/daemon/src/session-store.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import type { SessionKey } from '@agent-nexus/protocol';
 import { serializeSessionKey } from '@agent-nexus/protocol';
 
@@ -49,22 +50,28 @@ export class SessionStore {
   private readonly map = new Map<string, SessionEntry>();
   private readonly sessionIdsByKey = new Map<string, string>();
   private readonly keysBySessionId = new Map<string, SessionKey>();
+  private readonly trajectorySequencesBySessionId = new Map<string, number>();
   private readonly threadsByChannel = new Map<string, ThreadRegistryEntry>();
   private readonly workingDirsByChannel = new Map<string, string>();
-  private nextSessionSeq = 1;
 
   get(key: SessionKey): SessionEntry | undefined {
     return this.map.get(serializeSessionKey(key));
   }
 
-  set(key: SessionKey, entry: SessionEntry): void {
+  ensureSessionId(key: SessionKey): string {
     const keyStr = serializeSessionKey(key);
-    if (!this.sessionIdsByKey.has(keyStr)) {
-      const sessionId = `mem-${this.nextSessionSeq}`;
-      this.nextSessionSeq += 1;
+    let sessionId = this.sessionIdsByKey.get(keyStr);
+    if (!sessionId) {
+      sessionId = randomUUID();
       this.sessionIdsByKey.set(keyStr, sessionId);
       this.keysBySessionId.set(sessionId, { ...key });
     }
+    return sessionId;
+  }
+
+  set(key: SessionKey, entry: SessionEntry): void {
+    const keyStr = serializeSessionKey(key);
+    this.ensureSessionId(key);
     const existing = this.map.get(keyStr);
     const nextEntry: SessionEntry = { ...entry };
     // set() 只保留/更新 resumable 绑定；显式清除必须走 delete()。
@@ -86,12 +93,19 @@ export class SessionStore {
     this.map.set(keyStr, nextEntry);
   }
 
+  nextTrajectorySequence(sessionId: string): number {
+    const next = (this.trajectorySequencesBySessionId.get(sessionId) ?? 0) + 1;
+    this.trajectorySequencesBySessionId.set(sessionId, next);
+    return next;
+  }
+
   delete(key: SessionKey): boolean {
     const keyStr = serializeSessionKey(key);
     const sessionId = this.sessionIdsByKey.get(keyStr);
     if (sessionId) {
       this.sessionIdsByKey.delete(keyStr);
       this.keysBySessionId.delete(sessionId);
+      this.trajectorySequencesBySessionId.delete(sessionId);
     }
     return this.map.delete(keyStr);
   }
@@ -100,6 +114,7 @@ export class SessionStore {
     this.map.clear();
     this.sessionIdsByKey.clear();
     this.keysBySessionId.clear();
+    this.trajectorySequencesBySessionId.clear();
     this.threadsByChannel.clear();
     this.workingDirsByChannel.clear();
   }

--- a/packages/daemon/src/trajectory-store.ts
+++ b/packages/daemon/src/trajectory-store.ts
@@ -160,6 +160,20 @@ export interface TrajectoryPage {
   nextCursor?: string;
 }
 
+export interface TrajectoryStore {
+  upsertExternalSessionImport(record: ExternalSessionImportRecord): void;
+  getExternalSessionImport(
+    importId: string,
+  ): ExternalSessionImportRecord | undefined;
+  linkExternalSession(input: LinkExternalSessionInput): ExternalResumeBinding;
+  appendTrajectorySegment(segment: TrajectorySegment): void;
+  recordProviderCallObservation(observation: ProviderCallObservation): void;
+  getProviderCallObservation(
+    observationId: string,
+  ): ProviderCallObservation | undefined;
+  queryTrajectory(query: TrajectoryQuery): TrajectoryPage;
+}
+
 export type TrajectoryStoreErrorCode =
   | 'external-import-not-found'
   | 'native-resume-unavailable'
@@ -178,7 +192,7 @@ export class TrajectoryStoreError extends Error {
   }
 }
 
-export class InMemoryTrajectoryStore {
+export class InMemoryTrajectoryStore implements TrajectoryStore {
   private readonly imports = new Map<string, ExternalSessionImportRecord>();
   private readonly segments = new Map<string, TrajectorySegment>();
   private readonly observations = new Map<string, ProviderCallObservation>();
@@ -368,7 +382,7 @@ export interface SqliteTrajectoryStoreInput {
   redactor?: Redactor;
 }
 
-export class SqliteTrajectoryStore {
+export class SqliteTrajectoryStore implements TrajectoryStore {
   private readonly db: BetterSqliteDatabase;
   private readonly ownsDatabase: boolean;
   private readonly redactor: Redactor;


### PR DESCRIPTION
## Summary

P5 wires the trajectory observability read model into daemon runtime configuration, CLI startup, and Engine event handling after the P3/P4 read-model scaffolding.

本 PR：
- adds `daemon.trajectory` defaults and fail-closed parser coverage, including external import/provider capture scaffolding
- updates the CLI config template and reload semantics so `daemon.trajectory` changes are restart-required
- opens `SqliteTrajectoryStore` at config root `state.db` on startup and injects it into each Engine
- appends redacted `nexus-agent-event` trajectory segments for routed user input and AgentEvent output
- aligns runtime, `/sessions`, and trajectory `sessionId` through UUID-backed `SessionStore.ensureSessionId`
- keeps trajectory writes best-effort: store open/append failures do not block message delivery

## Why

P5 needs the read model from P3/P4 to receive actual runtime trajectory segments under the integration branch before later external import, provider observation, and viewer phases can build on it.

ADR: [ADR-0018](https://github.com/moesin-lab/agent-nexus/blob/codex/trajectory-observability/docs/dev/adr/0018-trajectory-observability-read-model.md)
Spec: [trajectory-observability.md](https://github.com/moesin-lab/agent-nexus/blob/codex/trajectory-observability/docs/dev/spec/infra/trajectory-observability.md), [config-routing.md](https://github.com/moesin-lab/agent-nexus/blob/codex/trajectory-observability/docs/dev/spec/config-routing.md)

## Test plan

- [x] Tests: `packages/daemon/src/config.test.ts`, `packages/daemon/src/engine.test.ts`, `packages/daemon/src/session-store.test.ts`, `packages/cli/src/config.test.ts`, `packages/cli/src/config-reload.test.ts`
- [x] `git diff --check` — passed
- [x] `corepack pnpm typecheck` — passed
- [x] `corepack pnpm test` — 34 files / 538 tests passed
- [x] `corepack pnpm build` — passed
- [ ] Manual: real Discord / real agent runtime path not run; this PR is covered by daemon/CLI unit integration tests and does not implement scanner/proxy/viewer flows

## Review notes

- Independent agent review: local Claude CLI review run against the branch; important findings were addressed and re-reviewed. Covered fixes include best-effort trajectory mapping, store-open downgrade, UUID session IDs for persistent read-model keys, and restart-required reload semantics for `daemon.trajectory`.
- Deep review: N/A; this PR does not implement external transcript scanning, provider proxy/capture, raw payload storage, or viewer behavior.

## Out of scope

- external import scanner and source adapters
- provider-call proxy/capture implementation
- trajectory viewer/report UI
- retention enforcement jobs
- merging into `main`