### PR TITLE
test(trajectory): add e2e read model verification

### DIFF
--- a/docs/dev/testing/discord-e2e.md
+++ b/docs/dev/testing/discord-e2e.md
@@ -92,6 +92,7 @@ E2E case 注入的是 `NormalizedEvent`，不是 raw gateway JSON。Discord raw 
 
 ```bash
 corepack pnpm test:e2e:discord -- --case happy-path
+corepack pnpm test:e2e:discord -- --case trajectory-read-model
 corepack pnpm test:e2e:discord -- --tag seed
 corepack pnpm test:e2e:discord -- --tag harness
 corepack pnpm test:e2e:discord -- --all
@@ -175,6 +176,7 @@ E2E 禁止用固定 sleep 等待业务结果。harness 提供显式等待：
 | `waitForAgentEvent(predicate, timeoutMs)` | recorder 看到某个 AgentEvent |
 | `waitForTurnFinished(traceId, timeoutMs)` | 同 traceId 的 turn terminal 到达 |
 | `waitForNoAgentCall(windowMs)` | 授权拒绝等负路径短窗口内未触发 agent |
+| `queryTrajectory(query)` | case 显式启用 trajectory store 时，查询 SQLite trajectory read model |
 
 等待失败时，runner 写出当前 transcript，并在 thrown error 中报告 case id、trace id 列表、最后一条事件类型和 artifact 绝对路径。
 
@@ -189,12 +191,14 @@ E2E 禁止用固定 sleep 等待业务结果。harness 提供显式等待：
 | `idempotency-replay` | Discord at-least-once 重放只处理一次 | 同 `(sessionKey, messageId)` 第二次不触发 agent；记录命中日志 |
 | `long-output-slicing` | 长回复切片归属清晰后，证明默认 E2E 不产生 fake-only 通过 | 不由 fake adapter 复刻 Discord `buildSlices`；最终断言随 platform-adapter owner 对切片归属的修正确定 |
 | `redaction` | agent 输出敏感模式时发到 Discord 前已脱敏 | outbound 不含原始 secret / 绝对路径；transcript 也不含原文 |
+| `trajectory-read-model` | runtime 事件写入 daemon trajectory read model | 用户输入、AgentEvent、usage anchor、sessionId、redaction 与 SQLite 查询结果匹配固定 fixture |
 
 当前实现状态与缺口：
 
 - `idempotency-replay` 需要按 spec 的 `(sessionKey, messageId)` 语义实现；当前已有可注入的内存 `IdempotencyStore`，但尚未覆盖 SQLite 持久化、TTL、GC 与 terminal status replay。
 - `redaction` 当前覆盖 daemon 到 IM outbound 的基础文本脱敏；日志 sink、agent 子进程 transcript 等全出口脱敏仍需后续按 redaction spec 补齐。
 - `long-output-slicing` 当前 seed 通过 fake platform 的 `maxTextLength` 能力模拟证明 harness 能捕获多条 outbound；真实 Discord 仍由 adapter 的 `buildSlices` 维护切片与 `MessageRef.messageIds`，段落 / 代码块边界、续页标记的最终归属仍需后续收敛。
+- `trajectory-read-model` 当前覆盖 scripted agent runtime 到 SQLite trajectory read model 的 daemon 链路；不覆盖外部 transcript scanner、真实 agent backend 或 provider proxy。
 - 若 session/idempotency 存储仍是内存实现，E2E 可以用 tmpdir state，但不能声称已覆盖 SQLite 持久化。
 
 ## 真实 Agent 选择
@@ -218,6 +222,7 @@ case 断言不能依赖完整 LLM 文本逐字一致。需要确定输出时，p
 
 - Discord raw gateway fixture 继续放 `testdata/discord/events/`，供 adapter 合约测试使用。
 - agent transcript fixture 继续放 owner backend 的 testdata；现有 Claude Code transcript 归 [`fixtures.md`](fixtures.md) 定义的 `testdata/cc-cli/transcripts/`，新增 Codex transcript 不在本文重新命名。
+- trajectory E2E 期望输出放 `testdata/trajectory/e2e/`；fixture 只保留已归一化、已脱敏、可稳定 diff 的 read model 视图，不保存运行时生成的 `segmentId`、`sessionId` 或 timestamp。
 - E2E seed case 配置可以放 `tests/e2e/discord/cases/`，只写脱敏输入和断言，不写运行产物。
 
 运行产物：

--- a/docs/dev/testing/fixtures.md
+++ b/docs/dev/testing/fixtures.md
@@ -43,6 +43,8 @@ related:
     │       └── ...
     ├── anthropic/
     │   └── responses/         # Anthropic API mock 响应
+    ├── trajectory/
+    │   └── e2e/               # trajectory read model 归一化期望输出
     └── eval/
         └── cases/             # Eval case（见 eval.md）
 ```
@@ -110,6 +112,13 @@ related:
 - 预期的归一化输出（NormalizedEvent、AgentEvent、OutboundMessage）
 - 测试跑时比对实际输出 == 快照
 - 更新策略见下文
+
+### Trajectory E2E 期望输出（`testdata/trajectory/e2e/*.expected.json`）
+
+- Discord E2E seed case 查询 daemon trajectory read model 后的归一化结果。
+- 只保存稳定字段：`source`、`kind`、`sequence`、`summary`、`redactionState`、必要 metadata 摘要。
+- 不保存运行时生成的 `segmentId`、`sessionId`、timestamp、临时目录或原始 secret。
+- fixture 必须是脱敏后的 read model 视图，不能包含外部原始 transcript 内容。
 
 ## 命名约定
 

--- a/scripts/discord-e2e-runner.mjs
+++ b/scripts/discord-e2e-runner.mjs
@@ -14,6 +14,7 @@ const CASE_PATTERNS = new Map([
   ['idempotency-replay', 'seed_idempotency_replay'],
   ['long-output-slicing', 'seed_long_output_slicing'],
   ['redaction', 'seed_redaction'],
+  ['trajectory-read-model', 'seed_trajectory_read_model'],
 ]);
 
 function usage() {
@@ -21,6 +22,7 @@ function usage() {
   corepack pnpm test:e2e:discord -- --all
   corepack pnpm test:e2e:discord -- --tag seed
   corepack pnpm test:e2e:discord -- --case happy-path
+  corepack pnpm test:e2e:discord -- --case trajectory-read-model
 
 Options:
   --all                 Run all Discord E2E tests.

--- a/testdata/trajectory/e2e/discord_runtime_read_model.expected.json
+++ b/testdata/trajectory/e2e/discord_runtime_read_model.expected.json
@@ -1,0 +1,135 @@
+[
+  {
+    "source": "nexus-agent-event",
+    "kind": "user-message",
+    "sequence": 1,
+    "traceId": "seed-trajectory-trace",
+    "summary": "trajectory input ANTHROPIC_API_KEY=<redacted> path=~/private/prompt.txt",
+    "confidence": "high",
+    "redactionState": "redacted",
+    "sameSession": true,
+    "metadata": {
+      "eventId": "seed-trajectory-event",
+      "messageId": "seed-trajectory-message",
+      "sessionKey": "discord-main:discord:C-e2e-main:U-e2e-owner",
+      "agentName": "scripted-agent"
+    }
+  },
+  {
+    "source": "nexus-agent-event",
+    "kind": "state-change",
+    "sequence": 2,
+    "traceId": "seed-trajectory-trace",
+    "summary": "session started: scripted-trajectory-session",
+    "confidence": "high",
+    "redactionState": "redacted",
+    "sameSession": true,
+    "metadata": {
+      "eventType": "session_started",
+      "agentEventSequence": 1,
+      "sessionKey": "discord-main:discord:C-e2e-main:U-e2e-owner",
+      "workingDir": "~/trajectory-secret-workdir"
+    }
+  },
+  {
+    "source": "nexus-agent-event",
+    "kind": "reasoning",
+    "sequence": 3,
+    "traceId": "seed-trajectory-trace",
+    "summary": "thinking with ANTHROPIC_API_KEY=<redacted>",
+    "confidence": "high",
+    "redactionState": "redacted",
+    "sameSession": true,
+    "metadata": {
+      "eventType": "thinking",
+      "agentEventSequence": 2,
+      "sessionKey": "discord-main:discord:C-e2e-main:U-e2e-owner"
+    }
+  },
+  {
+    "source": "nexus-agent-event",
+    "kind": "tool-call",
+    "sequence": 4,
+    "traceId": "seed-trajectory-trace",
+    "summary": "Read: ~/private/input.txt",
+    "confidence": "high",
+    "redactionState": "redacted",
+    "sameSession": true,
+    "metadata": {
+      "eventType": "tool_call_started",
+      "agentEventSequence": 3,
+      "sessionKey": "discord-main:discord:C-e2e-main:U-e2e-owner",
+      "toolName": "Read",
+      "callId": "tool-1"
+    }
+  },
+  {
+    "source": "nexus-agent-event",
+    "kind": "tool-result",
+    "sequence": 5,
+    "traceId": "seed-trajectory-trace",
+    "summary": "result contains DISCORD_TOKEN=<redacted> and ~/private/output.txt",
+    "confidence": "high",
+    "redactionState": "redacted",
+    "sameSession": true,
+    "metadata": {
+      "eventType": "tool_result",
+      "agentEventSequence": 4,
+      "sessionKey": "discord-main:discord:C-e2e-main:U-e2e-owner",
+      "callId": "tool-1",
+      "resultSequence": 1,
+      "contentKind": "text"
+    }
+  },
+  {
+    "source": "nexus-agent-event",
+    "kind": "usage",
+    "sequence": 6,
+    "traceId": "seed-trajectory-trace",
+    "turnSequence": 1,
+    "summary": "scripted-model, input 11, output 7, cost unknown",
+    "confidence": "high",
+    "redactionState": "redacted",
+    "sameSession": true,
+    "usageEventId": "usage:5",
+    "metadata": {
+      "eventType": "usage",
+      "agentEventSequence": 5,
+      "sessionKey": "discord-main:discord:C-e2e-main:U-e2e-owner",
+      "usageModel": "scripted-model",
+      "usageCompleteness": "partial"
+    }
+  },
+  {
+    "source": "nexus-agent-event",
+    "kind": "agent-message",
+    "sequence": 7,
+    "traceId": "seed-trajectory-trace",
+    "summary": "trajectory final answer",
+    "confidence": "high",
+    "redactionState": "redacted",
+    "sameSession": true,
+    "metadata": {
+      "eventType": "text_final",
+      "agentEventSequence": 6,
+      "sessionKey": "discord-main:discord:C-e2e-main:U-e2e-owner"
+    }
+  },
+  {
+    "source": "nexus-agent-event",
+    "kind": "state-change",
+    "sequence": 8,
+    "traceId": "seed-trajectory-trace",
+    "turnSequence": 1,
+    "summary": "turn finished: stop",
+    "confidence": "high",
+    "redactionState": "redacted",
+    "sameSession": true,
+    "metadata": {
+      "eventType": "turn_finished",
+      "agentEventSequence": 7,
+      "sessionKey": "discord-main:discord:C-e2e-main:U-e2e-owner",
+      "reason": "stop"
+    }
+  }
+]

--- a/tests/e2e/discord/harness.ts
+++ b/tests/e2e/discord/harness.ts
@@ -24,6 +24,11 @@ import type { PlatformAuthConfig } from '../../../packages/daemon/src/config.js'
 import { InMemoryIdempotencyStore } from '../../../packages/daemon/src/idempotency.js';
 import { createLogger } from '../../../packages/daemon/src/logger.js';
 import { SessionStore } from '../../../packages/daemon/src/session-store.js';
+import {
+  SqliteTrajectoryStore,
+  type TrajectoryPage,
+  type TrajectoryQuery,
+} from '../../../packages/daemon/src/trajectory-store.js';
 
 const DEFAULT_PLATFORM_CAPS: CapabilitySet = {
   maxTextLength: 2_000,
@@ -137,6 +142,9 @@ export interface DiscordE2EHarnessOptions {
   platformName?: string;
   platformCaps?: Partial<CapabilitySet>;
   sessionKey?: PlatformSessionKey;
+  trajectory?: {
+    enabled?: boolean;
+  };
   agentEvents: ScriptedAgentEvents;
 }
 
@@ -144,6 +152,7 @@ export interface DiscordE2EHarnessPaths {
   rootDir: string;
   workingDir: string;
   stateDir: string;
+  trajectoryDbPath: string;
   transcriptDir: string;
 }
 
@@ -156,6 +165,8 @@ export interface InjectMessageOptions {
   displayName?: string;
   guildId?: string;
   initiatorRoleIds?: string[];
+  receivedAt?: Date;
+  platformTimestamp?: Date;
 }
 
 export function scriptedTextReply(text: string): ScriptedAgentEvents {
@@ -388,6 +399,7 @@ export function createDiscordE2EHarness(options: DiscordE2EHarnessOptions): {
   ): Promise<NormalizedEvent>;
   paths: DiscordE2EHarnessPaths;
   platform: FakeDiscordPlatform;
+  queryTrajectory(query?: TrajectoryQuery): TrajectoryPage;
   start(): Promise<void>;
   stop(): Promise<void>;
   transcript: Transcript;
@@ -412,6 +424,7 @@ export function createDiscordE2EHarness(options: DiscordE2EHarnessOptions): {
     rootDir,
     workingDir: path.join(rootDir, 'workdir'),
     stateDir: path.join(rootDir, 'state'),
+    trajectoryDbPath: path.join(rootDir, 'state.db'),
     transcriptDir: path.join(rootDir, 'transcripts'),
   };
   mkdirSync(paths.workingDir, { recursive: true });
@@ -538,6 +551,10 @@ export function createDiscordE2EHarness(options: DiscordE2EHarnessOptions): {
     settleAgentWaiters,
     options.agentEvents,
   );
+  const trajectoryStore =
+    options.trajectory?.enabled === true
+      ? new SqliteTrajectoryStore({ path: paths.trajectoryDbPath })
+      : undefined;
   const engine = new Engine({
     platform,
     platformName: options.platformName ?? 'discord-main',
@@ -546,6 +563,9 @@ export function createDiscordE2EHarness(options: DiscordE2EHarnessOptions): {
     agent,
     logger: createLogger({ level: 'fatal', pretty: false }),
     sessionStore: new SessionStore(),
+    trajectory: trajectoryStore
+      ? { enabled: true, store: trajectoryStore }
+      : undefined,
     defaultSessionConfig: {
       workingDir: paths.workingDir,
       timeoutMs: 10_000,
@@ -600,6 +620,12 @@ export function createDiscordE2EHarness(options: DiscordE2EHarnessOptions): {
     paths,
     platform,
     transcript,
+    queryTrajectory(query: TrajectoryQuery = {}): TrajectoryPage {
+      if (!trajectoryStore) {
+        throw new Error('Trajectory store is not enabled for this harness');
+      }
+      return trajectoryStore.queryTrajectory(query);
+    },
     async start(): Promise<void> {
       await engine.start();
     },
@@ -607,6 +633,7 @@ export function createDiscordE2EHarness(options: DiscordE2EHarnessOptions): {
       if (stopped) return;
       stopped = true;
       await engine.stop();
+      trajectoryStore?.close();
       if (preserveArtifacts && transcript.status === 'running') {
         writeTranscript('passed');
       }
@@ -625,6 +652,7 @@ export function createDiscordE2EHarness(options: DiscordE2EHarnessOptions): {
         initiatorUserId:
           overrides.initiatorUserId ?? sessionKey.initiatorUserId,
       };
+      const receivedAt = overrides.receivedAt ?? new Date();
       const event: NormalizedEvent = {
         eventId: overrides.eventId ?? `e2e-event-${id}`,
         platform: 'discord',
@@ -635,8 +663,8 @@ export function createDiscordE2EHarness(options: DiscordE2EHarnessOptions): {
         text,
         rawPayload: {},
         rawContentType: 'application/json',
-        receivedAt: new Date(),
-        platformTimestamp: new Date(),
+        receivedAt,
+        platformTimestamp: overrides.platformTimestamp ?? receivedAt,
         guildId: overrides.guildId ?? 'G-e2e',
         initiatorRoleIds: overrides.initiatorRoleIds,
         initiator: {

--- a/tests/e2e/discord/runner.test.ts
+++ b/tests/e2e/discord/runner.test.ts
@@ -33,6 +33,17 @@ describe('Discord E2E runner args', () => {
     ]);
   });
 
+  it('maps --case trajectory-read-model to the trajectory seed test', () => {
+    expect(buildVitestArgs(['--case', 'trajectory-read-model'])).toEqual([
+      'run',
+      '--config',
+      'vitest.e2e.config.ts',
+      'tests/e2e/discord',
+      '--testNamePattern',
+      'seed_trajectory_read_model',
+    ]);
+  });
+
   it('ignores the pnpm argument separator before runner options', () => {
     expect(buildVitestArgs(['--', '--case', 'redaction'])).toEqual([
       'run',

--- a/tests/e2e/discord/seed.test.ts
+++ b/tests/e2e/discord/seed.test.ts
@@ -1,4 +1,8 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { afterEach, describe, expect, it } from 'vitest';
+import type { AgentEvent } from '../../../packages/protocol/src/index.js';
+import type { TrajectorySegment } from '../../../packages/daemon/src/trajectory-store.js';
 import {
   createDiscordE2EHarness,
   scriptedTextReply,
@@ -45,6 +49,158 @@ function allowOnlyOwner() {
 
 function outboundSends(events: TranscriptEvent[]) {
   return events.filter((event) => event.kind === 'outbound_send');
+}
+
+function loadExpectedTrajectoryFixture() {
+  const fixturePath = fileURLToPath(
+    new URL(
+      '../../../testdata/trajectory/e2e/discord_runtime_read_model.expected.json',
+      import.meta.url,
+    ),
+  );
+  return JSON.parse(readFileSync(fixturePath, 'utf8')) as unknown;
+}
+
+function trajectoryAgentEvents(): AgentEvent[] {
+  const timestamp = new Date('2026-06-23T10:30:00.000Z');
+  return [
+    {
+      type: 'session_started',
+      traceId: 'seed-trajectory-trace',
+      timestamp,
+      sequence: 1,
+      payload: {
+        agentSessionId: 'scripted-trajectory-session',
+        workingDir: '/home/node/trajectory-secret-workdir',
+        capabilities: {
+          supportsThinking: true,
+          supportsStreaming: false,
+          supportsToolCallEvents: true,
+          supportsInterrupt: false,
+          supportsStdinInterrupt: false,
+        },
+      },
+    },
+    {
+      type: 'thinking',
+      traceId: 'seed-trajectory-trace',
+      timestamp,
+      sequence: 2,
+      payload: {
+        text: 'thinking with ANTHROPIC_API_KEY=sk-ant-thinking-secret',
+      },
+    },
+    {
+      type: 'tool_call_started',
+      traceId: 'seed-trajectory-trace',
+      timestamp,
+      sequence: 3,
+      payload: {
+        callId: 'tool-1',
+        toolName: 'Read',
+        inputSummary: '/home/node/private/input.txt',
+      },
+    },
+    {
+      type: 'tool_result',
+      traceId: 'seed-trajectory-trace',
+      timestamp,
+      sequence: 4,
+      payload: {
+        callId: 'tool-1',
+        resultSequence: 1,
+        content: {
+          kind: 'text',
+          text: 'result contains DISCORD_TOKEN=MTksecret and /home/node/private/output.txt',
+        },
+        isError: false,
+      },
+    },
+    {
+      type: 'usage',
+      traceId: 'seed-trajectory-trace',
+      timestamp,
+      sequence: 5,
+      payload: {
+        model: 'scripted-model',
+        inputTokens: 11,
+        outputTokens: 7,
+        cacheReadTokens: 0,
+        cacheWriteTokens: 0,
+        costUsd: null,
+        turnSequence: 1,
+        toolCallsThisTurn: 1,
+        wallClockMs: 25,
+        completeness: 'partial',
+      },
+    },
+    {
+      type: 'text_final',
+      traceId: 'seed-trajectory-trace',
+      timestamp,
+      sequence: 6,
+      payload: {
+        text: 'trajectory final answer',
+      },
+    },
+    {
+      type: 'turn_finished',
+      traceId: 'seed-trajectory-trace',
+      timestamp,
+      sequence: 7,
+      payload: {
+        reason: 'stop',
+        turnSequence: 1,
+      },
+    },
+  ];
+}
+
+function normalizeTrajectorySegments(segments: TrajectorySegment[]) {
+  const firstSessionId = segments[0]?.sessionId;
+  return segments.map((segment) => {
+    const metadata = JSON.parse(segment.metadataJson) as Record<string, unknown>;
+    return {
+      source: segment.source,
+      kind: segment.kind,
+      sequence: segment.sequence,
+      traceId: segment.traceId,
+      turnSequence: segment.turnSequence,
+      summary: segment.summary,
+      confidence: segment.confidence,
+      redactionState: segment.redactionState,
+      sameSession: segment.sessionId === firstSessionId,
+      usageEventId: segment.usageEventId
+        ? segment.usageEventId.replace(`${segment.sessionId}:`, '')
+        : undefined,
+      metadata: {
+        eventId: metadata['eventId'],
+        messageId: metadata['messageId'],
+        eventType: metadata['eventType'],
+        agentEventSequence: metadata['agentEventSequence'],
+        sessionKey: metadata['sessionKey'],
+        agentName: metadata['agentName'],
+        toolName: metadata['toolName'],
+        callId: metadata['callId'],
+        resultSequence: metadata['resultSequence'],
+        contentKind: metadata['contentKind'],
+        usageModel:
+          typeof metadata['usage'] === 'object' &&
+          metadata['usage'] !== null &&
+          !Array.isArray(metadata['usage'])
+            ? (metadata['usage'] as Record<string, unknown>)['model']
+            : undefined,
+        usageCompleteness:
+          typeof metadata['usage'] === 'object' &&
+          metadata['usage'] !== null &&
+          !Array.isArray(metadata['usage'])
+            ? (metadata['usage'] as Record<string, unknown>)['completeness']
+            : undefined,
+        reason: metadata['reason'],
+        workingDir: metadata['workingDir'],
+      },
+    };
+  });
 }
 
 describe('Discord E2E seed cases', () => {
@@ -145,5 +301,51 @@ describe('Discord E2E seed cases', () => {
     expect(outbound.message.text).not.toContain('/home/node/secret');
     expect(outbound.message.text).toContain('ANTHROPIC_API_KEY=<redacted>');
     expect(outbound.message.text).toContain('~/secret/file.txt');
+  });
+
+  it('seed_trajectory_read_model_should_persist_runtime_events_to_sqlite_fixture', async () => {
+    const harness = makeHarness({
+      caseId: 'seed-trajectory-read-model',
+      trajectory: { enabled: true },
+      agentEvents: trajectoryAgentEvents,
+    });
+
+    await harness.start();
+    await harness.injectMessage(
+      'trajectory input ANTHROPIC_API_KEY=sk-ant-input-secret path=/home/node/private/prompt.txt',
+      {
+        eventId: 'seed-trajectory-event',
+        messageId: 'seed-trajectory-message',
+        traceId: 'seed-trajectory-trace',
+        receivedAt: new Date('2026-06-23T10:29:59.000Z'),
+      },
+    );
+    await harness.waitForTurnFinished('seed-trajectory-trace');
+
+    const page = harness.queryTrajectory({
+      source: 'nexus-agent-event',
+      limit: 20,
+    });
+    expect(page.segments).toHaveLength(8);
+    expect(page.segments.at(-1)).toMatchObject({
+      kind: 'state-change',
+      summary: 'turn finished: stop',
+    });
+    expect(new Set(page.segments.map((segment) => segment.sessionId)).size).toBe(
+      1,
+    );
+    expect(page.segments[0]?.sessionId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    );
+    expect(JSON.stringify(page.segments)).not.toContain('sk-ant');
+    expect(JSON.stringify(page.segments)).not.toContain('MTk');
+    expect(JSON.stringify(page.segments)).not.toContain('/home/node/private');
+    expect(JSON.stringify(page.segments)).not.toContain(
+      '/home/node/trajectory-secret-workdir',
+    );
+
+    expect(normalizeTrajectorySegments(page.segments)).toEqual(
+      loadExpectedTrajectoryFixture(),
+    );
   });
 });


### PR DESCRIPTION
## Summary

P6 adds a repeatable Discord E2E seed that proves runtime AgentEvent traffic is persisted into the daemon-owned trajectory read model and can be queried from SQLite.

本 PR：
- adds optional `SqliteTrajectoryStore` injection and `queryTrajectory()` to the Discord E2E harness
- adds the `trajectory-read-model` seed case and runner mapping
- checks the queried read model against a redacted expected fixture under `testdata/trajectory/e2e/`
- documents the new seed case and trajectory fixture location

## Why

P6 needs a stable verification artifact for the P3-P5 trajectory work: config/runtime wiring is already implemented, but the goal needs an end-to-end proof that a user message and AgentEvents become queryable trajectory segments without leaking raw secrets or runtime-only IDs into fixtures.

ADR: [ADR-0018](https://github.com/moesin-lab/agent-nexus/blob/codex/trajectory-observability/docs/dev/adr/0018-trajectory-observability-read-model.md)
Spec: [trajectory-observability.md](https://github.com/moesin-lab/agent-nexus/blob/codex/trajectory-observability/docs/dev/spec/infra/trajectory-observability.md), [discord-e2e.md](https://github.com/moesin-lab/agent-nexus/blob/codex/trajectory-observability/docs/dev/testing/discord-e2e.md), [fixtures.md](https://github.com/moesin-lab/agent-nexus/blob/codex/trajectory-observability/docs/dev/testing/fixtures.md)

## Test plan

- [x] Red: `corepack pnpm exec vitest run --config vitest.e2e.config.ts tests/e2e/discord/seed.test.ts --testNamePattern seed_trajectory_read_model` — failed before harness support with `queryTrajectory is not a function`
- [x] Tests: `tests/e2e/discord/seed.test.ts`, `tests/e2e/discord/runner.test.ts`
- [x] `corepack pnpm test:e2e:discord -- --case trajectory-read-model` — passed
- [x] `corepack pnpm test:e2e:discord -- --tag seed` — passed
- [x] `corepack pnpm test:e2e:discord -- --all` — 3 files / 21 tests passed
- [x] `corepack pnpm typecheck` — passed
- [x] `corepack pnpm test` — 34 files / 538 tests passed
- [x] `corepack pnpm build` — passed
- [x] `git diff --check` — passed
- [ ] Manual: real Discord / real agent runtime not run; this PR adds a scripted E2E seed and does not implement the real-agent runner, external import scanner, or provider proxy

## Review notes

- Independent agent review: Claude review saved at `/home/node/.goal/agent-nexus-trajectory-observability/reviews/p6-verification-claude-review-20260623.md`; no blocker/important findings. Two nits were addressed: explicit final segment assertion and broader raw secret/path negative assertions. The suggested `secret-workdir` substring assertion was narrowed to the raw absolute path because redaction intentionally preserves the basename as `~/trajectory-secret-workdir`.
- Deep review: N/A; this PR adds a focused E2E verification fixture and docs, not a new architecture/spec/security decision.

## Out of scope

- external transcript scanner/source adapters
- native external resume UI/command flow
- provider proxy/capture implementation
- real agent backend E2E runner
- merging into `main`