### PR TITLE
fix(codex): surface retry status without stopping session

### DIFF
--- a/docs/dev/spec/agent-backends/codex-cli.md
+++ b/docs/dev/spec/agent-backends/codex-cli.md
@@ -135,7 +135,7 @@ codex \
 | `item.completed` + `item.type == "command_execution"` | `tool_result` 后接 `tool_call_finished` |
 | 未识别 `item.type` | 不映射 AgentEvent；记 `codex_unknown_item` debug 日志，只保留 `type` / `id` / 安全摘要，不记录完整 payload |
 | `turn.completed` | `usage` 后接 `turn_finished{reason:"stop"}` |
-| `error` | `error` 诊断事件；永不单独结束 turn |
+| `error` | `status` + backend-private `codex_diagnostic_error` 日志；永不单独结束 turn |
 | `turn.failed` | `error` + `turn_finished{reason:"error"}` |
 | 进程被 interrupt signal 终止且无 terminal JSONL | runtime 合成 `turn_finished{reason:"user_interrupt", source:"runtime-synthesized"}` |
 | 未识别顶层 `type` | 不映射 AgentEvent；记 `codex_unknown_event` debug 日志，只保留顶层 `type` / 安全摘要，不记录完整 payload |
@@ -175,10 +175,9 @@ Usage 映射：
 
 | Codex JSONL | AgentEvent `error.payload` |
 |---|---|
-| `error.message` | `{ errorKind:"agent", code:"codex_error", message }` |
 | `turn.failed.error.message` | `{ errorKind:"agent", code:"codex_turn_failed", message }` |
 
-终态只由 `turn.completed`、`turn.failed` 或 runtime 合成的 interrupt/timeout 驱动；单独的 `error` 事件不得触发 `turn_finished`。
+Codex 顶层 `error` 是诊断 / 重连提示通道，可能出现 `Reconnecting... 1/5`、`Reconnecting... 2/5` 等临时断流信息；runtime 必须按到达顺序投递非终端 `status{message}` 并记录 backend-private 日志，不把它升级成 `AgentEvent.error`。终态只由 `turn.completed`、`turn.failed` 或 runtime 合成的 interrupt/timeout 驱动。
 
 ## 多轮语义
 
@@ -252,7 +251,7 @@ Codex 安全边界：
 
 1. JSONL fixture：baseline text → `session_started` / `text_final` / `usage` / `turn_finished`。
 2. JSONL fixture：`command_execution` start/completed → tool events 顺序正确。
-3. JSONL fixture：`error` + `turn.failed` → `error` + `turn_finished{reason:"error"}`。
+3. JSONL fixture：顶层 `error` → 连续 `status` 且不终止；`turn.failed` → `error` + `turn_finished{reason:"error"}`。
 4. JSONL fixture：未知 `item.type` 与未知顶层 `type` → debug 记录，不产 text/tool/terminal 事件，不崩溃。
 5. resume 测试：第一轮保存 `thread_id`，第二轮 argv 使用 `exec resume <thread_id>`；resume 回同 id 不重发 `session_started`。
 6. interrupt 测试：in-flight child 被终止后合成 `turn_finished{reason:"user_interrupt"}`，迟到 terminal 不双发。
@@ -272,6 +271,7 @@ Codex 安全边界：
 | `codex_compat_probe_complete` | info | `{ probeMode }` |
 | `codex_compat_probe_failed` | error | `{ step, cause }` |
 | `codex_subproc_error` | warn/error | `{ code, exitCode?, signal?, stderrSummary? }` |
+| `codex_diagnostic_error` | warn | `{ traceId, message }` |
 | `codex_interrupt_synthesized` | debug | `{ threadId?, pid?, signal }` |
 | `codex_unknown_item` | debug | `{ itemId?, itemType, summary? }` |
 | `codex_unknown_event` | debug | `{ eventType, summary? }` |

--- a/docs/dev/spec/agent-runtime.md
+++ b/docs/dev/spec/agent-runtime.md
@@ -204,6 +204,7 @@ enum EventType {
     thinking               // 内部推理片段（可选，不是所有后端支持）
     text_delta             // 文本增量（流式输出）
     text_final             // 一轮文本输出完成
+    status                 // 非终端状态 / 进度提示（如 backend 重连）
     tool_call_started      // 工具调用开始
     tool_call_progress     // 工具调用中（可选）
     tool_result            // 工具结果（独立事件；CC 多形态 content 结构化承载，见 ADR-0012 决策点 1 子问题 1-tr-B）
@@ -223,6 +224,7 @@ enum EventType {
 | `thinking` | `{ text: string }` |
 | `text_delta` | `{ text: string }` |
 | `text_final` | `{ text: string }` |
+| `status` | `{ message: string }` |
 | `tool_call_started` | `{ callId, toolName, inputSummary }` |
 | `tool_call_progress` | `{ callId, note }` |
 | `tool_result` | `{ callId, resultSequence: int, content: ToolResultContent, isError: bool }` |
@@ -252,6 +254,7 @@ enum EventType {
 - `callId` = CC 后端的 `tool_use.id` / `tool_result.tool_use_id` 归一化 ID（对应 `tool_call_started.callId`）。
 - `resultSequence` 同一 `callId` 内从 0 连续递增、不重复；不同 callId 间无可比性；最终投递顺序仍以 AgentEvent `sequence`（session 全局单调）为准。
 - `isError` ← CC `tool_result.is_error`，单条 result 级。
+- `status.message` 是非终端、可用户可见的进度 / 状态提示；它不表示 turn 失败，也不得触发 `turn_finished` 或 `session_stopped`。最终失败必须仍由 `error` / `turn_finished` / `session_stopped` 明确表达。
 
 ### TurnEndReason 枚举
 

--- a/docs/dev/spec/message-flow.md
+++ b/docs/dev/spec/message-flow.md
@@ -96,7 +96,7 @@ contracts:
     （EventType 完整枚举权威源：agent-runtime.md §AgentEvent §EventType；含
      session_started / thinking / text_delta / text_final / tool_call_started /
      tool_call_progress / tool_result / tool_call_finished / turn_finished / usage /
-     error / session_stopped）
+     status / error / session_stopped）
   - 后端专属工具 / sandbox 边界在 agent runtime 内执行（见下文 §工具边界校验）
         │
         │  (2) AgentEvent 流（push 给 daemon）

--- a/docs/dev/spec/message-protocol.md
+++ b/docs/dev/spec/message-protocol.md
@@ -243,7 +243,7 @@ daemon 默认用 `ui.toolMessages="append"` 展示工具调用轨迹：每个 `t
 
 同一 turn 内，daemon 对平台的用户可见输出（status、tool start、assistant 正文、final reply）必须按 AgentEvent 到达顺序串行执行：前一条 `send` / `edit` 完成前，不得启动后一条用户可见输出。否则慢平台请求会造成工具消息与 assistant 正文在 IM 侧错位。
 
-`status` 是非终端工作状态：支持 edit 的平台应复用同一条工作消息连续更新，后续 assistant 正文或工具消息到达时清除该临时状态；不支持 edit 的平台可降级为追加状态消息。
+`status` 是非终端工作状态：支持 edit 的平台应复用同一条工作消息连续更新，后续 assistant 正文、工具消息或终端错误到达时清除该临时状态；不支持 edit 的平台可降级为追加状态消息。
 
 在 `append` 模式下，`tool_call_started` 是 assistant 消息分段边界：如果 tool 前已经发送或缓冲了 assistant 文本，daemon 必须先固定该段文本，再发送 tool start；tool 之后到达的 `text_delta` / `text_final` 必须创建新的 assistant 消息，不得回头编辑 tool 前的消息。用户可见顺序应保持为 `assistant before tool` → `tool start` → `assistant after tool`。
 

--- a/docs/dev/spec/message-protocol.md
+++ b/docs/dev/spec/message-protocol.md
@@ -241,7 +241,9 @@ ADR-0012 已把模式 B 纳入 stream-json 主路径；daemon 在 `supportsEdit=
 
 daemon 默认用 `ui.toolMessages="append"` 展示工具调用轨迹：每个 `tool_call_started` 追加一条独立工具消息，消息正文包含工具名与目标摘要。`tool_result` 与 `tool_call_finished` 不再产生用户可见消息，也不编辑 start 消息；完整 result 细节只进入 trace 日志。后续 assistant 正文走自己的消息，不覆盖已发出的工具轨迹。
 
-同一 turn 内，daemon 对平台的用户可见输出（tool start、assistant 正文、final reply）必须按 AgentEvent 到达顺序串行执行：前一条 `send` / `edit` 完成前，不得启动后一条用户可见输出。否则慢平台请求会造成工具消息与 assistant 正文在 IM 侧错位。
+同一 turn 内，daemon 对平台的用户可见输出（status、tool start、assistant 正文、final reply）必须按 AgentEvent 到达顺序串行执行：前一条 `send` / `edit` 完成前，不得启动后一条用户可见输出。否则慢平台请求会造成工具消息与 assistant 正文在 IM 侧错位。
+
+`status` 是非终端工作状态：支持 edit 的平台应复用同一条工作消息连续更新，后续 assistant 正文或工具消息到达时清除该临时状态；不支持 edit 的平台可降级为追加状态消息。
 
 在 `append` 模式下，`tool_call_started` 是 assistant 消息分段边界：如果 tool 前已经发送或缓冲了 assistant 文本，daemon 必须先固定该段文本，再发送 tool start；tool 之后到达的 `text_delta` / `text_final` 必须创建新的 assistant 消息，不得回头编辑 tool 前的消息。用户可见顺序应保持为 `assistant before tool` → `tool start` → `assistant after tool`。
 

--- a/packages/agent/codex/src/index.test.ts
+++ b/packages/agent/codex/src/index.test.ts
@@ -508,7 +508,67 @@ describe('createCodexRuntime', () => {
     expect(finished.payload.status).toBe('ok');
   });
 
-  it('error 加 turn.failed 映射为诊断 error 和 terminal error', async () => {
+  it('顶层 error 映射为连续 status，不向 daemon 投递 AgentEvent.error', async () => {
+    const child = makeExecSubproc();
+    mockedExeca.mockReturnValueOnce(child as unknown as ReturnType<typeof execa>);
+    const runtime = makeRuntime();
+    const session = runtime.startSession(sessionKey, sessionConfig);
+    const events = collectEvents(runtime, session);
+
+    const turn = runtime.sendInput(session, {
+      type: 'user_message',
+      text: 'recover',
+      traceId: 'trace-recover',
+    });
+    await nextTick();
+    child.emitLine(JSON.stringify({ type: 'thread.started', thread_id: 'thread-recover' }));
+    child.emitLine(JSON.stringify({ type: 'turn.started' }));
+    for (const attempt of [1, 2, 3]) {
+      child.emitLine(JSON.stringify({
+        type: 'error',
+        message: `Reconnecting... ${attempt}/5 (stream disconnected before completion: tls handshake eof)`,
+      }));
+    }
+    child.emitLine(JSON.stringify({
+      type: 'item.completed',
+      item: { id: 'item_0', type: 'agent_message', text: 'recovered' },
+    }));
+    child.emitLine(JSON.stringify({
+      type: 'turn.completed',
+      usage: { input_tokens: 1, cached_input_tokens: 0, output_tokens: 1 },
+    }));
+    child.resolve();
+    await turn;
+
+    expect(events.map((event) => event.type)).toEqual([
+      'session_started',
+      'status',
+      'status',
+      'status',
+      'text_final',
+      'usage',
+      'turn_finished',
+    ]);
+    expect(
+      events
+        .filter((event) => event.type === 'status')
+        .map((event) => event.payload.message),
+    ).toEqual([
+      'Reconnecting... 1/5 (stream disconnected before completion: tls handshake eof)',
+      'Reconnecting... 2/5 (stream disconnected before completion: tls handshake eof)',
+      'Reconnecting... 3/5 (stream disconnected before completion: tls handshake eof)',
+    ]);
+    expect(fakeLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        traceId: 'trace-recover',
+        message: 'Reconnecting... 1/5 (stream disconnected before completion: tls handshake eof)',
+      }),
+      'codex_diagnostic_error',
+    );
+    expect(session.state).toBe('Idle');
+  });
+
+  it('turn.failed 映射为 terminal error', async () => {
     const child = makeExecSubproc();
     mockedExeca.mockReturnValueOnce(child as unknown as ReturnType<typeof execa>);
     const runtime = makeRuntime();
@@ -527,10 +587,13 @@ describe('createCodexRuntime', () => {
 
     expect(events.map((event) => event.type)).toEqual([
       'session_started',
-      'error',
+      'status',
       'error',
       'turn_finished',
     ]);
+    const status = events[1];
+    if (status?.type !== 'status') throw new Error('expected status');
+    expect(status.payload.message).toBe('temporary reconnecting');
     const terminal = events.at(-1);
     if (terminal?.type !== 'turn_finished') throw new Error('expected terminal');
     expect(terminal.payload).toEqual({ reason: 'error', turnSequence: 1 });

--- a/packages/agent/codex/src/index.ts
+++ b/packages/agent/codex/src/index.ts
@@ -456,11 +456,17 @@ export function createCodexRuntime(opts: CodexRuntimeOptions): AgentRuntime {
       cleanupAfterTurn(session, state);
     } else if (type === 'error') {
       if (!turn || turn.terminalEmitted) return;
-      emitEvent(state, 'error', turn.traceId, {
-        errorKind: 'agent',
-        code: 'codex_error',
-        message: safeString(event['message']) ?? 'Codex CLI emitted an error',
-      });
+      const message = truncate(
+        safeString(event['message']) ?? 'Codex CLI emitted a diagnostic error',
+      );
+      emitEvent(state, 'status', turn.traceId, { message });
+      logger.warn(
+        {
+          traceId: turn.traceId,
+          message,
+        },
+        'codex_diagnostic_error',
+      );
     } else if (type === 'turn.failed') {
       if (!turn || turn.terminalEmitted) return;
       const err = isRecord(event['error']) ? event['error'] : {};

--- a/packages/daemon/src/engine.test.ts
+++ b/packages/daemon/src/engine.test.ts
@@ -5221,6 +5221,45 @@ describe('Engine', () => {
     expect((platform.edit.mock.calls[0]![1] as OutboundMessage).text).toBe('hello');
   });
 
+  it('status 事件连续更新同一条用户可见工作消息，最终回复清除 status', async () => {
+    const platform = makePlatform({ supportsEdit: true });
+    const agent = makeAgent();
+    const store = new SessionStore();
+    const engine = new Engine({
+      platform,
+      agent: agent.runtime,
+      logger: SILENT_LOGGER,
+      sessionStore: store,
+      defaultSessionConfig: DEFAULT_CFG,
+      streaming: { streamEditThrottleMs: 0 },
+    });
+
+    await engine.start();
+    const dispatchHandler = (platform.start as ReturnType<typeof vi.fn>).mock.calls[0]![0] as EventHandler;
+
+    agent.queueEvents([
+      ev('status', { message: 'Reconnecting... 1/5' }),
+      ev('status', { message: 'Reconnecting... 2/5' }),
+      ev('status', { message: 'Reconnecting... 3/5' }),
+      ev('text_final', { text: 'done' }),
+      ev('turn_finished', { reason: 'stop', turnSequence: 1 }),
+    ]);
+
+    await dispatchHandler(makeEvent('hello'));
+
+    expect(platform.send).toHaveBeenCalledTimes(1);
+    expect((platform.send.mock.calls[0]![1] as OutboundMessage).text).toBe(
+      'Reconnecting... 1/5',
+    );
+    expect(platform.edit).toHaveBeenCalledTimes(3);
+    expect(platform.edit.mock.calls.map((call) => (call[1] as OutboundMessage).text)).toEqual([
+      'Reconnecting... 2/5',
+      'Reconnecting... 3/5',
+      'done',
+    ]);
+    expect(agent.runtime.stopSession).not.toHaveBeenCalled();
+  });
+
   it('长回复 edit 交给 platform adapter 维护切片与 messageIds', async () => {
     const platform = makePlatform({ supportsEdit: true, maxTextLength: 5 });
     const agent = makeAgent();

--- a/packages/daemon/src/engine.test.ts
+++ b/packages/daemon/src/engine.test.ts
@@ -5260,6 +5260,76 @@ describe('Engine', () => {
     expect(agent.runtime.stopSession).not.toHaveBeenCalled();
   });
 
+  it('supportsEdit=true：status 后终端 error 复用工作消息，不留下过期 status', async () => {
+    const platform = makePlatform({ supportsEdit: true });
+    const agent = makeAgent();
+    const store = new SessionStore();
+    const engine = new Engine({
+      platform,
+      agent: agent.runtime,
+      logger: SILENT_LOGGER,
+      sessionStore: store,
+      defaultSessionConfig: DEFAULT_CFG,
+      streaming: { streamEditThrottleMs: 0 },
+    });
+
+    await engine.start();
+    const dispatchHandler = (platform.start as ReturnType<typeof vi.fn>).mock.calls[0]![0] as EventHandler;
+
+    agent.queueEvents([
+      ev('status', { message: 'Reconnecting... 1/5' }),
+      ev('error', {
+        errorKind: 'agent',
+        code: 'codex_turn_failed',
+        message: '401 Unauthorized',
+      }),
+      ev('turn_finished', { reason: 'error', turnSequence: 1 }),
+    ]);
+
+    await dispatchHandler(makeEvent('hello'));
+
+    expect(platform.send).toHaveBeenCalledTimes(1);
+    expect((platform.send.mock.calls[0]![1] as OutboundMessage).text).toBe(
+      'Reconnecting... 1/5',
+    );
+    expect(platform.edit).toHaveBeenCalledTimes(1);
+    expect((platform.edit.mock.calls[0]![1] as OutboundMessage).text).toBe(
+      '[agent error: agent] 401 Unauthorized',
+    );
+  });
+
+  it('supportsEdit=false：status 降级为追加消息且最终回复顺序正确', async () => {
+    const platform = makePlatform();
+    const agent = makeAgent();
+    const store = new SessionStore();
+    const engine = new Engine({
+      platform,
+      agent: agent.runtime,
+      logger: SILENT_LOGGER,
+      sessionStore: store,
+      defaultSessionConfig: DEFAULT_CFG,
+    });
+
+    await engine.start();
+    const dispatchHandler = (platform.start as ReturnType<typeof vi.fn>).mock.calls[0]![0] as EventHandler;
+
+    agent.queueEvents([
+      ev('status', { message: 'Reconnecting... 1/5' }),
+      ev('status', { message: 'Reconnecting... 2/5' }),
+      ev('text_final', { text: 'done' }),
+      ev('turn_finished', { reason: 'stop', turnSequence: 1 }),
+    ]);
+
+    await dispatchHandler(makeEvent('hello'));
+
+    expect(platform.edit).not.toHaveBeenCalled();
+    expect(platform.send.mock.calls.map((call) => (call[1] as OutboundMessage).text)).toEqual([
+      'Reconnecting... 1/5',
+      'Reconnecting... 2/5',
+      'done',
+    ]);
+  });
+
   it('长回复 edit 交给 platform adapter 维护切片与 messageIds', async () => {
     const platform = makePlatform({ supportsEdit: true, maxTextLength: 5 });
     const agent = makeAgent();

--- a/packages/daemon/src/engine.ts
+++ b/packages/daemon/src/engine.ts
@@ -2849,6 +2849,13 @@ export class Engine {
           }
           if (e.type === 'error') {
             errored = true;
+            const statusOnlyMessage =
+              statusText !== undefined &&
+              toolStatus === undefined &&
+              buf.length === 0 &&
+              messageRef !== undefined;
+            const errorText = `[agent error: ${e.payload.errorKind}] ${e.payload.message}`;
+            statusText = undefined;
             cancelPendingEdit();
             clearTyping();
             this.logger.error(
@@ -2862,7 +2869,12 @@ export class Engine {
               'agent_error',
             );
             try {
-              await safeSend(`[agent error: ${e.payload.errorKind}] ${e.payload.message}`);
+              if (platformCaps.supportsEdit && statusOnlyMessage && messageRef) {
+                await safeEdit(messageRef, errorText);
+                currentRenderedText = errorText;
+              } else {
+                await safeSend(errorText);
+              }
             } finally {
               closeSession();
             }

--- a/packages/daemon/src/engine.ts
+++ b/packages/daemon/src/engine.ts
@@ -2444,6 +2444,7 @@ export class Engine {
       let typingInterval: ReturnType<typeof setInterval> | undefined;
       let typingActive = false;
       let toolStatus: string | undefined;
+      let statusText: string | undefined;
       const toolCallStartedAt = new Map<string, number>();
       const toolMessages = new Map<string, ToolMessageState>();
 
@@ -2492,8 +2493,9 @@ export class Engine {
       };
 
       const renderVisibleText = (): string => {
-        if (toolStatus && buf.length > 0) return `${buf}\n\n${toolStatus}`;
-        return buf.length > 0 ? buf : (toolStatus ?? '[working]');
+        const statusLines = [toolStatus, statusText].filter(Boolean).join('\n');
+        if (statusLines && buf.length > 0) return `${buf}\n\n${statusLines}`;
+        return buf.length > 0 ? buf : (statusLines || '[working]');
       };
 
       const ensureMessageRef = (
@@ -2737,12 +2739,14 @@ export class Engine {
             return;
           }
           if (e.type === 'text_delta') {
+            statusText = undefined;
             sawDelta = true;
             buf += e.payload.text;
             await scheduleEdit();
             return;
           }
           if (e.type === 'text_final') {
+            statusText = undefined;
             if (sawDelta) {
               buf = e.payload.text;
             } else {
@@ -2752,7 +2756,17 @@ export class Engine {
             await scheduleEdit();
             return;
           }
+          if (e.type === 'status') {
+            statusText = e.payload.message;
+            if (platformCaps.supportsEdit) {
+              await scheduleEdit();
+            } else {
+              await safeSend(e.payload.message);
+            }
+            return;
+          }
           if (e.type === 'tool_call_started') {
+            statusText = undefined;
             toolCallStartedAt.set(e.payload.callId, Date.now());
             this.logger.info(
               {

--- a/packages/protocol/src/agent.test.ts
+++ b/packages/protocol/src/agent.test.ts
@@ -63,10 +63,17 @@ const events = [
     payload: { text: 'final' },
   },
   {
-    type: 'tool_call_started',
+    type: 'status',
     traceId: 'trace-1',
     timestamp: new Date(0),
     sequence: 4,
+    payload: { message: 'Reconnecting... 2/5' },
+  },
+  {
+    type: 'tool_call_started',
+    traceId: 'trace-1',
+    timestamp: new Date(0),
+    sequence: 5,
     payload: {
       callId: 'toolu-1',
       toolName: 'Read',
@@ -77,7 +84,7 @@ const events = [
     type: 'tool_call_progress',
     traceId: 'trace-1',
     timestamp: new Date(0),
-    sequence: 5,
+    sequence: 6,
     payload: {
       callId: 'toolu-1',
       note: 'running',
@@ -87,7 +94,7 @@ const events = [
     type: 'tool_result',
     traceId: 'trace-1',
     timestamp: new Date(0),
-    sequence: 6,
+    sequence: 7,
     payload: {
       callId: 'toolu-1',
       resultSequence: 0,
@@ -99,7 +106,7 @@ const events = [
     type: 'tool_call_finished',
     traceId: 'trace-1',
     timestamp: new Date(0),
-    sequence: 7,
+    sequence: 8,
     payload: {
       callId: 'toolu-1',
       toolName: 'Read',
@@ -110,7 +117,7 @@ const events = [
     type: 'usage',
     traceId: 'trace-1',
     timestamp: new Date(0),
-    sequence: 8,
+    sequence: 9,
     payload: {
       model: 'claude-sonnet',
       inputTokens: 1,
@@ -128,7 +135,7 @@ const events = [
     type: 'turn_finished',
     traceId: 'trace-1',
     timestamp: new Date(0),
-    sequence: 9,
+    sequence: 10,
     payload: {
       reason: 'wallclock_timeout',
       turnSequence: 1,
@@ -139,7 +146,7 @@ const events = [
     type: 'error',
     traceId: 'trace-1',
     timestamp: new Date(0),
-    sequence: 10,
+    sequence: 11,
     payload: {
       errorKind: 'runtime',
       code: 'E_RUNTIME',
@@ -151,7 +158,7 @@ const events = [
     type: 'session_stopped',
     traceId: 'trace-1',
     timestamp: new Date(0),
-    sequence: 11,
+    sequence: 12,
     payload: { reason: 'wallclock_timeout' },
   },
 ] satisfies AgentEvent[];
@@ -162,6 +169,7 @@ function eventTypeName(event: AgentEvent): AgentEvent['type'] {
     case 'thinking':
     case 'text_delta':
     case 'text_final':
+    case 'status':
     case 'tool_call_started':
     case 'tool_call_progress':
     case 'tool_result':
@@ -185,6 +193,7 @@ describe('AgentEvent protocol contract', () => {
       'thinking',
       'text_delta',
       'text_final',
+      'status',
       'tool_call_started',
       'tool_call_progress',
       'tool_result',

--- a/packages/protocol/src/agent.ts
+++ b/packages/protocol/src/agent.ts
@@ -102,6 +102,13 @@ export type AgentEvent =
       payload: { text: string };
     }
   | {
+      type: 'status';
+      traceId: string;
+      timestamp: Date;
+      sequence: number;
+      payload: { message: string };
+    }
+  | {
       type: 'tool_call_started';
       traceId: string;
       timestamp: Date;


### PR DESCRIPTION
## Summary

Codex CLI can emit top-level `error` JSONL entries for transient reconnect progress, such as `Reconnecting... 1/5`, before the turn either recovers or eventually fails. The daemon previously treated every AgentEvent `error` as terminal, so users could see only one retry line before the session was closed.

本 PR：
- Adds a non-terminal `status` AgentEvent for backend progress messages.
- Maps Codex top-level `error` JSONL entries to ordered `status` events plus backend-private diagnostic logs instead of terminal agent errors.
- Renders `status` in daemon as a user-visible working message that updates in place on editable platforms.
- Keeps `turn.failed` as the terminal error path and updates specs/tests for the new contract.
- Covers terminal-error and non-edit platform status rendering paths found during independent review.

## Why

This keeps transient Codex reconnect attempts visible as progress while preserving the existing terminal failure semantics for real turn failures. It also prevents the first retry diagnostic from closing the active session before later `2/5`, `3/5`, etc. messages arrive.

ADR: N/A - no architecture decision; this is a protocol/event mapping bugfix within the existing agent runtime contract.
Spec: `docs/dev/spec/agent-runtime.md`, `docs/dev/spec/agent-backends/codex-cli.md`, `docs/dev/spec/message-flow.md`, `docs/dev/spec/message-protocol.md`.

## Test plan

- [x] Tests: `packages/agent/codex/src/index.test.ts` covers repeated top-level Codex `error` entries becoming ordered `status` events and `turn.failed` remaining terminal.
- [x] Tests: `packages/daemon/src/engine.test.ts` covers consecutive `status` updates, `status -> terminal error`, and non-edit platform status append ordering.
- [x] Tests: `packages/protocol/src/agent.test.ts` covers the new `status` AgentEvent union member.
- [x] `corepack pnpm typecheck` - passed in `/tmp/agent-nexus-codex-status-pr`.
- [x] `corepack pnpm test` - passed in `/tmp/agent-nexus-codex-status-pr` with 532 tests.
- [x] Manual: real Discord/Codex CLI retry path not run; covered with Codex runtime fake child process and daemon platform mock.

## Review notes

- Independent agent review: Claude review completed; two important findings were fixed in `f0821ea` (`status -> error` stale message and non-edit status coverage). No unresolved review threads.
- Deep review: N/A - scoped bugfix plus protocol/spec sync; no deployment, security model, or backend selection change.

## Out of scope

- Changing `agents[].timeoutMs` or any CLI timeout configuration behavior.
- Retrying or reconnecting inside agent-nexus itself; Codex CLI still owns its own retry policy.
- Changing terminal handling for child process failures or wall-clock timeout.
