### PR TITLE
docs(readme): focus root readme on onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,78 +2,85 @@
 title: agent-nexus
 type: root
 status: active
-summary: 把本机 Claude Code CLI 接入 Discord 的本机桥；MVP 已支持长驻 stream-json、工具可见性与流式 edit
-tags: [project, discord, cc-cli]
+summary: 把本机编码 agent 接入 Discord 的本机桥，支持 Claude Code CLI 和 Codex CLI 后端
+tags: [project, discord, cc-cli, codex]
 related:
   - root/AGENTS
-  - dev/adr/0001-im-platform-discord
-  - dev/adr/0002-agent-backend-claude-code-cli
-  - dev/adr/0003-deployment-local-desktop
-  - dev/adr/0004-language-runtime
+  - product/README
+  - product/user-guide
+  - ops/runbook
+  - dev/README
 ---
 
 # agent-nexus
 
-把本机 Claude Code CLI 接入 IM 平台的桥。首个目标平台：Discord。
+agent-nexus 是一个本机运行的 IM 桥接服务。它把 Discord 消息路由到你本机的编码 agent，让你可以在 Discord 里驱动 Claude Code CLI 或 Codex CLI 处理本机项目。
 
-## 定位
+当前状态：可用于本机 Discord MVP。Discord 是当前唯一平台，部署、密钥和 agent CLI 登录状态由本机用户维护。
 
-agent-nexus 让你在 IM（当前：Discord）里直接和本机 Claude Code 对话，用 IM 作为"远程遥控器"驱动本机的编码 agent；同时把观测、权限、成本控制做成一等公民。
+## 特性
 
-这是一个参考 [cc-connect](https://github.com/chenhg5/cc-connect) 但刻意规避其已知教训的重新实现：**文档先行、契约先行、测试先行**。
-
-## 当前能力
-
-**Discord + 本机 Claude Code CLI MVP** 已可端到端运行：
-
-- Discord `@mention` → daemon `Engine` → 长驻 Claude Code `stream-json` 子进程 → Discord 回复。
-- 同一 `(platformName, platform, channelId, userId)` 复用 daemon RoutingSession；`/new`、`/stop` 等 agent slash command 会路由给对应 agent package 处理，`/nexus-kill` 终止当前 Nexus route 并清除 resume 记录。
-- IM 侧可看到工具调用状态、流式文本、typing 指示与原地 edit。
-- 白名单外工具会在执行前被拒绝；机制见 [`docs/dev/spec/security/tool-boundary.md`](docs/dev/spec/security/tool-boundary.md)。`Bash` 不在默认允许集。
-
-仍处在本机桌面形态：Discord 是当前唯一平台，部署与密钥由本机用户维护。
-
-## 已锁定的前置决策
-
-| 维度 | 决策 | ADR |
-|---|---|---|
-| IM 平台（MVP） | Discord | [0001](docs/dev/adr/0001-im-platform-discord.md) |
-| Agent 后端 | Claude Code CLI（默认）/ Codex CLI（显式配置） | [0002](docs/dev/adr/0002-agent-backend-claude-code-cli.md), [0014](docs/dev/adr/0014-agent-backend-codex-cli.md) |
-| 部署形态 | 本机桌面 | [0003](docs/dev/adr/0003-deployment-local-desktop.md) |
-| 实现语言 | TypeScript / Node + pnpm monorepo | [0004](docs/dev/adr/0004-language-runtime.md) |
+- Discord `@mention` 与 slash command 路由到本机 agent。
+- 支持 Claude Code CLI 和 Codex CLI 后端。
+- 按 `(platformName, platform, channelId, userId)` 复用会话，并支持新建、停止、resume 与 route kill。
+- 支持 Discord thread 会话、session 列表、working directory override、settings 面板与 queue 操作。
+- 流式回复、typing 指示、工具调用状态与原地 edit。
+- 基于 allowlist 的访问控制；Claude Code 后端默认不启用 `Bash`。
+- 配置、密钥和运行状态默认放在 `~/.agent-nexus/`，也可用 `--home` 或 `AGENT_NEXUS_HOME` 跑多实例。
 
 ## 快速开始
 
-### 1. 前置依赖
+### 前置条件
 
-- Node ≥ 20、pnpm ≥ 10（`packageManager` 已锁 `pnpm@10.33.2`）
-- 本机已装 Claude Code CLI（`claude --version` 能跑）；如不在 `PATH` 里，配置项 `agents[].claudeCode.bin` 给绝对路径
-- 如要启用 Codex backend，本机还需安装并登录 Codex CLI（`codex --version` 能跑）；如不在 `PATH` 里，配置项 `agents[].codex.bin` 给绝对路径
-- Discord bot：在 [Discord Developer Portal](https://discord.com/developers/applications) 建 application + bot，记下 bot user ID 和 token；intents 至少打开 `MESSAGE CONTENT INTENT`
+- Node >= 20
+- pnpm >= 10（仓库锁定 `pnpm@10.33.2`）
+- 已安装并登录 Claude Code CLI 或 Codex CLI
+- 一个 Discord bot token、bot user id、你的 Discord user id
+- Discord bot 已加入目标 server，并开启 `MESSAGE CONTENT INTENT`
 
-### 2. 安装与构建
+Discord bot 创建、邀请和权限配置见 [`docs/product/platforms/discord.md`](docs/product/platforms/discord.md)。
+
+### 安装
 
 ```bash
 pnpm install
-pnpm build         # tsc --build；CLI 入口会额外 bundle 成 npm bin
-pnpm pack:cli      # 产物 packages/cli/agent-nexus-cli-*.tgz
-pnpm test          # vitest 全量
-pnpm typecheck     # 仅 tsc --build；不生成 npm bin bundle
+pnpm build
+pnpm test
 ```
 
-### 3. 配置
+开发模式直接运行源码：
 
-首次运行会自动创建配置脚手架：
+```bash
+pnpm dev
+```
 
-- `~/.agent-nexus/` 和 `~/.agent-nexus/secrets/`，权限为 0700
-- `~/.agent-nexus/config.json` 模板，权限为 0600
-- `~/.agent-nexus/secrets/DISCORD_BOT_TOKEN` 空文件，权限为 0600
+构建并安装本地 CLI：
+
+```bash
+pnpm pack:cli
+npm install -g packages/cli/agent-nexus-cli-*.tgz
+agent-nexus
+```
+
+首次运行会创建：
+
+- `~/.agent-nexus/config.json`
+- `~/.agent-nexus/secrets/DISCORD_BOT_TOKEN`
 
 需要跑 stable / dev 等多个实例时，用 `--home <dir>` 或 `AGENT_NEXUS_HOME=<dir>` 指定实例根目录；`config.json`、`secrets/`、`state/` 都会从这个根目录派生。
 
-之后每次启动都会检查 `config.json`，把模板中新增但本地缺失的字段自动补齐到文件中；已有字段不会被覆盖。没有安全默认值的必填字段只会补占位值，仍需手动填写。
+填入 Discord token：
 
-编辑 `~/.agent-nexus/config.json`（至少填 `platforms[].botUserId`、`platforms[].auth.allowlist.userIds` 或 `roleIds`、`agents[].claudeCode.workingDir`，并给 binding 填 channel id）：
+```bash
+echo -n '<your-discord-bot-token>' > ~/.agent-nexus/secrets/DISCORD_BOT_TOKEN
+chmod 600 ~/.agent-nexus/secrets/DISCORD_BOT_TOKEN
+```
+
+token 文件权限不是 `0600` 时，agent-nexus 会拒绝启动。
+
+### 最小配置
+
+编辑 `~/.agent-nexus/config.json`。下面示例使用 Claude Code CLI：
 
 ```json
 {
@@ -83,15 +90,9 @@ pnpm typecheck     # 仅 tsc --build；不生成 npm bin bundle
       "type": "discord",
       "botUserId": "1234567890123456789",
       "tokenRef": "DISCORD_BOT_TOKEN",
-      "publicChannelMode": "thread",
       "auth": {
         "allowlist": {
-          "userIds": ["2345678901234567890"],
-          "roleIds": [],
-          "allowedGuildIds": [],
-          "allowedChannelIds": [],
-          "allowDM": true,
-          "requireMentionOrSlash": true
+          "userIds": ["2345678901234567890"]
         }
       }
     }
@@ -101,10 +102,7 @@ pnpm typecheck     # 仅 tsc --build；不生成 npm bin bundle
       "name": "claude-prod",
       "backend": "claudecode",
       "claudeCode": {
-        "workingDir": "/path/to/your/repo",
-        "bin": "claude",
-        "permissionLevel": "default",
-        "allowedTools": ["Read", "Grep", "Glob", "Edit", "Write"]
+        "workingDir": "/path/to/your/repo"
       }
     }
   ],
@@ -119,132 +117,87 @@ pnpm typecheck     # 仅 tsc --build；不生成 npm bin bundle
         }
       }
     }
-  ],
-  "daemon": {
-    "commandRegistry": {
-      "registration": {
-        "enabled": true,
-        "applyTimeoutMs": 30000,
-        "retry": {
-          "maxAttempts": 3,
-          "backoffMs": 1000
-        }
-      },
-      "aliases": {
-        "singleAgent": {
-          "enabled": true
-        },
-        "legacy": {
-          "replyMode": true
-        }
-      },
-      "textPrefixes": {
-        "newSession": true
-      }
-    }
-  },
-  "ui": {
-    "toolMessages": "append"
-  },
-  "log": {
-    "level": "info"
-  }
+  ]
 }
 ```
 
-```bash
-chmod 600 ~/.agent-nexus/config.json
-```
+Codex backend、字段说明、多实例配置和安全边界见 [`docs/product/user-guide.md`](docs/product/user-guide.md)。
 
-字段说明：
+### 启动
 
-- `platforms[].botUserId`（必填）：bot 的 Discord user ID
-- `platforms[].auth.allowlist.userIds` / `roleIds`（必填其一）：允许使用 bot 的 Discord user 或 role ID
-- `platforms[].auth.allowlist.allowedGuildIds` / `allowedChannelIds`（可选）：进一步收窄允许的 guild / channel；空数组表示不按该维度收窄
-- `platforms[].testGuildId`（可选）：把 slash command 限定注册到某个测试 guild，开发时更快生效
-- `agents[].backend`（必填）：选择 `claudecode` 或 `codex`
-- `agents[].claudeCode.workingDir`（`backend=claudecode` 时必填）：CC 默认工作目录，per-session 可覆盖
-- `agents[].claudeCode.bin`（可选，默认 `claude`）：CC CLI 可执行路径
-- `agents[].claudeCode.permissionLevel`（可选，默认 `default`）：原样传给 Claude Code 子进程的 `--permission-mode`，允许 `default` / `acceptEdits` / `auto` / `bypassPermissions` / `dontAsk` / `plan`
-- `agents[].claudeCode.allowedTools`（可选）：默认 `Read/Grep/Glob/Edit/Write`。**`Bash` 不在默认集**——启用须显式列出，启动会打 warn（参见 [`docs/dev/spec/security/tool-boundary.md`](docs/dev/spec/security/tool-boundary.md)）
-- `agents[].codex.workingDir`（`backend=codex` 时必填）：Codex 默认工作目录，传给 `--cd`
-- `daemon.commandRegistry.registration.enabled`（可选，默认 `true`）：设为 `false` 时不向 Discord apply slash command 注册计划，本地 command dispatch 保持 fail-closed
-- `daemon.commandRegistry.registration.applyTimeoutMs`（可选，默认 `30000`）：slash command 注册 apply 超时
-- `daemon.commandRegistry.aliases.singleAgent.enabled`（可选，默认 `true`）：控制裸 `/new` / `/stop` single-agent slash alias；稳定 `/codex-new` / `/codex-stop` / `/claudecode-new` / `/claudecode-stop` 不受影响
-- `daemon.commandRegistry.aliases.legacy.replyMode`（可选，默认 `true`）：控制 legacy `/reply-mode` 是否注册；稳定 `/discord-reply-mode` 不受影响
-- `daemon.commandRegistry.textPrefixes.newSession`（可选，默认 `true`）：控制 `@bot /new` 文本前缀；不影响 slash command
-- `bindings[].platformName` / `agentName`（必填）：把命名 platform bot 绑定到命名 agent
-- `bindings[].match.discord.channelIds`（必填）：该 binding 匹配的 Discord channel/thread id 列表
-- `codex.bin`（可选，默认 `codex`）：Codex CLI 可执行路径
-- `codex.model`（可选）：传给 Codex CLI 的 `--model`
-- `codex.sandbox`（可选，默认 `read-only`）：允许 `read-only` / `workspace-write`
-- `codex.addDirs`（可选，默认 `[]`）：逐个传给 `--add-dir`
-- `codex.loadUserConfig` / `codex.loadRules`（可选，默认 `false`）：默认传 `--ignore-user-config` / `--ignore-rules`，避免继承未审计的本机 Codex 配置或 rules
-- `ui.toolMessages`（可选，默认 `append`）：`append` 会把每个工具调用作为单独消息追加，并在结果到达时编辑该工具消息补结果摘要；`compact` 回到旧式紧凑显示，只把工具状态揉进当前回复消息
-- `log.level`（可选，默认 `info`）：`trace|debug|info|warn|error|fatal`
-
-写 Discord bot token 到 `~/.agent-nexus/secrets/DISCORD_BOT_TOKEN`（**权限必须 0600**，否则启动拒绝）：
+配置完成后再次启动：
 
 ```bash
-echo -n '<your-discord-bot-token>' > ~/.agent-nexus/secrets/DISCORD_BOT_TOKEN
-chmod 600 ~/.agent-nexus/secrets/DISCORD_BOT_TOKEN
+agent-nexus
 ```
 
-### 4. 运行
-
-开发模式（`tsx` 热加载源码）：
+开发模式使用：
 
 ```bash
 pnpm dev
 corepack pnpm --filter @agent-nexus/cli dev --home ~/.agent-nexus-dev
 ```
 
-构建后跑（生产模式）：
+## 使用
 
-```bash
-pnpm build
-pnpm pack:cli
-npm install -g packages/cli/agent-nexus-cli-*.tgz
-agent-nexus
-agent-nexus --home ~/.agent-nexus-stable
+启动成功后，在绑定的 Discord channel 里发送：
+
+```text
+@bot 帮我解释这个仓库的入口
 ```
 
-启动会先跑 CC CLI 兼容性 probe（版本、`--print` JSON、长驻 `stream-json`、工具权限检查），失败直接 `exit 1`；通过后连 Discord，看到 `discord_ready` / `engine_started` 日志即可在频道里 `@bot ping`。
+常用命令：
 
-### 5. 使用
+| 命令 | 用途 |
+|---|---|
+| `@bot <prompt>` | 向当前绑定的 agent 发送一轮对话 |
+| `@bot /new` | 清空当前 route 的会话 |
+| `/claudecode-new` / `/codex-new` | 为对应后端开启新会话 |
+| `/claudecode-stop` / `/codex-stop` | 停止对应后端当前任务 |
+| `/nexus-kill` | 终止当前 Nexus route 并清除 resume 记录 |
+| `/nexus-sessions` | 查看并切换可恢复 session |
+| `/nexus-new-thread` | 创建 Discord private thread 作为新会话容器 |
+| `/nexus-working-dir` | 设置 channel 或下一次 session 的 working directory |
+| `/nexus-settings` | 打开当前 route 的 settings 面板 |
+| `/nexus-queue` | 查看、重排、编辑或取消 pending prompts |
+| `/nexus-reload-config` | 热加载 bindings、auth、UI 与文本前缀配置 |
+| `/discord-reply-mode` | 切换 Discord 消息触发模式 |
 
-- `@bot <prompt>`：发起一轮 CC 对话；同 `(platformName, platform, channelId, userId)` 后续消息复用活跃 session
-- `@bot /new`：清当前 routed SessionKey 的内存 session，回复 `[new session ready]`；可用 `daemon.commandRegistry.textPrefixes.newSession=false` 禁用
-- `@bot /new <prompt>`：清 + 立即用 `<prompt>` 起新一轮；同样受 `textPrefixes.newSession` 控制
-- `/claudecode-new` / `/codex-new`：按绑定到当前频道的 agent owner 路由给对应 agent package；只有对应 backend 已配置且在该 Discord 注册 scope 有 binding 时才会出现
-- `/claudecode-stop` / `/codex-stop`：按绑定到当前频道的 agent owner 路由给对应 agent package；具体停止语义由该 agent runtime 决定
-- `/new` / `/stop`：仅在同一个 Discord 注册 scope 里只有一种 agent owner 且 `daemon.commandRegistry.aliases.singleAgent.enabled=true` 时作为便捷 alias 出现
-- `/nexus-kill`：daemon 直接终止当前 RoutingSession，并清除 resume 记录
-- `/nexus-sessions`：daemon 以仅调用方可见的下拉菜单列出内存态可恢复 session；每项用第一条用户消息做标题，选择后当前 channel/user 切到对应 agent conversation，下一条消息 resume
-- `/nexus-new-thread`：daemon 在当前 Discord channel 下创建 private thread，默认把调用者加入；thread 内第一条用户消息启动新的 agent session。只有创建时未传标题、仍使用默认占位标题时，才会自动把 thread 名改成第一条消息生成的标题
-- `/nexus-working-dir path:<absolute-path> [scope:<channel|session>]`：默认设置当前 channel/thread 的 workingDir default；thread 未设置时继承父 channel default；`scope=session` 设置当前 channel/thread + user 下一次新 agent session 的一次性 override。路径必须在当前 binding 目标 agent 的默认 `workingDir` 内，不会影响当前已活跃 session
-- `/nexus-settings`：daemon 返回仅调用方可见的 settings 面板，展示/修改 reply-mode、effective workingDir、channel agent binding、可恢复 session 和 thread 创建入口；面板操作每次返回一条新的 ephemeral 最新快照。workingDir 直接用 modal 输入路径，binding 是当前进程内的 channel override，重启后回到配置文件 binding
-- `/nexus-queue [action:<status|clear|next>]`：打开当前 channel/thread + user 的 daemon queue 面板；可选择 pending item 后上移、下移、编辑 prompt、取消，也可插入一条 next prompt；`next` 中断当前 running turn 并让下一条 pending item 继续执行；`clear` 只取消 pending items，不中断 running turn
-- `/nexus-reload-config`：daemon 重新加载 `config.json` 并热应用 bindings / auth / ui / textPrefixes；解析失败保留旧配置并返回错误，其余字段变更需重启生效
-- `/discord-reply-mode mode:<mention|all>`：在 allowlist 内切换 Discord 消息触发模式
-- `/reply-mode mode:<mention|all>`：legacy alias；`daemon.commandRegistry.aliases.legacy.replyMode=true` 时注册
+默认只响应显式 `@bot` 的消息，且调用者必须命中 allowlist。Slash command 会按当前频道绑定的后端动态注册。
 
-约束：
+## 项目结构
 
-- 默认只响应**显式 @ 本机器人**的消息；切到 `all` 后仍只响应 `allowedUserIds` 内用户
-- 只剥本 bot 的 mention，其他 `@<user>` 保留给 CC 看到原文
-- 附件、reaction、delete 暂未支持；Discord thread 可作为会话容器，并支持 `/nexus-new-thread` 创建；长回复会按切片发送 / edit
+```text
+packages/
+  cli/                # CLI 入口与配置加载
+  daemon/             # 路由、会话与命令分发
+  platform/discord/   # Discord adapter
+  agent/              # Claude Code / Codex 后端
+  protocol/           # 归一化消息协议
+docs/
+  product/            # 使用者文档
+  ops/                # 本机运行与排障
+  dev/                # 架构、spec、ADR 与协作规则
+```
 
-## 文档入口
+## 文档
 
-- **开发者**：先读 [`AGENTS.md`](AGENTS.md) 和 [`docs/dev/README.md`](docs/dev/README.md)
-- **使用者**：[`docs/product/README.md`](docs/product/README.md)
-- **运维者**：[`docs/ops/runbook.md`](docs/ops/runbook.md)
-- **所有文档导航**：[`docs/README.md`](docs/README.md)
+- 使用指南：[`docs/product/user-guide.md`](docs/product/user-guide.md)
+- Discord 配置：[`docs/product/platforms/discord.md`](docs/product/platforms/discord.md)
+- 运维手册：[`docs/ops/runbook.md`](docs/ops/runbook.md)
+- 开发者入口：[`AGENTS.md`](AGENTS.md) 与 [`docs/dev/README.md`](docs/dev/README.md)
+- 全部文档导航：[`docs/README.md`](docs/README.md)
 
-## 协作
+## 开发
 
-本仓库使用 Conventional Commits。任何代码或接口改动之前必须先有 ADR 或 spec 落盘。详细规则见 [`AGENTS.md`](AGENTS.md)。
+```bash
+pnpm typecheck
+pnpm test
+pnpm test:watch
+pnpm test:e2e:discord
+```
+
+本仓库使用 [Conventional Commits](https://www.conventionalcommits.org/)。开发协作规则见 [`AGENTS.md`](AGENTS.md)。
 
 ## 许可证
 


### PR DESCRIPTION
## Summary

Root README had grown into a mixed project note, detailed setup reference, and internal process index. This PR rewrites it as a concise open source project entry point.

本 PR：
- Reframes the README around project purpose, features, quick start, minimal config, usage, project structure, docs, and development commands.
- Removes the cc-connect origin story, front-loaded decision table, full config field dictionary, and internal PR/process exposition from the root entry.
- Links detailed Discord setup, Codex backend details, configuration fields, security notes, multi-instance setup, and operations to existing product / ops docs.
- Keeps current `origin/main` user-facing capabilities visible at README-entry granularity, including sessions, threads, working directory overrides, settings, and queue controls.

## Why

The root README should optimize for first-time readers and contributors. Detailed user configuration already has a single owner in `docs/product/user-guide.md`, while internal decisions and contribution process live under `docs/dev/` and `AGENTS.md`.

ADR: N/A - README copy/navigation-only change; no architectural decision changed.
Spec: N/A - no runtime contract or public API changed.

## Test plan

- [x] Tests: N/A - documentation-only change; no test files changed.
- [x] `git diff --check -- README.md` - passed.
- [x] README JSON block parse check with `JSON.parse` - passed.
- [x] README local Markdown link existence check - passed.
- [x] `rg "cc-connect|前置决策|文档先行|契约先行|测试先行|已锁定的前置决策" README.md` - no matches.
- [x] Manual: N/A - no runtime, Discord, or CLI behavior changed.

## Review notes

- Independent agent review: Claude CLI reviewed the initial README diff; it reported one important startup-flow issue and three nits. All were addressed before PR creation.
- Deep review: skipped at user request after correcting the branch base to `origin/main`.

## Out of scope

- Changing runtime behavior, config schema, Discord command registration, or backend defaults.
- Rewriting `docs/product/user-guide.md`, `docs/ops/runbook.md`, or `docs/dev/**`.
- Adding distribution packaging or hosted deployment docs.
