### PR TITLE
feat(discord): render tool calls as embed cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ related:
 
 ### Changed
 
+- Discord 工具调用轨迹在平台支持时改用 embed 工具卡片展示，同时保留纯文本 fallback；工具结果仍不进入用户可见消息。
 - `/nexus-working-dir` 和 settings 里的 workingDir modal 允许设置默认 agent `workingDir` 之外的绝对路径。
 - 重构 `spec/cost-and-limits.md`：一等 limits 为 turn/wall-clock/tool-call/并发/退避/熔断，$ 预算降为 opt-in；对应同步 `spec/observability.md`（新增 `turn_limit_hit` / `tool_limit_hit` / `wallclock_timeout` 事件与 `toolCallsThisTurn` / `wallClockMs` 字段）、`architecture/session-model.md`（Session 元数据结构）、`spec/persistence.md`（sessions 表字段；`budget_events` 重命名为 `usage_events`）、`testing/eval.md`（case 05 扩为 `resource-limit-hit`）。
 - `spec/cost-and-limits.md` 二次修订（配合 ADR-0006）：开头重心从"订阅用户"改为"机制分层"；把"订阅配额跟踪"从"未来占位"提升为与 `$ 预算`并列的二等可选机制；合约测试增加"用户路径对称"case。

--- a/docs/dev/spec/message-protocol.md
+++ b/docs/dev/spec/message-protocol.md
@@ -239,13 +239,15 @@ ADR-0012 已把模式 B 纳入 stream-json 主路径；daemon 在 `supportsEdit=
 
 ### 工具消息展示
 
-daemon 默认用 `ui.toolMessages="append"` 展示工具调用轨迹：每个 `tool_call_started` 追加一条独立工具消息，消息正文包含工具名与目标摘要。`tool_result` 与 `tool_call_finished` 不再产生用户可见消息，也不编辑 start 消息；完整 result 细节只进入 trace 日志。后续 assistant 正文走自己的消息，不覆盖已发出的工具轨迹。
+daemon 默认用 `ui.toolMessages="append"` 展示工具调用轨迹：每个 `tool_call_started` 追加一条独立工具消息，消息正文包含工具名与目标摘要。平台声明 `supportsEmbeds=true` 时，这条独立工具消息可以同时携带一个平台中立的 `MessageEmbed` 工具卡片；`text` 仍必须保留可读 fallback。平台不支持 embed、fallback 文本超过平台单条消息长度、或处于 `compact` 模式时，必须退回纯文本展示。
 
 同一 turn 内，daemon 对平台的用户可见输出（status、tool start、assistant 正文、final reply）必须按 AgentEvent 到达顺序串行执行：前一条 `send` / `edit` 完成前，不得启动后一条用户可见输出。否则慢平台请求会造成工具消息与 assistant 正文在 IM 侧错位。
 
 `status` 是非终端工作状态：支持 edit 的平台应复用同一条工作消息连续更新，后续 assistant 正文、工具消息或终端错误到达时清除该临时状态；不支持 edit 的平台可降级为追加状态消息。
 
 在 `append` 模式下，`tool_call_started` 是 assistant 消息分段边界：如果 tool 前已经发送或缓冲了 assistant 文本，daemon 必须先固定该段文本，再发送 tool start；tool 之后到达的 `text_delta` / `text_final` 必须创建新的 assistant 消息，不得回头编辑 tool 前的消息。用户可见顺序应保持为 `assistant before tool` → `tool start` → `assistant after tool`。
+
+工具卡片只表达 start 事件，不承载 result。若同一个 append 工具消息后续被 edit，未显式传空 `embeds` 时沿用平台原有 embed 保留语义；需要清空时必须显式传 `embeds: []`。
 
 工具目标摘要由 agent backend 归一化为 `tool_call_started.payload.inputSummary`，daemon 只负责展示，不重新解析 backend 原始 input。Claude Code backend 的摘要规则：
 
@@ -256,7 +258,9 @@ daemon 默认用 `ui.toolMessages="append"` 展示工具调用轨迹：每个 `t
 
 工具 result 内容默认不进入用户消息。文件内容、diff、搜索命中、Bash stdout/stderr 等富展示需另行定义代码块、行号剥离、脱敏和消息位置策略后再启用。
 
-`ui.toolMessages="compact"` 用于低噪声模式：工具状态合并进当前回复消息，后续 final reply 可覆盖这条状态消息。该模式不保证保留完整用户可见工具轨迹；结构化日志仍按 observability 事件记录。
+工具 start fallback 文本与工具卡片字段都必须先经过出站脱敏，再按平台限制截断；禁止先截断再脱敏。这样避免长 input 在截断边界打碎 token 后绕过脱敏规则。工具卡片字段截断只影响卡片，不能改变 trace 日志里的结构化 tool 事件。
+
+`ui.toolMessages="compact"` 用于低噪声模式：工具状态合并进当前回复消息，后续 final reply 可覆盖这条状态消息。该模式不保证保留完整用户可见工具轨迹；结构化日志仍按 observability 事件记录。`compact` 模式本期不挂工具卡片，避免临时状态消息被 final reply 编辑覆盖时产生 stale embed。
 
 ## 控制语义
 

--- a/docs/dev/spec/platform-adapter.md
+++ b/docs/dev/spec/platform-adapter.md
@@ -496,6 +496,17 @@ Adapter 在 `client.on('ready')` 比较 `client.user?.id` 与 config 的 `botUse
 | `ephemeral` | Interaction response flags |
 | 超过 2000 字符 | 切片成多条（切片策略见 message-protocol） |
 
+Discord adapter 声明 `supportsEmbeds=true` 时，必须把 `OutboundMessage.embeds` 映射到 Discord rich embed。capability 翻转与 `send` / `edit` 实现必须同 PR 原子落地，禁止先声明支持但静默丢弃 embed。
+
+`send` / `edit` 的 embed 语义：
+
+- 单片消息：`text` 映射为 `content`，`embeds` 原样映射为 Discord `embeds`。
+- 多片消息：调用方应优先避免为切片消息附 embed；adapter 若收到多片 text + embeds，只能把 embeds 挂在第一片，后续片保持纯 content。
+- `embeds` 字段缺省：不改变平台既有 embed 状态（edit 场景）。
+- `embeds: []`：显式清空该消息上的 embed。
+
+所有 outbound embed 文本字段必须由 daemon 在调用 adapter 前完成出站脱敏；adapter 只做平台协议映射，不重新解析 tool input 或执行业务脱敏。
+
 ### Thread 创建错误语义
 
 ```text

--- a/packages/daemon/src/engine.test.ts
+++ b/packages/daemon/src/engine.test.ts
@@ -5973,8 +5973,160 @@ describe('Engine', () => {
     expect((platform.send.mock.calls[0]![1] as OutboundMessage).text).toBe(
       'Bash:\n```bash\nnpm test\n```',
     );
+    expect((platform.send.mock.calls[0]![1] as OutboundMessage).embeds).toBeUndefined();
     expect(platform.edit).not.toHaveBeenCalled();
     expect((platform.send.mock.calls[1]![1] as OutboundMessage).text).toBe('done');
+  });
+
+  it('默认 append 且平台支持 embeds：tool start 发送 fallback text 和工具卡片', async () => {
+    const platform = makePlatform({ supportsEdit: true, supportsEmbeds: true });
+    const agent = makeAgent();
+    const store = new SessionStore();
+    const engine = new Engine({
+      platform,
+      agent: agent.runtime,
+      logger: SILENT_LOGGER,
+      sessionStore: store,
+      defaultSessionConfig: DEFAULT_CFG,
+    });
+
+    await engine.start();
+    const dispatchHandler = (platform.start as ReturnType<typeof vi.fn>).mock.calls[0]![0] as EventHandler;
+
+    agent.queueEvents([
+      ev('tool_call_started', {
+        callId: 'tool-read',
+        toolName: 'Read',
+        inputSummary: 'src/index.ts',
+      }),
+      ev('text_final', { text: 'done' }),
+      ev('turn_finished', { reason: 'stop', turnSequence: 1 }),
+    ]);
+
+    await dispatchHandler(makeEvent('read file'));
+
+    expect(platform.send).toHaveBeenCalledTimes(2);
+    const toolMessage = platform.send.mock.calls[0]![1] as OutboundMessage;
+    expect(toolMessage.text).toBe('Read: src/index.ts');
+    expect(toolMessage.embeds).toEqual([
+      {
+        title: 'Tool: Read',
+        description: 'src/index.ts',
+        color: 0x64748b,
+      },
+    ]);
+    expect((platform.send.mock.calls[1]![1] as OutboundMessage).text).toBe('done');
+    expect((platform.send.mock.calls[1]![1] as OutboundMessage).embeds).toBeUndefined();
+  });
+
+  it('默认 append 且平台支持 embeds：Bash 工具卡片保留 fenced bash 描述', async () => {
+    const platform = makePlatform({ supportsEdit: true, supportsEmbeds: true });
+    const agent = makeAgent();
+    const store = new SessionStore();
+    const engine = new Engine({
+      platform,
+      agent: agent.runtime,
+      logger: SILENT_LOGGER,
+      sessionStore: store,
+      defaultSessionConfig: DEFAULT_CFG,
+    });
+
+    await engine.start();
+    const dispatchHandler = (platform.start as ReturnType<typeof vi.fn>).mock.calls[0]![0] as EventHandler;
+
+    agent.queueEvents([
+      ev('tool_call_started', {
+        callId: 'tool-bash',
+        toolName: 'Bash',
+        inputSummary: 'npm test',
+      }),
+      ev('turn_finished', { reason: 'stop', turnSequence: 1 }),
+    ]);
+
+    await dispatchHandler(makeEvent('run tests'));
+
+    const toolMessage = platform.send.mock.calls[0]![1] as OutboundMessage;
+    expect(toolMessage.text).toBe('Bash:\n```bash\nnpm test\n```');
+    expect(toolMessage.embeds?.[0]).toMatchObject({
+      title: 'Tool: Bash',
+      description: '```bash\nnpm test\n```',
+      color: 0x64748b,
+    });
+  });
+
+  it('默认 append 且平台支持 embeds：embed 字段先脱敏再截断', async () => {
+    const platform = makePlatform({
+      maxTextLength: 6000,
+      supportsEdit: true,
+      supportsEmbeds: true,
+    });
+    const agent = makeAgent();
+    const store = new SessionStore();
+    const engine = new Engine({
+      platform,
+      agent: agent.runtime,
+      logger: SILENT_LOGGER,
+      sessionStore: store,
+      defaultSessionConfig: DEFAULT_CFG,
+    });
+
+    await engine.start();
+    const dispatchHandler = (platform.start as ReturnType<typeof vi.fn>).mock.calls[0]![0] as EventHandler;
+    const summary = `${'x'.repeat(3985)} sk-ant-secret-near-boundary ${'y'.repeat(200)} path=/home/node/secret/file.ts`;
+
+    agent.queueEvents([
+      ev('tool_call_started', {
+        callId: 'tool-read',
+        toolName: 'Read',
+        inputSummary: summary,
+      }),
+      ev('turn_finished', { reason: 'stop', turnSequence: 1 }),
+    ]);
+
+    await dispatchHandler(makeEvent('read secret'));
+
+    const toolMessage = platform.send.mock.calls[0]![1] as OutboundMessage;
+    expect(toolMessage.text).not.toContain('sk-ant');
+    expect(toolMessage.text).not.toContain('/home/node/secret');
+    const description = toolMessage.embeds?.[0]?.description ?? '';
+    expect(description.length).toBeLessThanOrEqual(4000);
+    expect(description).not.toContain('sk-ant');
+    expect(description).not.toContain('/home/node/secret');
+  });
+
+  it('默认 append 且平台支持 embeds：tool fallback text 超单条长度时退回纯文本', async () => {
+    const platform = makePlatform({
+      maxTextLength: 40,
+      supportsEdit: true,
+      supportsEmbeds: true,
+    });
+    const agent = makeAgent();
+    const store = new SessionStore();
+    const engine = new Engine({
+      platform,
+      agent: agent.runtime,
+      logger: SILENT_LOGGER,
+      sessionStore: store,
+      defaultSessionConfig: DEFAULT_CFG,
+    });
+
+    await engine.start();
+    const dispatchHandler = (platform.start as ReturnType<typeof vi.fn>).mock.calls[0]![0] as EventHandler;
+
+    agent.queueEvents([
+      ev('tool_call_started', {
+        callId: 'tool-read',
+        toolName: 'Read',
+        inputSummary: 'x'.repeat(80),
+      }),
+      ev('turn_finished', { reason: 'stop', turnSequence: 1 }),
+    ]);
+
+    await dispatchHandler(makeEvent('read long input'));
+
+    const toolMessage = platform.send.mock.calls[0]![1] as OutboundMessage;
+    expect(toolMessage.text).toBe(`Read: ${'x'.repeat(80)}`);
+    expect(toolMessage.embeds).toBeUndefined();
   });
 
   it('默认 append：同一 turn 的 tool start send 完成前不发送 final reply', async () => {
@@ -6068,7 +6220,7 @@ describe('Engine', () => {
   });
 
   it('compact：tool 状态沿用当前回复消息，final edit 覆盖为最终回复', async () => {
-    const platform = makePlatform({ supportsEdit: true });
+    const platform = makePlatform({ supportsEdit: true, supportsEmbeds: true });
     const agent = makeAgent();
     const store = new SessionStore();
     const engine = new Engine({
@@ -6105,8 +6257,10 @@ describe('Engine', () => {
     expect((platform.send.mock.calls[0]![1] as OutboundMessage).text).toBe(
       'Read: src/index.ts',
     );
+    expect((platform.send.mock.calls[0]![1] as OutboundMessage).embeds).toBeUndefined();
     expect(platform.edit).toHaveBeenCalledTimes(1);
     expect((platform.edit.mock.calls[0]![1] as OutboundMessage).text).toBe('done');
+    expect((platform.edit.mock.calls[0]![1] as OutboundMessage).embeds).toBeUndefined();
   });
 
   it('默认 append：Read 等非 Bash 工具 result 不展示用户可见内容或状态', async () => {

--- a/packages/daemon/src/engine.ts
+++ b/packages/daemon/src/engine.ts
@@ -12,8 +12,10 @@ import type {
   EventHandlerResult,
   EventModalResponse,
   MessageComponent,
+  MessageEmbed,
   MessageRef,
   NormalizedEvent,
+  OutboundMessage,
   PlatformAdapter,
   SessionConfig,
   SessionKey,
@@ -183,6 +185,12 @@ const QUEUE_MOVE_UP_COMPONENT_PREFIX = `${QUEUE_COMPONENT_PREFIX}up:`;
 const QUEUE_MOVE_DOWN_COMPONENT_PREFIX = `${QUEUE_COMPONENT_PREFIX}down:`;
 const QUEUE_CANCEL_COMPONENT_PREFIX = `${QUEUE_COMPONENT_PREFIX}cancel:`;
 const QUEUE_PROMPT_FIELD_ID = 'prompt';
+const TOOL_EMBED_ACCENT_COLOR = 0x64748b;
+const EMBED_TITLE_LIMIT = 256;
+const EMBED_DESCRIPTION_LIMIT = 4000;
+const EMBED_FIELD_NAME_LIMIT = 256;
+const EMBED_FIELD_VALUE_LIMIT = 1024;
+const EMBED_FOOTER_TEXT_LIMIT = 2048;
 
 interface ActiveAgentSession {
   agent: AgentRuntime;
@@ -206,6 +214,18 @@ interface ToolMessageState {
   startText: string;
 }
 
+interface ToolStartRender {
+  text: string;
+  embed: MessageEmbed;
+}
+
+type OutboundSendInput =
+  | string
+  | {
+      text: string;
+      embeds?: MessageEmbed[];
+    };
+
 type PreparedWorkingDirUpdate =
   | {
       ok: true;
@@ -220,12 +240,33 @@ function codeBlock(lang: string, text: string): string {
   return `${fence}${lang}\n${text}\n${fence}`;
 }
 
-function renderToolStart(toolName: string, inputSummary: string): string {
+function truncateText(text: string, maxLength: number): string {
+  if (text.length <= maxLength) return text;
+  if (maxLength <= 3) return text.slice(0, maxLength);
+  return `${text.slice(0, maxLength - 3)}...`;
+}
+
+function renderToolStart(toolName: string, inputSummary: string): ToolStartRender {
   const summary = inputSummary.length > 0 ? inputSummary : '(no input)';
+  const description = toolName === 'Bash' ? codeBlock('bash', summary) : summary;
   if (toolName === 'Bash') {
-    return `Bash:\n${codeBlock('bash', summary)}`;
+    return {
+      text: `Bash:\n${description}`,
+      embed: {
+        title: `Tool: ${toolName}`,
+        description,
+        color: TOOL_EMBED_ACCENT_COLOR,
+      },
+    };
   }
-  return `${toolName}: ${summary}`;
+  return {
+    text: `${toolName}: ${summary}`,
+    embed: {
+      title: `Tool: ${toolName}`,
+      description,
+      color: TOOL_EMBED_ACCENT_COLOR,
+    },
+  };
 }
 
 function summarizeToolResultContent(content: ToolResultContent): string {
@@ -2529,6 +2570,74 @@ export class Engine {
     }
   }
 
+  private redactAndTruncateForEmbed(
+    text: string,
+    traceId: string,
+    maxLength: number,
+  ): string {
+    return truncateText(this.redactForOutbound(text, traceId), maxLength);
+  }
+
+  private redactMessageEmbed(embed: MessageEmbed, traceId: string): MessageEmbed {
+    const redacted: MessageEmbed = { ...embed };
+    if (embed.title !== undefined) {
+      redacted.title = this.redactAndTruncateForEmbed(
+        embed.title,
+        traceId,
+        EMBED_TITLE_LIMIT,
+      );
+    }
+    if (embed.description !== undefined) {
+      redacted.description = this.redactAndTruncateForEmbed(
+        embed.description,
+        traceId,
+        EMBED_DESCRIPTION_LIMIT,
+      );
+    }
+    if (embed.fields) {
+      redacted.fields = embed.fields.map((field) => ({
+        ...field,
+        name: this.redactAndTruncateForEmbed(
+          field.name,
+          traceId,
+          EMBED_FIELD_NAME_LIMIT,
+        ),
+        value: this.redactAndTruncateForEmbed(
+          field.value,
+          traceId,
+          EMBED_FIELD_VALUE_LIMIT,
+        ),
+      }));
+    }
+    if (embed.footer) {
+      redacted.footer = {
+        text: this.redactAndTruncateForEmbed(
+          embed.footer.text,
+          traceId,
+          EMBED_FOOTER_TEXT_LIMIT,
+        ),
+      };
+    }
+    return redacted;
+  }
+
+  private redactOutboundMessage(
+    message: OutboundMessage,
+    traceId: string,
+  ): OutboundMessage {
+    return {
+      ...message,
+      text: this.redactForOutbound(message.text, traceId),
+      ...(message.embeds !== undefined
+        ? {
+            embeds: message.embeds.map((embed) =>
+              this.redactMessageEmbed(embed, traceId),
+            ),
+          }
+        : {}),
+    };
+  }
+
   private appendNexusTrajectorySegment(
     active: ActiveAgentSession,
     input: {
@@ -2933,14 +3042,18 @@ export class Engine {
       const toolMessages = new Map<string, ToolMessageState>();
       let activeSessionForTrajectory: ActiveAgentSession | undefined;
 
-      const safeSend = async (text: string): Promise<MessageRef | undefined> => {
+      const safeSend = async (
+        input: OutboundSendInput,
+      ): Promise<MessageRef | undefined> => {
         try {
-          const outboundText = this.redactForOutbound(text, event.traceId);
-          return await this.platform.send(event.sessionKey, {
-            text: outboundText,
+          const payload =
+            typeof input === 'string' ? { text: input } : input;
+          const outbound = this.redactOutboundMessage({
+            ...payload,
             traceId: event.traceId,
             sessionKey: event.sessionKey,
-          });
+          }, event.traceId);
+          return await this.platform.send(event.sessionKey, outbound);
         } catch (sendErr) {
           this.logger.error(
             {
@@ -3130,6 +3243,7 @@ export class Engine {
         callId: string,
         text: string,
         toolName?: string,
+        embeds?: MessageEmbed[],
       ): Promise<void> => {
         let state = toolMessages.get(callId);
         if (!state) {
@@ -3154,14 +3268,16 @@ export class Engine {
             state.ref = ref;
             await safeEdit(ref, text);
           } else if (!ref || !platformCaps.supportsEdit) {
-            state.ref = await safeSend(text);
+            state.ref = await safeSend(
+              embeds !== undefined ? { text, embeds } : text,
+            );
           }
           state.startText = text;
           return;
         }
 
         state.startText = text;
-        state.pendingRef = safeSend(text)
+        state.pendingRef = safeSend(embeds !== undefined ? { text, embeds } : text)
           .then((ref) => {
             state.ref = ref;
             return ref;
@@ -3286,19 +3402,29 @@ export class Engine {
               },
               'tool_call_input',
             );
-            const startText = renderToolStart(
+            const start = renderToolStart(
               e.payload.toolName,
               e.payload.inputSummary,
             );
             if (toolMessageMode === 'append') {
               await splitAssistantMessageBeforeTool();
+              const redactedStartText = this.redactForOutbound(
+                start.text,
+                event.traceId,
+              );
+              const embeds =
+                platformCaps.supportsEmbeds &&
+                redactedStartText.length <= platformCaps.maxTextLength
+                  ? [start.embed]
+                  : undefined;
               await upsertToolMessage(
                 e.payload.callId,
-                startText,
+                start.text,
                 e.payload.toolName,
+                embeds,
               );
             } else {
-              await ensureToolVisible(startText);
+              await ensureToolVisible(start.text);
             }
             return;
           }

--- a/packages/platform/discord/src/index.test.ts
+++ b/packages/platform/discord/src/index.test.ts
@@ -1295,6 +1295,7 @@ describe('edit / typing capabilities', () => {
 
     expect(platform.capabilities()).toMatchObject({
       supportsEdit: true,
+      supportsEmbeds: true,
       supportsTypingIndicator: true,
       supportsSlashCommands: true,
       supportsThreads: true,
@@ -1435,6 +1436,67 @@ describe('edit / typing capabilities', () => {
     );
   });
 
+  it('send 单片带 embed：传 content 和 embeds 给 Discord', async () => {
+    const send = vi.fn(async () => ({ id: 'm-1' }));
+    discordMock.channelsFetch.mockResolvedValueOnce(makeTextChannel({ send }));
+    const platform = makePlatform();
+    const embeds = [
+      {
+        title: 'Tool: Read',
+        description: 'src/index.ts',
+        color: 0x5865f2,
+      },
+    ];
+
+    const ref = await platform.send({
+      platform: 'discord',
+      channelId: 'C1',
+      initiatorUserId: OTHER_ID,
+    }, {
+      text: 'Read: src/index.ts',
+      embeds,
+      traceId: 't-1',
+      sessionKey: { platform: 'discord', channelId: 'C1', initiatorUserId: OTHER_ID },
+    });
+
+    expect(send).toHaveBeenCalledWith({
+      content: 'Read: src/index.ts',
+      embeds,
+    });
+    expect(ref.messageIds).toEqual(['m-1']);
+    expect(ref.messageId).toBe('m-1');
+  });
+
+  it('send 多片带 embed：只在第一片带 embeds', async () => {
+    const send = vi
+      .fn()
+      .mockResolvedValueOnce({ id: 'm-1' })
+      .mockResolvedValueOnce({ id: 'm-2' });
+    discordMock.channelsFetch.mockResolvedValueOnce(makeTextChannel({ send }));
+    const platform = makePlatform();
+    const embeds = [{ title: 'Tool: Read', description: 'long', color: 0x5865f2 }];
+    const text = 'x'.repeat(SLICE_SIZE + 1);
+
+    const ref = await platform.send({
+      platform: 'discord',
+      channelId: 'C1',
+      initiatorUserId: OTHER_ID,
+    }, {
+      text,
+      embeds,
+      traceId: 't-1',
+      sessionKey: { platform: 'discord', channelId: 'C1', initiatorUserId: OTHER_ID },
+    });
+
+    expect(send).toHaveBeenNthCalledWith(1, {
+      content: 'x'.repeat(SLICE_SIZE),
+      embeds,
+    });
+    expect(send).toHaveBeenNthCalledWith(2, 'x');
+    expect(ref.messageIds).toEqual(['m-1', 'm-2']);
+    expect(ref.messageId).toBe('m-2');
+  });
+
   it('edit 单片消息：用 MessageManager.edit 更新已有 message id', async () => {
     const edit = vi.fn(async (id: string) => ({ id }));
     discordMock.channelsFetch.mockResolvedValueOnce(makeTextChannel({ edit }));
@@ -1456,6 +1518,63 @@ describe('edit / typing capabilities', () => {
     expect(edit).toHaveBeenCalledWith('m-1', 'updated');
     expect(ref.messageIds).toEqual(['m-1']);
     expect(ref.messageId).toBe('m-1');
+  });
+
+  it('edit 单片带 embed：传 content 和 embeds 给 Discord', async () => {
+    const edit = vi.fn(async (id: string) => ({ id }));
+    discordMock.channelsFetch.mockResolvedValueOnce(makeTextChannel({ edit }));
+    const platform = makePlatform();
+    const ref = {
+      platform: 'discord',
+      channelId: 'C1',
+      messageId: 'm-1',
+      messageIds: ['m-1'],
+      sentAt: new Date(0),
+    };
+    const embeds = [
+      {
+        title: 'Tool: Read',
+        description: 'src/index.ts',
+        color: 0x5865f2,
+      },
+    ];
+
+    await platform.edit(ref, {
+      text: 'Read: src/index.ts',
+      embeds,
+      traceId: 't-1',
+      sessionKey: { platform: 'discord', channelId: 'C1', initiatorUserId: OTHER_ID },
+    });
+
+    expect(edit).toHaveBeenCalledWith('m-1', {
+      content: 'Read: src/index.ts',
+      embeds,
+    });
+  });
+
+  it('edit 单片 embeds=[]：显式清空 Discord embeds', async () => {
+    const edit = vi.fn(async (id: string) => ({ id }));
+    discordMock.channelsFetch.mockResolvedValueOnce(makeTextChannel({ edit }));
+    const platform = makePlatform();
+    const ref = {
+      platform: 'discord',
+      channelId: 'C1',
+      messageId: 'm-1',
+      messageIds: ['m-1'],
+      sentAt: new Date(0),
+    };
+
+    await platform.edit(ref, {
+      text: 'updated',
+      embeds: [],
+      traceId: 't-1',
+      sessionKey: { platform: 'discord', channelId: 'C1', initiatorUserId: OTHER_ID },
+    });
+
+    expect(edit).toHaveBeenCalledWith('m-1', {
+      content: 'updated',
+      embeds: [],
+    });
   });
 
   it('edit 增长到多片：追加发送新 slice 并回写 MessageRef', async () => {

--- a/packages/platform/discord/src/index.ts
+++ b/packages/platform/discord/src/index.ts
@@ -41,6 +41,7 @@ import type {
   EventHandlerResult,
   EventModalResponse,
   MessageComponent,
+  MessageEmbed,
   MessageRef,
   NormalizedEvent,
   OutboundMessage,
@@ -125,7 +126,7 @@ export const DISCORD_CAPABILITIES: CapabilitySet = {
   supportsEdit: true,
   supportsDelete: false,
   supportsReactions: false,
-  supportsEmbeds: false,
+  supportsEmbeds: true,
   supportsButtons: true,
   supportsSelects: true,
   supportsModals: true,
@@ -509,6 +510,30 @@ function discordMessageComponents(
   }
   flushButtons();
   return rows;
+}
+
+function discordMessageEmbeds(
+  embeds: readonly MessageEmbed[] | undefined,
+): MessageEmbed[] | undefined {
+  if (embeds === undefined) return undefined;
+  return embeds.map((embed) => ({
+    ...embed,
+    ...(embed.fields
+      ? {
+          fields: embed.fields.map((field) => ({ ...field })),
+        }
+      : {}),
+    ...(embed.footer ? { footer: { ...embed.footer } } : {}),
+  }));
+}
+
+function discordMessagePayload(
+  content: string,
+  embeds: readonly MessageEmbed[] | undefined,
+): string | { content: string; embeds: MessageEmbed[] } {
+  const discordEmbeds = discordMessageEmbeds(embeds);
+  if (discordEmbeds === undefined) return content;
+  return { content, embeds: discordEmbeds };
 }
 
 function discordModal(response: EventModalResponse): unknown {
@@ -1147,8 +1172,13 @@ export function createDiscordPlatform(opts: DiscordPlatformOptions): DiscordPlat
 
       const sentIds: string[] = [];
       try {
-        for (const slice of slices) {
-          const msg = await channel.send(slice);
+        for (const [index, slice] of slices.entries()) {
+          const msg = await channel.send(
+            discordMessagePayload(
+              slice,
+              index === 0 ? message.embeds : undefined,
+            ),
+          );
           sentIds.push(msg.id);
         }
       } catch (err) {
@@ -1192,7 +1222,13 @@ export function createDiscordPlatform(opts: DiscordPlatformOptions): DiscordPlat
         const existingIds = [...ref.messageIds];
 
         for (let i = 0; i < Math.min(slices.length, existingIds.length); i++) {
-          await channel.messages.edit(existingIds[i]!, slices[i]!);
+          await channel.messages.edit(
+            existingIds[i]!,
+            discordMessagePayload(
+              slices[i]!,
+              i === 0 ? message.embeds : undefined,
+            ),
+          );
         }
 
         if (slices.length > existingIds.length) {


### PR DESCRIPTION
## Summary

Discord 里的工具调用轨迹现在是裸文本，读起来不像一个独立的工具块。本 PR 在 Discord adapter 支持 embed 后，让 append 模式的 `tool_call_started` 发送一个带纯文本 fallback 的平台中立工具卡片；compact 模式、超长 fallback、以及不支持 embed 的平台仍保持纯文本。

本 PR：
- 让 Discord adapter 声明并实现 `supportsEmbeds=true`，在 `send` / `edit` 中映射 `OutboundMessage.embeds`
- 让 daemon 在 append 模式下为 tool start 生成 `MessageEmbed` 工具卡片
- 保持 `tool_result` / `tool_call_finished` 不进入用户可见消息
- 对 embed 字段执行出站脱敏后再截断
- 更新 message protocol / platform adapter spec、CHANGELOG 和合约测试

## Why

ADR: N/A。本改动不引入新外部依赖、不改变部署形态、不改变模块依赖方向；沿用既有 `MessageEmbed` / `supportsEmbeds` 协议。

Spec:
- `docs/dev/spec/message-protocol.md`
- `docs/dev/spec/platform-adapter.md`

## Test plan

- [x] Tests: `packages/daemon/src/engine.test.ts` 覆盖 embed tool card、fallback、compact text-only、redact-before-truncate、超长 fallback 退纯文本
- [x] Tests: `packages/platform/discord/src/index.test.ts` 覆盖 `supportsEmbeds`、send/edit embed payload、显式 `embeds: []` 清空、多片首片 embed
- [x] `corepack pnpm test` — 37 files / 593 tests passed
- [x] `corepack pnpm typecheck` — passed
- [x] `corepack pnpm build` — passed
- [x] Manual: 未跑真实 Discord bot 验证；当前环境没有真实 guild/token 验证窗口，行为由 mocked Discord adapter contract 覆盖

## Review notes

- Independent agent review: Claude diff review completed. It found no blocker. One important test-gap finding was accepted: strengthened the redact-before-truncate test so the embed description actually crosses the truncation limit. A nit about Discord brand color in daemon was also addressed by switching to a neutral accent.
- Deep review: GAN review completed 2 rounds before implementation. Round 1 found the original plan under-specified embed redaction, edit lifecycle, long summary truncation, and blast radius. Round 2 marked the revised plan `接近最优`; remaining redaction-before-truncation constraint was added before implementation.

## 异议 & 回应（来自 argue / GAN self-check）

- **异议 1（blocker）**：embed 字段如果不走出站脱敏，会绕过现有 text redaction。
  **回应**：采纳。`redactOutboundMessage` 现在会处理 embed title/description/fields/footer，且测试覆盖 secret 不出现在 fallback text 或 embed description。

- **异议 2（important）**：先截断再脱敏会把 secret 切碎，导致正则不命中。
  **回应**：采纳。spec 明确 `redact -> truncate`；实现中 `redactAndTruncateForEmbed` 固定顺序，测试覆盖截断边界。

- **异议 3（important）**：compact 模式复用 final reply 消息，挂 embed 容易留下 stale embed。
  **回应**：采纳。compact 模式本 PR 保持 text-only；tool card 只用于 append 模式独立 tool start 消息。

- **异议 4（important）**：把 embed 透传进所有 send/edit 路径会扩大回归面。
  **回应**：采纳。daemon 只在 append-mode `upsertToolMessage` 调用点传 optional embed；普通 assistant/status/final reply 路径保持原样。

## Out of scope

- Tool result 富展示
- Components V2 / Container
- 附件或文件预览
- 每个工具的颜色/icon 分类
- 全局 outbound `allowed_mentions` 策略调整