### PR TITLE
fix(cli): make codex probe honor agent timeout

### DIFF
--- a/packages/cli/src/agent.test.ts
+++ b/packages/cli/src/agent.test.ts
@@ -130,7 +130,7 @@ describe('createAgentRuntime', () => {
     expect(runCodexProbeMock).toHaveBeenCalledWith({
       config: codex,
       logger,
-      timeoutMs: 300_000,
+      timeoutMs: 1_800_000,
     });
     expect(createCodexRuntimeMock).toHaveBeenCalledWith({ config: codex, logger });
     expect(runClaudeProbeMock).not.toHaveBeenCalled();
@@ -139,6 +139,32 @@ describe('createAgentRuntime', () => {
     expect(selected.defaultSessionConfig).toEqual({
       workingDir: '/codex',
       timeoutMs: 1_800_000,
+    });
+  });
+
+  it('codex backend 未配置 timeoutMs 时 probe 使用默认 timeout', async () => {
+    const codex = {
+      bin: 'codex',
+      workingDir: '/codex',
+      sandbox: 'read-only',
+      addDirs: [],
+      loadUserConfig: false,
+      loadRules: false,
+    } as const;
+
+    const selected = await createAgentRuntime(
+      { name: 'codex-dev', backend: 'codex', codex },
+      logger,
+    );
+
+    expect(runCodexProbeMock).toHaveBeenCalledWith({
+      config: codex,
+      logger,
+      timeoutMs: 300_000,
+    });
+    expect(selected.defaultSessionConfig).toEqual({
+      workingDir: '/codex',
+      timeoutMs: 300_000,
     });
   });
 });

--- a/packages/cli/src/agent.ts
+++ b/packages/cli/src/agent.ts
@@ -21,8 +21,6 @@ import {
   type AgentNexusConfig,
 } from './config.js';
 
-const CODEX_COMPATIBILITY_PROBE_TIMEOUT_MS = DEFAULT_AGENT_TIMEOUT_MS;
-
 export interface SelectedAgent {
   agent: AgentRuntime;
   defaultSessionConfig: Omit<
@@ -41,7 +39,7 @@ export async function createAgentRuntime(
     await runCodexCompatibilityProbe({
       config: codex,
       logger,
-      timeoutMs: CODEX_COMPATIBILITY_PROBE_TIMEOUT_MS,
+      timeoutMs,
     });
     return {
       agent: createCodexRuntime({ config: codex, logger }),


### PR DESCRIPTION
## Summary

Codex sessions now support `agents[].timeoutMs`, but the Codex startup compatibility probe still used the fixed default timeout.

This PR:
- Makes the Codex compatibility probe use the selected agent timeout.
- Keeps the default fallback at 300000ms when `agents[].timeoutMs` is omitted.
- Adds coverage for explicit and default probe timeout behavior.

## Why

The Codex runtime should use one agent-level timeout value instead of letting the session path and startup probe diverge.

ADR: N/A - no new architecture decision; this implements the existing timeout contract.
Spec: `docs/dev/spec/config-routing.md` and `docs/dev/spec/agent-runtime.md`.

## Test plan

- [x] Tests: `packages/cli/src/agent.test.ts` covers explicit timeout propagation and default fallback.
- [x] `corepack pnpm test` - 37 files / 585 tests passed.
- [x] `corepack pnpm typecheck` - passed.
- [x] `corepack pnpm build` - passed.
- [x] Manual: branch is rebased onto `origin/main` `964d34880a3cd829ae93b168d2102ffcb62599f9`; `merge-base HEAD origin/main` matches `origin/main`.

## Review notes

- Independent agent review: Claude CLI review posted at https://github.com/moesin-lab/agent-nexus/pull/173#issuecomment-4801207623; accepted SSOT and default-timeout test findings.
- Deep review: N/A - final diff is two CLI files and does not change the architecture/spec contract.

## Out of scope

- Changing Claude Code probe timeout behavior.
- Adding a separate startup-probe timeout cap.
- Reworking YOLO permission model changes already on `origin/main`.