### PR TITLE
feat(daemon): capture transcript-only provider usage

### DIFF
--- a/docs/dev/spec/infra/persistence.md
+++ b/docs/dev/spec/infra/persistence.md
@@ -314,6 +314,7 @@ interface Store {
     upsertExternalSessionImport(record) -> void
     appendTrajectorySegment(segment) -> void
     recordProviderCallObservation(observation) -> void
+    pruneProviderCallObservations(before) -> int
     queryTrajectory(query) -> TrajectoryPage
 }
 ```

--- a/docs/dev/spec/infra/trajectory-observability.md
+++ b/docs/dev/spec/infra/trajectory-observability.md
@@ -362,6 +362,13 @@ Capture 规则：
 | Codex App/Desktop local transcript | unsupported | unsupported | allowed | off |
 | unknown | unsupported | unsupported | unsupported | off |
 
+当前 daemon runtime 实现状态：
+
+- 已实现 `codex` / `claudecode` backend 的 `transcript-only` usage observation：当 agent runtime 发出 `usage` AgentEvent 且 `providerCapture.enabled=true` 时，daemon 写入 metadata-only `ProviderCallObservation` 和 `source=provider-call, kind=usage` 的 trajectory segment。
+- 尚未实现 provider proxy runner；`reverse-proxy` / `forward-proxy` 配置在运行时 fail-closed，记录 `provider_capture_failed`，不写 observation。
+- `ProviderCaptureService.recordProviderCall` 提供 redacted + size-limited payload 写入 helper，只允许写 `<home>/trajectory/provider-calls/`；当前 runtime 尚无 provider proxy 调用方，只有单元测试覆盖该 helper。
+- provider capture 开启时，启动按 `providerCapture.retentionDays` 清理过期 `provider_call_observations` 及其 `provider-call` trajectory segments。
+
 ## 查询契约
 
 ```text
@@ -424,7 +431,10 @@ TrajectoryPage {
 - backend mismatch 拒绝 resume，不清除已有 RoutingSession ref。
 - 成功绑定 external session 后才停止当前 live runtime handle；失败路径不改变旧 ref。
 - provider capture 默认关闭。
+- provider capture 开启后，`codex` / `claudecode` 的 `usage` AgentEvent 产生 transcript-only provider observation。
+- 未实现的 provider proxy mode fail-closed 且不写 observation。
 - redaction 失败时 provider payload 不落盘。
+- provider observation retention 同步清理对应 `provider-call` trajectory segment。
 - `includeContent=true` 不读取外部原始 transcript。
 - unknown schema 产生 `unknown` segment 或 unsupported reason，不抛裸异常。
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,6 +6,7 @@ import {
   Engine,
   ExternalSessionImportService,
   InMemoryIdempotencyStore,
+  ProviderCaptureService,
   SessionStore,
   SqliteTrajectoryStore,
   createLogger,
@@ -109,6 +110,25 @@ async function main(): Promise<void> {
         contentStorageRoot: configRoot(),
       })
     : undefined;
+  const providerCaptureService = trajectoryStore
+    ? new ProviderCaptureService({
+        config: config.daemon.trajectory.providerCapture,
+        store: trajectoryStore,
+        contentStorageRoot: configRoot(),
+      })
+    : undefined;
+  const providerCapture = config.daemon.trajectory.providerCapture.enabled
+    ? providerCaptureService
+    : undefined;
+  if (providerCapture) {
+    const retention = providerCapture.applyRetention();
+    if (retention.deletedObservations > 0) {
+      logger.info(
+        { deletedObservations: retention.deletedObservations },
+        'provider_capture_retention_applied',
+      );
+    }
+  }
   const engines: Engine[] = [];
   // targets 在下面循环里随 engine 创建逐个填充；reloader 调用时才读取
   const configReloadTargets: ConfigReloadTarget[] = [];
@@ -211,6 +231,7 @@ async function main(): Promise<void> {
         store: trajectoryStore,
       },
       externalSessionImporter,
+      providerCapture,
     });
     engines.push(engine);
     configReloadTargets.push({

--- a/packages/daemon/src/engine.test.ts
+++ b/packages/daemon/src/engine.test.ts
@@ -30,6 +30,7 @@ import { Engine } from './engine.js';
 import { ExternalSessionImportServiceError } from './external-session-import.js';
 import { InMemoryIdempotencyStore } from './idempotency.js';
 import { createLogger, type Logger } from './logger.js';
+import { ProviderCaptureService } from './provider-capture.js';
 import type { RoutingEntry } from './router.js';
 import { SessionStore } from './session-store.js';
 import {
@@ -560,6 +561,7 @@ function makeThrowingTrajectoryStore(): TrajectoryStore & {
     }),
     recordProviderCallObservation: vi.fn(),
     getProviderCallObservation: vi.fn(() => undefined),
+    pruneProviderCallObservations: vi.fn(() => 0),
     queryTrajectory: vi.fn(() => ({ segments: [] })),
   };
 }
@@ -702,6 +704,100 @@ describe('Engine', () => {
       turnSequence: 1,
       usageEventId: expect.any(String),
     });
+  });
+
+  it('provider capture enabled 时把 usage AgentEvent 记录为 transcript-only provider observation', async () => {
+    const platform = makePlatform();
+    const agent = makeAgent();
+    const store = new SessionStore();
+    const trajectoryStore = new InMemoryTrajectoryStore();
+    const providerCapture = new ProviderCaptureService({
+      config: {
+        enabled: true,
+        mode: 'transcript-only',
+        bindHost: '127.0.0.1',
+        port: null,
+        storeRawStreams: false,
+        maxRequestBytes: 1024,
+        maxResponseBytes: 1024,
+        retentionDays: 30,
+      },
+      store: trajectoryStore,
+      idFactory: () => 'obs-engine-usage',
+    });
+    const engine = new Engine({
+      platform,
+      agents: [
+        {
+          agentName: 'codex-dev',
+          agentOwner: 'codex',
+          agent: agent.runtime,
+          defaultSessionConfig: DEFAULT_CFG,
+        },
+      ],
+      routingTable: [
+        {
+          bindingName: 'discord-main-codex',
+          platformName: 'mock-platform',
+          platformType: 'discord',
+          agentName: 'codex-dev',
+          match: { discord: { channelIds: ['C1'] } },
+        },
+      ],
+      platformAuth: PLATFORM_AUTH_ALLOW_U1,
+      logger: SILENT_LOGGER,
+      sessionStore: store,
+      trajectory: { enabled: true, store: trajectoryStore },
+      providerCapture,
+    });
+
+    agent.queueEvents([
+      ev('session_started', { agentSessionId: 'sid-123' }, 1),
+      ev(
+        'usage',
+        {
+          model: 'gpt-5',
+          inputTokens: 10,
+          outputTokens: 5,
+          cacheReadTokens: 1,
+          cacheWriteTokens: 2,
+          costUsd: null,
+          turnSequence: 1,
+          toolCallsThisTurn: 0,
+          wallClockMs: 1000,
+          completeness: 'partial',
+        },
+        2,
+      ),
+      ev('text_final', { text: 'answer' }, 3),
+      ev('turn_finished', { reason: 'stop', turnSequence: 1 }, 4),
+    ]);
+
+    await engine.start();
+    const dispatchHandler = (platform.start as ReturnType<typeof vi.fn>).mock.calls[0]![0] as EventHandler;
+    await dispatchHandler(makeEvent('hello'));
+
+    const sessionId = (agent.startSession.mock.calls[0]![1] as SessionConfig)
+      .sessionId;
+    expect(trajectoryStore.getProviderCallObservation('obs-engine-usage'))
+      .toMatchObject({
+        sessionId,
+        traceId: 't-1',
+        backend: 'codex',
+        captureMode: 'transcript-only',
+        model: 'gpt-5',
+        redactionState: 'metadata-only',
+      });
+    expect(
+      trajectoryStore.queryTrajectory({ source: 'provider-call' }).segments,
+    ).toEqual([
+      expect.objectContaining({
+        sessionId,
+        providerObservationId: 'obs-engine-usage',
+        kind: 'usage',
+        source: 'provider-call',
+      }),
+    ]);
   });
 
   it('trajectory enabled=false 时不写 read model', async () => {

--- a/packages/daemon/src/engine.ts
+++ b/packages/daemon/src/engine.ts
@@ -47,6 +47,10 @@ import {
   QueueItemCancelledError,
   queueKeyFromEvent,
 } from './message-queue.js';
+import type {
+  ProviderCaptureRecordResult,
+  ProviderCaptureRecorder,
+} from './provider-capture.js';
 import { BasicRedactor, type Redactor } from './redaction.js';
 import { RouteError, selectRoute, type RoutingEntry } from './router.js';
 import type { SessionStore } from './session-store.js';
@@ -117,6 +121,7 @@ export interface EngineDeps {
     store?: TrajectoryStore;
   };
   externalSessionImporter?: ExternalSessionImporter;
+  providerCapture?: ProviderCaptureRecorder;
 }
 
 const DEFAULT_STREAM_EDIT_THROTTLE_MS = 1500;
@@ -327,6 +332,7 @@ export class Engine {
   private readonly trajectoryEnabled: boolean;
   private readonly trajectoryStore?: TrajectoryStore;
   private readonly externalSessionImporter?: ExternalSessionImporter;
+  private readonly providerCapture?: ProviderCaptureRecorder;
   private readonly streamEditThrottleMs: number;
   private readonly typingRefreshMs: number;
   private readonly agentSessions = new Map<string, ActiveAgentSession>();
@@ -379,6 +385,7 @@ export class Engine {
     this.trajectoryEnabled = deps.trajectory?.enabled ?? true;
     this.trajectoryStore = deps.trajectory?.store;
     this.externalSessionImporter = deps.externalSessionImporter;
+    this.providerCapture = deps.providerCapture;
     this.streamEditThrottleMs =
       deps.streaming?.streamEditThrottleMs ?? DEFAULT_STREAM_EDIT_THROTTLE_MS;
     this.typingRefreshMs =
@@ -2672,6 +2679,68 @@ export class Engine {
     }
   }
 
+  private recordProviderUsageBestEffort(
+    active: ActiveAgentSession,
+    event: Extract<AgentEvent, { type: 'usage' }>,
+    agentSlot: EngineAgent,
+  ): void {
+    if (!this.providerCapture) return;
+    const backend = agentSlot.agentOwner ?? agentSlot.agent.name();
+    let result: ProviderCaptureRecordResult;
+    try {
+      result = this.providerCapture.recordUsageObservation({
+        backend,
+        sessionId: active.sessionId,
+        traceId: event.traceId,
+        observedAt: event.timestamp,
+        agentEventSequence: event.sequence,
+        trajectorySequence: this.sessionStore.nextTrajectorySequence(
+          active.sessionId,
+        ),
+        usage: event.payload,
+      });
+    } catch (err) {
+      this.logger.warn(
+        {
+          traceId: event.traceId,
+          sessionId: active.sessionId,
+          backend,
+          err,
+        },
+        'provider_capture_failed',
+      );
+      return;
+    }
+
+    if (result.status === 'recorded') {
+      this.logger.info(
+        {
+          traceId: event.traceId,
+          sessionId: active.sessionId,
+          backend,
+          captureMode: 'transcript-only',
+          observationId: result.observationId,
+          alignmentConfidence: 'medium',
+          redactionState: 'metadata-only',
+        },
+        'provider_call_observed',
+      );
+      return;
+    }
+    if (result.status === 'unsupported' || result.status === 'dropped') {
+      this.logger.warn(
+        {
+          traceId: event.traceId,
+          sessionId: active.sessionId,
+          backend,
+          code: result.code,
+          reason: result.status === 'unsupported' ? result.reason : undefined,
+        },
+        'provider_capture_failed',
+      );
+    }
+  }
+
   private appendAgentEventTrajectoryBestEffort(
     active: ActiveAgentSession,
     event: AgentEvent,
@@ -3062,6 +3131,13 @@ export class Engine {
               e,
               sessionKeyStr,
             );
+            if (e.type === 'usage') {
+              this.recordProviderUsageBestEffort(
+                activeSessionForTrajectory,
+                e,
+                agentSlot,
+              );
+            }
           }
           if (e.type === 'session_started') {
             const agentSessionId = e.payload.agentSessionId;

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -93,6 +93,17 @@ export {
   type ResumeEligibility,
 } from './external-session-import.js';
 export {
+  ProviderCaptureService,
+  isProviderCaptureSupported,
+  type ProviderCallCaptureInput,
+  type ProviderCaptureErrorCode,
+  type ProviderCaptureRecordResult,
+  type ProviderCaptureRecorder,
+  type ProviderCaptureServiceInput,
+  type ProviderCaptureSupport,
+  type ProviderUsageObservationInput,
+} from './provider-capture.js';
+export {
   DEFAULT_DAEMON_RUNTIME_CONFIG,
   parseDaemonConfig,
   parseDaemonRuntimeConfig,

--- a/packages/daemon/src/provider-capture.test.ts
+++ b/packages/daemon/src/provider-capture.test.ts
@@ -1,0 +1,317 @@
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  DEFAULT_DAEMON_RUNTIME_CONFIG,
+  type ProviderCaptureConfig,
+} from './config.js';
+import {
+  ProviderCaptureService,
+  isProviderCaptureSupported,
+} from './provider-capture.js';
+import { InMemoryTrajectoryStore } from './trajectory-store.js';
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('isProviderCaptureSupported', () => {
+  it('only enables the implemented transcript-only backend paths', () => {
+    expect(isProviderCaptureSupported('codex', 'transcript-only')).toEqual({
+      supported: true,
+    });
+    expect(isProviderCaptureSupported('claudecode', 'transcript-only')).toEqual({
+      supported: true,
+    });
+    expect(isProviderCaptureSupported('codex', 'reverse-proxy')).toMatchObject({
+      supported: false,
+      code: 'provider-capture-unsupported',
+    });
+    expect(isProviderCaptureSupported('future', 'transcript-only')).toMatchObject({
+      supported: false,
+      code: 'provider-capture-unsupported',
+    });
+  });
+});
+
+describe('ProviderCaptureService', () => {
+  it('does not record observations when provider capture is disabled', () => {
+    const store = new InMemoryTrajectoryStore();
+    const service = new ProviderCaptureService({
+      config: providerConfig({ enabled: false }),
+      store,
+      now: fixedNow,
+    });
+
+    const result = service.recordUsageObservation(usageInput());
+
+    expect(result).toEqual({
+      status: 'disabled',
+      code: 'provider-capture-disabled',
+    });
+    expect(store.queryTrajectory({ source: 'provider-call' }).segments).toEqual([]);
+  });
+
+  it('fails closed for unsupported capture modes without writing store records', () => {
+    const store = new InMemoryTrajectoryStore();
+    const service = new ProviderCaptureService({
+      config: providerConfig({ enabled: true, mode: 'reverse-proxy' }),
+      store,
+      now: fixedNow,
+    });
+
+    const result = service.recordUsageObservation(usageInput());
+
+    expect(result).toMatchObject({
+      status: 'unsupported',
+      code: 'provider-capture-unsupported',
+    });
+    expect(store.queryTrajectory({ source: 'provider-call' }).segments).toEqual([]);
+  });
+
+  it('records transcript-only usage as a provider observation and trajectory segment', () => {
+    const store = new InMemoryTrajectoryStore();
+    const service = new ProviderCaptureService({
+      config: providerConfig({ enabled: true, mode: 'transcript-only' }),
+      store,
+      now: fixedNow,
+      idFactory: fixedIdFactory('obs-usage'),
+    });
+
+    const result = service.recordUsageObservation(
+      usageInput({ trajectorySequence: 7 }),
+    );
+
+    expect(result).toMatchObject({
+      status: 'recorded',
+      observationId: 'obs-usage',
+    });
+    expect(store.getProviderCallObservation('obs-usage')).toMatchObject({
+      observationId: 'obs-usage',
+      sessionId: 'sess-1',
+      traceId: 'trace-1',
+      backend: 'codex',
+      captureMode: 'transcript-only',
+      model: 'gpt-5',
+      requestBytes: 0,
+      responseBytes: 0,
+      redactionState: 'metadata-only',
+      alignment: {
+        confidence: 'medium',
+        turnSequence: 3,
+        agentEventSequence: 42,
+        reasons: ['agent-usage-event'],
+      },
+    });
+    const segments = store.queryTrajectory({ source: 'provider-call' }).segments;
+    expect(segments).toHaveLength(1);
+    expect(segments[0]).toMatchObject({
+      sessionId: 'sess-1',
+      providerObservationId: 'obs-usage',
+      kind: 'usage',
+      sequence: 7,
+      confidence: 'medium',
+      redactionState: 'metadata-only',
+    });
+  });
+
+  it('writes redacted managed provider payload files within configured size limits', () => {
+    const store = new InMemoryTrajectoryStore();
+    const contentRoot = tempDir();
+    const service = new ProviderCaptureService({
+      config: providerConfig({
+        enabled: true,
+        mode: 'transcript-only',
+        maxRequestBytes: 200,
+        maxResponseBytes: 200,
+        storeRawStreams: false,
+      }),
+      store,
+      contentStorageRoot: contentRoot,
+      now: fixedNow,
+      idFactory: fixedIdFactory('obs-payload'),
+    });
+
+    const result = service.recordProviderCall({
+      backend: 'codex',
+      captureMode: 'transcript-only',
+      sessionId: 'sess-1',
+      traceId: 'trace-1',
+      requestStartedAt: new Date('2026-06-23T11:00:00.000Z'),
+      responseFinishedAt: new Date('2026-06-23T11:00:01.000Z'),
+      providerHost: 'api.openai.com',
+      model: 'gpt-5',
+      requestBody: 'Authorization: sk-ant-secret /home/node/private',
+      responseBody: 'answer for /home/node/private',
+      streamFrames: 'raw stream frame should not be written',
+      alignment: {
+        confidence: 'medium',
+        turnSequence: 3,
+        agentEventSequence: 42,
+        reasons: ['test'],
+      },
+      trajectorySequence: 8,
+    });
+
+    expect(result).toMatchObject({
+      status: 'recorded',
+      observationId: 'obs-payload',
+    });
+    const observation = store.getProviderCallObservation('obs-payload');
+    expect(observation).toMatchObject({
+      redactionState: 'redacted',
+      requestBodyRef: 'trajectory/provider-calls/obs-payload/request.txt',
+      responseBodyRef: 'trajectory/provider-calls/obs-payload/response.txt',
+    });
+    expect(observation).not.toHaveProperty('streamFramesRef');
+    const request = readFileSync(
+      join(contentRoot, observation!.requestBodyRef!),
+      'utf8',
+    );
+    expect(request).toContain('<redacted:secret>');
+    expect(request).toContain('~/private');
+    expect(request).not.toContain('sk-ant-secret');
+    expect(request).not.toContain('/home/node/private');
+  });
+
+  it('drops payload refs when redaction throws', () => {
+    const store = new InMemoryTrajectoryStore();
+    const contentRoot = tempDir();
+    const service = new ProviderCaptureService({
+      config: providerConfig({ enabled: true, mode: 'transcript-only' }),
+      store,
+      contentStorageRoot: contentRoot,
+      redactor: {
+        redact: vi.fn(() => {
+          throw new Error('redaction failed');
+        }),
+      },
+      now: fixedNow,
+      idFactory: fixedIdFactory('obs-redaction-failed'),
+    });
+
+    const result = service.recordProviderCall({
+      backend: 'codex',
+      captureMode: 'transcript-only',
+      sessionId: 'sess-1',
+      traceId: 'trace-1',
+      requestStartedAt: new Date('2026-06-23T11:00:00.000Z'),
+      requestBody: 'sk-ant-secret',
+      alignment: {
+        confidence: 'low',
+        reasons: ['test'],
+      },
+      trajectorySequence: 9,
+    });
+
+    expect(result).toMatchObject({
+      status: 'dropped',
+      code: 'provider-capture-redaction-failed',
+      observationId: 'obs-redaction-failed',
+    });
+    const observation = store.getProviderCallObservation('obs-redaction-failed');
+    expect(observation).toMatchObject({
+      redactionState: 'dropped',
+      errorCode: 'provider-capture-redaction-failed',
+    });
+    expect(observation).not.toHaveProperty('requestBodyRef');
+    expect(existsSync(join(contentRoot, 'trajectory/provider-calls/obs-redaction-failed/request.txt')))
+      .toBe(false);
+  });
+
+  it('applies provider observation retention to observations and provider-call segments', () => {
+    const store = new InMemoryTrajectoryStore();
+    const service = new ProviderCaptureService({
+      config: providerConfig({ enabled: true, mode: 'transcript-only', retentionDays: 30 }),
+      store,
+      now: () => new Date('2026-06-23T11:00:00.000Z'),
+      idFactory: fixedIdFactory('obs-old', 'obs-new'),
+    });
+
+    service.recordProviderCall({
+      backend: 'codex',
+      captureMode: 'transcript-only',
+      sessionId: 'sess-1',
+      traceId: 'trace-old',
+      requestStartedAt: new Date('2026-05-01T00:00:00.000Z'),
+      alignment: { confidence: 'low', reasons: ['old'] },
+      trajectorySequence: 1,
+    });
+    service.recordProviderCall({
+      backend: 'codex',
+      captureMode: 'transcript-only',
+      sessionId: 'sess-1',
+      traceId: 'trace-new',
+      requestStartedAt: new Date('2026-06-20T00:00:00.000Z'),
+      alignment: { confidence: 'low', reasons: ['new'] },
+      trajectorySequence: 2,
+    });
+
+    expect(service.applyRetention()).toEqual({ deletedObservations: 1 });
+    expect(store.getProviderCallObservation('obs-old')).toBeUndefined();
+    expect(store.getProviderCallObservation('obs-new')).toBeDefined();
+    expect(store.queryTrajectory({ source: 'provider-call' }).segments.map((s) => s.providerObservationId))
+      .toEqual(['obs-new']);
+  });
+});
+
+function providerConfig(
+  overrides: Partial<ProviderCaptureConfig> = {},
+): ProviderCaptureConfig {
+  return {
+    ...DEFAULT_DAEMON_RUNTIME_CONFIG.trajectory.providerCapture,
+    ...overrides,
+  };
+}
+
+function usageInput(
+  overrides: Partial<Parameters<ProviderCaptureService['recordUsageObservation']>[0]> = {},
+): Parameters<ProviderCaptureService['recordUsageObservation']>[0] {
+  return {
+    backend: 'codex',
+    sessionId: 'sess-1',
+    traceId: 'trace-1',
+    observedAt: new Date('2026-06-23T11:00:00.000Z'),
+    agentEventSequence: 42,
+    trajectorySequence: 1,
+    usage: {
+      model: 'gpt-5',
+      inputTokens: 100,
+      outputTokens: 20,
+      cacheReadTokens: 4,
+      cacheWriteTokens: 2,
+      costUsd: null,
+      turnSequence: 3,
+      toolCallsThisTurn: 1,
+      wallClockMs: 1234,
+      completeness: 'partial',
+    },
+    ...overrides,
+  };
+}
+
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'agent-nexus-provider-capture-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function fixedNow(): Date {
+  return new Date('2026-06-23T11:00:00.000Z');
+}
+
+function fixedIdFactory(...ids: string[]): () => string {
+  let index = 0;
+  return () => ids[Math.min(index++, ids.length - 1)] ?? 'obs-fallback';
+}

--- a/packages/daemon/src/provider-capture.ts
+++ b/packages/daemon/src/provider-capture.ts
@@ -1,0 +1,469 @@
+import { randomUUID } from 'node:crypto';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { UsageRecord } from '@agent-nexus/protocol';
+import type { ProviderCaptureConfig } from './config.js';
+import { BasicRedactor, type Redactor } from './redaction.js';
+import type {
+  ProviderCallObservation,
+  ProviderTurnAlignment,
+  TrajectoryRedactionState,
+  TrajectoryStore,
+} from './trajectory-store.js';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+type PreparedPayload = {
+  status: 'absent' | 'too-large' | 'no-storage-root' | 'ready';
+  text?: string;
+};
+
+export type ProviderCaptureErrorCode =
+  | 'provider-capture-disabled'
+  | 'provider-capture-unsupported'
+  | 'provider-capture-redaction-failed';
+
+export type ProviderCaptureSupport =
+  | { supported: true }
+  | {
+      supported: false;
+      code: 'provider-capture-unsupported';
+      reason: string;
+    };
+
+export type ProviderCaptureRecordResult =
+  | {
+      status: 'disabled';
+      code: 'provider-capture-disabled';
+    }
+  | {
+      status: 'unsupported';
+      code: 'provider-capture-unsupported';
+      reason: string;
+    }
+  | {
+      status: 'recorded';
+      observationId: string;
+    }
+  | {
+      status: 'dropped';
+      code: 'provider-capture-redaction-failed';
+      observationId: string;
+    };
+
+export interface ProviderUsageObservationInput {
+  backend: string;
+  sessionId?: string;
+  traceId?: string;
+  observedAt: Date;
+  agentEventSequence: number;
+  trajectorySequence: number;
+  usage: UsageRecord;
+}
+
+export interface ProviderCallCaptureInput {
+  backend: string;
+  captureMode: ProviderCaptureConfig['mode'];
+  sessionId?: string;
+  traceId?: string;
+  requestStartedAt: Date;
+  responseFinishedAt?: Date;
+  providerHost?: string;
+  model?: string;
+  requestBody?: string;
+  responseBody?: string;
+  streamFrames?: string;
+  alignment: ProviderTurnAlignment;
+  trajectorySequence?: number;
+}
+
+export interface ProviderCaptureRecorder {
+  recordUsageObservation(
+    input: ProviderUsageObservationInput,
+  ): ProviderCaptureRecordResult;
+}
+
+export interface ProviderCaptureServiceInput {
+  config: ProviderCaptureConfig;
+  store: TrajectoryStore;
+  contentStorageRoot?: string;
+  redactor?: Redactor;
+  now?: () => Date;
+  idFactory?: () => string;
+}
+
+export class ProviderCaptureService implements ProviderCaptureRecorder {
+  private readonly config: ProviderCaptureConfig;
+  private readonly store: TrajectoryStore;
+  private readonly contentStorageRoot?: string;
+  private readonly redactor: Redactor;
+  private readonly now: () => Date;
+  private readonly idFactory: () => string;
+
+  constructor(input: ProviderCaptureServiceInput) {
+    this.config = input.config;
+    this.store = input.store;
+    this.contentStorageRoot = input.contentStorageRoot;
+    this.redactor = input.redactor ?? new BasicRedactor();
+    this.now = input.now ?? (() => new Date());
+    this.idFactory = input.idFactory ?? randomUUID;
+  }
+
+  recordUsageObservation(
+    input: ProviderUsageObservationInput,
+  ): ProviderCaptureRecordResult {
+    const guard = this.guardCapture(input.backend, 'transcript-only');
+    if (guard) return guard;
+
+    const observationId = this.idFactory();
+    const summary = summarizeUsageRecord(input.usage);
+    const observedAt = input.observedAt.toISOString();
+    const alignment: ProviderTurnAlignment = {
+      confidence: 'medium',
+      turnSequence: input.usage.turnSequence,
+      agentEventSequence: input.agentEventSequence,
+      reasons: ['agent-usage-event'],
+    };
+    const observation: ProviderCallObservation = {
+      observationId,
+      backend: input.backend,
+      captureMode: 'transcript-only',
+      requestStartedAt: observedAt,
+      responseFinishedAt: observedAt,
+      model: input.usage.model,
+      requestSummary: summary,
+      responseSummary: summary,
+      requestBytes: 0,
+      responseBytes: 0,
+      redactionState: 'metadata-only',
+      alignment,
+      metadataJson: safeJson({
+        source: 'agent-usage-event',
+        usage: input.usage,
+      }),
+    };
+    if (input.sessionId) observation.sessionId = input.sessionId;
+    if (input.traceId) observation.traceId = input.traceId;
+
+    this.store.recordProviderCallObservation(observation);
+    this.appendProviderTrajectorySegment({
+      observationId,
+      sessionId: input.sessionId,
+      traceId: input.traceId,
+      kind: 'usage',
+      sequence: input.trajectorySequence,
+      ts: observedAt,
+      summary,
+      redactionState: 'metadata-only',
+      alignment,
+      metadata: {
+        source: 'agent-usage-event',
+        backend: input.backend,
+        captureMode: 'transcript-only',
+        model: input.usage.model,
+        agentEventSequence: input.agentEventSequence,
+      },
+    });
+
+    return { status: 'recorded', observationId };
+  }
+
+  // Future proxy runners should enter here after collecting request/response payloads.
+  // The current Engine runtime only calls recordUsageObservation for transcript-only usage.
+  recordProviderCall(input: ProviderCallCaptureInput): ProviderCaptureRecordResult {
+    const guard = this.guardCapture(input.backend, input.captureMode);
+    if (guard) return guard;
+
+    const observationId = this.idFactory();
+    const requestBytes = byteLength(input.requestBody);
+    const responseBytes =
+      input.responseBody === undefined ? undefined : byteLength(input.responseBody);
+    let requestBodyRef: string | undefined;
+    let responseBodyRef: string | undefined;
+    let streamFramesRef: string | undefined;
+    let redactionState: TrajectoryRedactionState = 'metadata-only';
+    let redactionFailed = false;
+    const payloadMetadata: Record<string, unknown> = {
+      requestBytes,
+      responseBytes,
+      storeRawStreams: this.config.storeRawStreams,
+    };
+
+    let request: PreparedPayload = { status: 'absent' };
+    let response: PreparedPayload = { status: 'absent' };
+    let stream: PreparedPayload | undefined;
+
+    try {
+      request = this.preparePayload(input.requestBody, this.config.maxRequestBytes);
+      response = this.preparePayload(
+        input.responseBody,
+        this.config.maxResponseBytes,
+      );
+      stream = this.config.storeRawStreams
+        ? this.preparePayload(input.streamFrames, this.config.maxResponseBytes)
+        : undefined;
+    } catch {
+      redactionFailed = true;
+      redactionState = 'dropped';
+      payloadMetadata['redaction'] = 'failed';
+    }
+
+    if (!redactionFailed) {
+      try {
+        payloadMetadata['requestPayload'] = request.status;
+        payloadMetadata['responsePayload'] = response.status;
+        if (stream) payloadMetadata['streamPayload'] = stream.status;
+        if (request.status === 'ready') {
+          requestBodyRef = this.writePayload(observationId, 'request.txt', request.text);
+          redactionState = 'redacted';
+        }
+        if (response.status === 'ready') {
+          responseBodyRef = this.writePayload(observationId, 'response.txt', response.text);
+          redactionState = 'redacted';
+        }
+        if (stream?.status === 'ready') {
+          streamFramesRef = this.writePayload(
+            observationId,
+            'stream-frames.txt',
+            stream.text,
+          );
+          redactionState = 'redacted';
+        }
+      } catch (err) {
+        this.removePayloadDir(observationId);
+        throw err;
+      }
+    }
+
+    const requestStartedAt = input.requestStartedAt.toISOString();
+    const responseFinishedAt = input.responseFinishedAt?.toISOString();
+    const requestSummary = summarizeProviderPayload('request', requestBytes);
+    const responseSummary =
+      responseBytes === undefined
+        ? undefined
+        : summarizeProviderPayload('response', responseBytes);
+    const observation: ProviderCallObservation = {
+      observationId,
+      backend: input.backend,
+      captureMode: input.captureMode,
+      requestStartedAt,
+      requestSummary,
+      requestBytes,
+      redactionState,
+      alignment: input.alignment,
+      metadataJson: safeJson({
+        source: 'provider-capture',
+        payload: payloadMetadata,
+      }),
+    };
+    if (input.sessionId) observation.sessionId = input.sessionId;
+    if (input.traceId) observation.traceId = input.traceId;
+    if (responseFinishedAt) observation.responseFinishedAt = responseFinishedAt;
+    if (input.providerHost) observation.providerHost = input.providerHost;
+    if (input.model) observation.model = input.model;
+    if (responseSummary) observation.responseSummary = responseSummary;
+    if (requestBodyRef) observation.requestBodyRef = requestBodyRef;
+    if (responseBodyRef) observation.responseBodyRef = responseBodyRef;
+    if (streamFramesRef) observation.streamFramesRef = streamFramesRef;
+    if (responseBytes !== undefined) observation.responseBytes = responseBytes;
+    if (redactionFailed) {
+      observation.errorCode = 'provider-capture-redaction-failed';
+    }
+
+    this.store.recordProviderCallObservation(observation);
+    if (input.trajectorySequence !== undefined) {
+      this.appendProviderTrajectorySegment({
+        observationId,
+        sessionId: input.sessionId,
+        traceId: input.traceId,
+        kind: responseSummary ? 'provider-response' : 'provider-request',
+        sequence: input.trajectorySequence,
+        ts: responseFinishedAt ?? requestStartedAt,
+        summary: responseSummary ?? requestSummary,
+        redactionState,
+        alignment: input.alignment,
+        metadata: {
+          source: 'provider-capture',
+          backend: input.backend,
+          captureMode: input.captureMode,
+          providerHost: input.providerHost,
+          model: input.model,
+        },
+      });
+    }
+
+    if (redactionFailed) {
+      return {
+        status: 'dropped',
+        code: 'provider-capture-redaction-failed',
+        observationId,
+      };
+    }
+    return { status: 'recorded', observationId };
+  }
+
+  applyRetention(): { deletedObservations: number } {
+    const cutoff = new Date(
+      this.now().getTime() - this.config.retentionDays * DAY_MS,
+    ).toISOString();
+    return {
+      deletedObservations: this.store.pruneProviderCallObservations({
+        before: cutoff,
+      }),
+    };
+  }
+
+  private guardCapture(
+    backend: string,
+    captureMode: ProviderCaptureConfig['mode'],
+  ): Extract<ProviderCaptureRecordResult, { status: 'disabled' | 'unsupported' }> | undefined {
+    if (!this.config.enabled) {
+      return {
+        status: 'disabled',
+        code: 'provider-capture-disabled',
+      };
+    }
+    const configuredSupport = isProviderCaptureSupported(
+      backend,
+      this.config.mode,
+    );
+    if (!configuredSupport.supported) {
+      return {
+        status: 'unsupported',
+        code: configuredSupport.code,
+        reason: configuredSupport.reason,
+      };
+    }
+    const inputSupport = isProviderCaptureSupported(backend, captureMode);
+    if (!inputSupport.supported) {
+      return {
+        status: 'unsupported',
+        code: inputSupport.code,
+        reason: inputSupport.reason,
+      };
+    }
+    return undefined;
+  }
+
+  private preparePayload(
+    raw: string | undefined,
+    maxBytes: number,
+  ): PreparedPayload {
+    if (raw === undefined) return { status: 'absent' };
+    const redacted = this.redactor.redact(raw);
+    if (byteLength(redacted) > maxBytes) return { status: 'too-large' };
+    if (!this.contentStorageRoot) return { status: 'no-storage-root' };
+    return { status: 'ready', text: redacted };
+  }
+
+  private writePayload(
+    observationId: string,
+    fileName: 'request.txt' | 'response.txt' | 'stream-frames.txt',
+    text: string | undefined,
+  ): string {
+    const pathSegment = encodeURIComponent(observationId);
+    const dir = join(
+      this.contentStorageRoot ?? '.',
+      'trajectory',
+      'provider-calls',
+      pathSegment,
+    );
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+    writeFileSync(join(dir, fileName), text ?? '', {
+      encoding: 'utf8',
+      mode: 0o600,
+    });
+    return `trajectory/provider-calls/${pathSegment}/${fileName}`;
+  }
+
+  private removePayloadDir(observationId: string): void {
+    if (!this.contentStorageRoot) return;
+    rmSync(
+      join(
+        this.contentStorageRoot,
+        'trajectory',
+        'provider-calls',
+        encodeURIComponent(observationId),
+      ),
+      { recursive: true, force: true },
+    );
+  }
+
+  private appendProviderTrajectorySegment(input: {
+    observationId: string;
+    sessionId?: string;
+    traceId?: string;
+    kind: 'usage' | 'provider-request' | 'provider-response';
+    sequence: number;
+    ts: string;
+    summary: string;
+    redactionState: TrajectoryRedactionState;
+    alignment: ProviderTurnAlignment;
+    metadata: Record<string, unknown>;
+  }): void {
+    this.store.appendTrajectorySegment({
+      segmentId: `provider:${input.observationId}`,
+      sessionId: input.sessionId,
+      providerObservationId: input.observationId,
+      source: 'provider-call',
+      kind: input.kind,
+      traceId: input.traceId,
+      turnSequence: input.alignment.turnSequence,
+      sequence: input.sequence,
+      ts: input.ts,
+      summary: input.summary,
+      confidence: input.alignment.confidence,
+      redactionState: input.redactionState,
+      metadataJson: safeJson(input.metadata),
+    });
+  }
+}
+
+export function isProviderCaptureSupported(
+  backend: string,
+  mode: ProviderCaptureConfig['mode'],
+): ProviderCaptureSupport {
+  const normalizedBackend = backend.toLowerCase();
+  if (mode !== 'transcript-only') {
+    return {
+      supported: false,
+      code: 'provider-capture-unsupported',
+      reason: `Provider capture mode ${mode} is not implemented by this daemon runtime`,
+    };
+  }
+  if (normalizedBackend === 'codex' || normalizedBackend === 'claudecode') {
+    return { supported: true };
+  }
+  return {
+    supported: false,
+    code: 'provider-capture-unsupported',
+    reason: `Provider capture backend ${backend} is not supported`,
+  };
+}
+
+function summarizeUsageRecord(usage: UsageRecord): string {
+  const cost =
+    usage.costUsd === null ? 'cost unknown' : `cost $${usage.costUsd.toFixed(6)}`;
+  return [
+    usage.model,
+    `input ${usage.inputTokens}`,
+    `output ${usage.outputTokens}`,
+    cost,
+  ].join(', ');
+}
+
+function summarizeProviderPayload(kind: 'request' | 'response', bytes: number): string {
+  return `${kind} metadata, ${bytes} bytes captured`;
+}
+
+function byteLength(value: string | undefined): number {
+  return Buffer.byteLength(value ?? '', 'utf8');
+}
+
+function safeJson(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return '{"serialization":"failed"}';
+  }
+}

--- a/packages/daemon/src/trajectory-sqlite-store.test.ts
+++ b/packages/daemon/src/trajectory-sqlite-store.test.ts
@@ -182,6 +182,55 @@ describe('SqliteTrajectoryStore', () => {
     store.close();
   });
 
+  it('prunes old provider observations and their provider-call segments', () => {
+    const store = new SqliteTrajectoryStore({ path: tempDbPath() });
+    store.recordProviderCallObservation(
+      observation({
+        observationId: 'obs-old',
+        requestStartedAt: '2026-05-01T00:00:00.000Z',
+      }),
+    );
+    store.recordProviderCallObservation(
+      observation({
+        observationId: 'obs-new',
+        requestStartedAt: '2026-06-20T00:00:00.000Z',
+      }),
+    );
+    store.appendTrajectorySegment(
+      segment({
+        segmentId: 'seg-old-provider',
+        importId: undefined,
+        providerObservationId: 'obs-old',
+        source: 'provider-call',
+        kind: 'provider-request',
+        sequence: 1,
+      }),
+    );
+    store.appendTrajectorySegment(
+      segment({
+        segmentId: 'seg-new-provider',
+        importId: undefined,
+        providerObservationId: 'obs-new',
+        source: 'provider-call',
+        kind: 'provider-request',
+        sequence: 2,
+      }),
+    );
+
+    expect(
+      store.pruneProviderCallObservations({
+        before: '2026-06-01T00:00:00.000Z',
+      }),
+    ).toBe(1);
+
+    expect(store.getProviderCallObservation('obs-old')).toBeUndefined();
+    expect(store.getProviderCallObservation('obs-new')).toBeDefined();
+    expect(
+      store.queryTrajectory({ source: 'provider-call' }).segments.map((s) => s.segmentId),
+    ).toEqual(['seg-new-provider']);
+    store.close();
+  });
+
   it('queries with stable keyset pagination and confidence filtering', () => {
     const store = new SqliteTrajectoryStore({ path: tempDbPath() });
 

--- a/packages/daemon/src/trajectory-store.ts
+++ b/packages/daemon/src/trajectory-store.ts
@@ -4,6 +4,7 @@ import { type Database as BetterSqliteDatabase } from 'better-sqlite3';
 import { BasicRedactor, type Redactor } from './redaction.js';
 
 const require = createRequire(import.meta.url);
+const SQLITE_DELETE_BATCH_SIZE = 900;
 
 export type TrajectoryConfidence = 'high' | 'medium' | 'low' | 'unknown';
 
@@ -171,6 +172,7 @@ export interface TrajectoryStore {
   getProviderCallObservation(
     observationId: string,
   ): ProviderCallObservation | undefined;
+  pruneProviderCallObservations(input: { before: string }): number;
   queryTrajectory(query: TrajectoryQuery): TrajectoryPage;
 }
 
@@ -299,6 +301,27 @@ export class InMemoryTrajectoryStore implements TrajectoryStore {
   ): ProviderCallObservation | undefined {
     const observation = this.observations.get(observationId);
     return observation ? this.cloneObservation(observation) : undefined;
+  }
+
+  pruneProviderCallObservations(input: { before: string }): number {
+    const deleted = new Set<string>();
+    for (const observation of this.observations.values()) {
+      if (observation.requestStartedAt < input.before) {
+        deleted.add(observation.observationId);
+      }
+    }
+    for (const observationId of deleted) {
+      this.observations.delete(observationId);
+    }
+    for (const [segmentId, segment] of this.segments) {
+      if (
+        segment.providerObservationId &&
+        deleted.has(segment.providerObservationId)
+      ) {
+        this.segments.delete(segmentId);
+      }
+    }
+    return deleted.size;
   }
 
   queryTrajectory(query: TrajectoryQuery): TrajectoryPage {
@@ -650,6 +673,42 @@ export class SqliteTrajectoryStore implements TrajectoryStore {
       .prepare('SELECT * FROM provider_call_observations WHERE observation_id = ?')
       .get(observationId) as ProviderCallObservationRow | undefined;
     return row ? this.cloneObservation(observationFromRow(row)) : undefined;
+  }
+
+  pruneProviderCallObservations(input: { before: string }): number {
+    return this.db.transaction((before: string) => {
+      const rows = this.db
+        .prepare(
+          'SELECT observation_id FROM provider_call_observations WHERE request_started_at < ?',
+        )
+        .all(before) as Array<{ observation_id: string }>;
+      const observationIds = rows.map((row) => row.observation_id);
+      if (observationIds.length === 0) return 0;
+      for (
+        let start = 0;
+        start < observationIds.length;
+        start += SQLITE_DELETE_BATCH_SIZE
+      ) {
+        const batch = observationIds.slice(
+          start,
+          start + SQLITE_DELETE_BATCH_SIZE,
+        );
+        const placeholders = batch.map(() => '?').join(', ');
+        this.db
+          .prepare(
+            `DELETE FROM trajectory_segments
+             WHERE provider_observation_id IN (${placeholders})`,
+          )
+          .run(...batch);
+        this.db
+          .prepare(
+            `DELETE FROM provider_call_observations
+             WHERE observation_id IN (${placeholders})`,
+          )
+          .run(...batch);
+      }
+      return observationIds.length;
+    })(input.before);
   }
 
   queryTrajectory(query: TrajectoryQuery): TrajectoryPage {


### PR DESCRIPTION
## Summary

Adds the P7 provider-capture runtime path for trajectory observability without claiming proxy capture support.

本 PR：
- Adds `ProviderCaptureService` for opt-in transcript-only `usage` AgentEvent observations on `codex` / `claudecode` backends.
- Wires enabled provider capture into Engine and CLI while keeping default provider capture disabled.
- Adds redacted provider payload helper coverage for future proxy runners and documents that it has no current runtime caller.
- Adds retention cleanup for provider observations and provider-call trajectory segments.
- Updates trajectory and persistence specs with current implementation limits.

## Why

P7 acceptance still required optional provider-call observability after external session import/resume landed in PR #164. This PR closes the currently feasible runtime path: metadata-only transcript-derived provider observations, fail-closed unsupported proxy modes, redaction/size-limit helper coverage, retention, and confidence-based turn alignment.

ADR: N/A - implements the existing trajectory observability spec without a new design decision.
Spec: `docs/dev/spec/infra/trajectory-observability.md`, `docs/dev/spec/infra/persistence.md`.

## Test plan

- [x] Tests: `packages/daemon/src/provider-capture.test.ts`, `packages/daemon/src/engine.test.ts`, `packages/daemon/src/trajectory-sqlite-store.test.ts`.
- [x] `corepack pnpm exec vitest run packages/daemon/src/provider-capture.test.ts packages/daemon/src/engine.test.ts packages/daemon/src/trajectory-sqlite-store.test.ts --testNamePattern "ProviderCapture|provider capture|isProviderCaptureSupported|SqliteTrajectoryStore"` - passed.
- [x] `corepack pnpm typecheck` - passed.
- [x] `corepack pnpm test` - passed.
- [x] `corepack pnpm build` - passed.
- [x] `git diff --check` - passed.
- [x] `git diff --cached --check` - passed before commit.
- [x] Manual: not run against real provider proxy traffic; current runtime intentionally has no proxy runner and only records transcript-only usage observations.

## Review notes

- Independent agent review: `/home/node/.goal/agent-nexus-trajectory-observability/reviews/p7-provider-capture-claude-review-20260623.md` and focused re-review `/home/node/.goal/agent-nexus-trajectory-observability/reviews/p7-provider-capture-claude-rereview-20260623.md`; re-review approved with no blocker/important findings.
- Deep review: N/A - this is a scoped P7 runtime completion PR, not a new architecture/spec decision; independent review was run and important findings were fixed.

## Out of scope

- Implementing a provider reverse/forward proxy runner.
- Replaying imported transcript content into model context.
- Adding UI for trajectory/provider observation browsing.