### PR TITLE
docs(workflow): require main-based branches for new topics

### DIFF
--- a/docs/dev/process/code-review.md
+++ b/docs/dev/process/code-review.md
@@ -38,7 +38,7 @@ GitHub ruleset + `pr-metadata` workflow 是 merge 门禁；它们不能保证 ag
 node scripts/validate-pr-metadata.mjs --hook
 ```
 
-脚本从 stdin 读取 hook JSON；仅命中 GitHub MCP `create_pull_request` / `update_pull_request` 类工具时校验 `tool_input.title` / `tool_input.body`，其他工具直接放行。校验失败时 exit 2 并在 stderr 输出缺失项，agent 不应继续创建或改坏 PR。
+脚本从 stdin 读取 hook JSON；仅命中 GitHub MCP `create_pull_request` / `update_pull_request` 类工具时校验 `tool_input.title` / `tool_input.body`，其他工具直接放行。校验内容包括 Conventional Commits 标题、正文必填段落、checkbox、review 字段，以及 PR 正文中文要求（标题不纳入中文要求）。校验失败时 exit 2 并在 stderr 输出缺失项，agent 不应继续创建或改坏 PR。
 
 本地 hook 配置不入库。Claude Code 示例：
 

--- a/docs/dev/process/commit-and-branch.md
+++ b/docs/dev/process/commit-and-branch.md
@@ -40,6 +40,8 @@ main
 
 ### 开分支前工作区检查
 
+这里的"新任务"按 topic 判断：新的需求、bug、文档主题、规则调整，或不依赖当前未合并 PR 分支的独立 follow-up，默认都是新 topic。新 topic 的基线必须是 `main`。
+
 开任何新任务分支前，先确认当前分支和工作区：
 
 ```bash
@@ -51,7 +53,7 @@ git status --short --branch
 
 - 当前分支是 `main`
 - 工作区没有未提交改动
-- 新任务不是明确声明的 stacked PR / 修复链
+- 新任务不是明确依赖当前未合并 PR 分支的 stacked PR / 同会话连续修复链
 
 如果当前 worktree 已在 feature 分支、或有无关未提交改动，禁止在其上为无关任务继续 `git switch -c`。正确做法是从 `main` 开独立 worktree，例如：
 
@@ -59,7 +61,9 @@ git status --short --branch
 git worktree add -b <type>/<short-description> ../<repo>-<short-description> main
 ```
 
-只有当新任务明确依赖当前 feature 分支，才允许从该分支开 stacked PR；此时必须在分支说明或 PR body 里写清 `base=<当前 PR 分支>`。
+同会话连续修复链指同一会话内连续暴露的 bug，scope 差距不大、同主题、且新问题在当前 PR 合并前无法独立验证 / 独立合并（典型：A 不修就跑不到 B 的代码路径）。判据：在新开分支前先问"这个新 fix 在当前 PR 合并前能独立 run 通 / 独立合并吗？"——答否就不该并行。
+
+只有当新任务明确依赖当前未合并 PR 分支，才允许从该分支继续提交或开 stacked PR；开 stacked PR 时必须在分支说明或 PR body 里写清 `base=<当前 PR 分支>`。
 
 ## 合并策略
 

--- a/docs/dev/process/workflow.md
+++ b/docs/dev/process/workflow.md
@@ -56,6 +56,7 @@ related:
 ## 分支先行（不可跳过）
 
 - 一切改动必须在从 `main` checkout 的新分支上进行，包括纯文档、错别字、依赖补丁升级。
+- **每个新 topic 都必须重新从 `main` 派生**：topic 定义、worktree 操作与同会话连续修复链 / stacked PR 例外判定见 [`commit-and-branch.md` §开分支前工作区检查](commit-and-branch.md#开分支前工作区检查)。
 - 禁止在 `main` 上直接编辑、commit 或累积未 PR 的改动。
 - 即便是"一行改动"，也走 分支 → PR → review → squash merge 的完整链路。
 
@@ -107,7 +108,7 @@ related:
 
 - **及时同步文档**：代码改了接口，同 PR 改 spec；不接受"下 PR 再补"。
 - **范围收敛**：一旦发现当前改动牵扯到**无关**问题，开新 Issue，不要在当前 PR 里顺手改。
-- **同会话连续修复链**：同一会话内连续暴露的 bug，若 scope 差距不大、同主题、且新问题在当前 PR 合并前无法独立验证（典型：A 不修就跑不到 B 的代码路径），**应叠在当前分支继续提交（首选）或开 stacked PR 声明 `base=<当前 PR 分支>`（次选）**，禁止机械地从 `main` 拉并行 PR。判据：在新开分支前先问"这个新 fix 在当前 PR 合并前能独立 run 通 / 独立合并吗？"——答否就不该并行。"范围收敛"管的是无关顺手改，本条管的是有关连环修；两者互补不冲突。
+- **同会话连续修复链先分流**：有关连环修与无关顺手改的分界见 [`commit-and-branch.md` §开分支前工作区检查](commit-and-branch.md#开分支前工作区检查)；无关问题开新 Issue，有依赖的同会话连续修复链不要机械地从 `main` 拉并行 PR。
 - **失败时暂停**：如果某一步发现前提不成立（ADR 前提错了、spec 里某字段设计不对），**回到上一步**而不是绕过。
 
 ## 本地开发
@@ -120,6 +121,7 @@ related:
 ## 反模式
 
 - **在 `main` 上直接实现 / commit**（违反"分支先行"，绕过 PR 与独立 agent review）
+- 在已有 feature 分支上继续做无关新 topic，或从 feature 分支切出无依赖新分支（见 [`commit-and-branch.md` §禁止事项](commit-and-branch.md#禁止事项行为)）
 - 先写实现再补测试（违反 TDD，见 `process/tdd.md`）
 - 先写实现再补 spec（违反"契约先行"）
 - ADR 写完就开始写代码，跳过评审

--- a/docs/dev/standards/code-review.md
+++ b/docs/dev/standards/code-review.md
@@ -18,10 +18,16 @@ related:
 
 PR 描述沿用仓库既有形态：`Summary` / `Why` / `Test plan` / `Out of scope`。可以加其它小节，但不能省略 [`../process/code-review.md` §PR 必答三问](../process/code-review.md#pr-必答三问)、review 与验证；Test plan 必须用 checkbox 明示，便于 reviewer 一眼拒绝未完成项。
 
+PR 正文整体与各必填段落都必须以中文为主；固定英文 section 标题、`ADR:` / `Spec:` / `Tests:` 等字段名、命令、路径、代码标识符和专有名词可以保留英文。PR title 不受本条约束，仍按 [`commit-style.md`](commit-style.md) 使用 Conventional Commits。
+
+`pr-metadata` 同步门禁用正文整体与必填段落的中文比例做近似校验；reviewer 仍按本节规则判断正文是否实际可读、是否用英文段落绕过门禁。
+
+各必填段落不接受裸 `N/A`；确实不适用时也写中文理由，例如 `N/A - 本 PR 不涉及运行时路径。`。
+
 ```markdown
 ## Summary
 
-<背景和当前问题，1-2 段>
+<用中文说明背景和当前问题，1-2 段>
 
 本 PR：
 - <改了什么，1-5 条>
@@ -30,8 +36,8 @@ PR 描述沿用仓库既有形态：`Summary` / `Why` / `Test plan` / `Out of sc
 
 <为什么要做；对应的 issue / ADR / spec，或 N/A + 理由>
 
-ADR: <链接或 N/A + 理由>
-Spec: <链接或 N/A + 理由>
+ADR: <链接或 N/A + 中文理由>
+Spec: <链接或 N/A + 中文理由>
 
 ## Test plan
 
@@ -41,8 +47,8 @@ Spec: <链接或 N/A + 理由>
 
 ## Review notes
 
-- Independent agent review: <review log / PR comment / N/A + 理由>
-- Deep review: <触发条件满足时的 review log；未触发则写 N/A + 理由>
+- Independent agent review: <review log / PR comment / N/A + 中文理由>
+- Deep review: <触发条件满足时的 review log；未触发则写 N/A + 中文理由>
 
 ## Out of scope
 

--- a/scripts/validate-pr-metadata.mjs
+++ b/scripts/validate-pr-metadata.mjs
@@ -31,6 +31,85 @@ const requiredReviewFields = [
   /^- Deep review:\s*\S.+/im,
 ];
 
+const requiredChineseSections = [
+  '## Summary',
+  '## Why',
+  '## Test plan',
+  '## Review notes',
+  '## Out of scope',
+];
+const prBodyMinCjkCount = 20;
+const prBodyMinCjkRatio = 0.25;
+const prBodySectionMinCjkCount = 1;
+const prBodySectionMinCjkRatio = 0.15;
+
+function countMatches(text, pattern) {
+  return (text.match(pattern) || []).length;
+}
+
+function normalizeLanguageText(text) {
+  return text
+    .replace(/```[\s\S]*?```/g, '')
+    .replace(/`[^`]*`/g, '')
+    .replace(/^\s*(ADR|Spec):/gim, '')
+    .replace(/^\s*-\s*\[[ xX]\]\s*(Tests|Manual):/gim, '')
+    .replace(/^\s*-\s*(Independent agent review|Deep review):/gim, '')
+    .replace(/\bN\/A\b/g, '')
+    .split('\n')
+    .filter((line) => !/^##\s+/.test(line.trim()))
+    .join('\n');
+}
+
+function validateChineseText(text, label, { minCjkCount, minRatio }) {
+  const languageText = normalizeLanguageText(text);
+  const cjkCount = countMatches(languageText, /[\u3400-\u9fff]/g);
+  const latinCount = countMatches(languageText, /[A-Za-z]/g);
+  const totalLetters = cjkCount + latinCount;
+  const errors = [];
+
+  if (cjkCount < minCjkCount) {
+    errors.push(`${label} must be written in Chinese; PR title is excluded from this requirement.`);
+  }
+
+  if (totalLetters > 0 && cjkCount / totalLetters < minRatio) {
+    errors.push(`${label} must be primarily Chinese text; English section labels, commands, paths, and proper nouns are allowed.`);
+  }
+
+  return errors;
+}
+
+function escapeRegExp(text) {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function sectionBody(body, heading) {
+  const headingMatch = new RegExp(`^${escapeRegExp(heading)}\\s*$`, 'm').exec(body);
+  if (!headingMatch) return '';
+
+  const start = headingMatch.index + headingMatch[0].length;
+  const rest = body.slice(start);
+  const nextHeadingMatch = /^##\s+/m.exec(rest);
+  const end = nextHeadingMatch ? start + nextHeadingMatch.index : body.length;
+  return body.slice(start, end);
+}
+
+function validatePrBodyLanguage(body) {
+  const errors = validateChineseText(body, 'PR body', {
+    minCjkCount: prBodyMinCjkCount,
+    minRatio: prBodyMinCjkRatio,
+  });
+
+  for (const section of requiredChineseSections) {
+    if (!body.includes(section)) continue;
+    errors.push(...validateChineseText(sectionBody(body, section), `PR body section ${section}`, {
+      minCjkCount: prBodySectionMinCjkCount,
+      minRatio: prBodySectionMinCjkRatio,
+    }));
+  }
+
+  return errors;
+}
+
 function validatePrTitle(title) {
   const normalizedTitle = typeof title === 'string' ? title : '';
   if (titlePattern.test(normalizedTitle)) {
@@ -45,6 +124,8 @@ function validatePrTitle(title) {
 function validatePrBody(body) {
   const errors = [];
   const normalizedBody = typeof body === 'string' ? body : '';
+
+  errors.push(...validatePrBodyLanguage(normalizedBody));
 
   for (const section of requiredSections) {
     if (!normalizedBody.includes(section)) {
@@ -208,31 +289,32 @@ async function runTitleBodyMode(title, bodyFile) {
 function sampleBody() {
   return `## Summary
 
-Adds PR metadata validation.
+新增 PR metadata 校验，避免格式不完整的 PR 描述进入 review。
 
 本 PR：
-- Adds validation.
+- 校验 PR title 和 PR body 的必填结构。
+- 校验 PR 正文以中文为主。
 
 ## Why
 
-Keep PR descriptions complete.
+PR 描述是 reviewer 理解范围、验证方式和剩余风险的入口。正文统一使用中文，可以减少本仓库协作语境下的信息损耗。
 
-ADR: N/A - repository metadata check only.
-Spec: N/A - no runtime contract change.
+ADR: N/A - 仅调整仓库协作校验。
+Spec: N/A - 不涉及运行时契约。
 
 ## Test plan
 
-- [x] Tests: self-test.
-- [x] \`node scripts/validate-pr-metadata.mjs --self-test\` - passed.
+- [x] Tests: 覆盖 validator 自检样例。
+- [x] \`node scripts/validate-pr-metadata.mjs --self-test\` - 通过。
 
 ## Review notes
 
-- Independent agent review: N/A - self-test fixture.
-- Deep review: N/A - no architecture change.
+- Independent agent review: N/A - 自检 fixture。
+- Deep review: N/A - 无架构变更。
 
 ## Out of scope
 
-- Merge automation.
+- 合并自动化。
 `;
 }
 
@@ -251,6 +333,105 @@ async function runSelfTest() {
   });
   if (invalidErrors.length === 0) {
     throw new Error('invalid fixture unexpectedly passed');
+  }
+
+  const englishBodyErrors = validatePrMetadata({
+    title: 'docs(pr): require chinese pull request body',
+    body: `## Summary
+
+Adds pull request body validation.
+
+## Why
+
+Keep review metadata readable.
+
+ADR: N/A - docs only.
+Spec: N/A - no runtime contract.
+
+## Test plan
+
+- [x] Tests: validator self-test.
+
+## Review notes
+
+- Independent agent review: N/A - fixture.
+- Deep review: N/A - no architecture change.
+
+## Out of scope
+
+- Merge automation.
+`,
+  });
+  if (!englishBodyErrors.some((error) => error.includes('Chinese'))) {
+    throw new Error('english body fixture did not fail the Chinese body check');
+  }
+
+  const mixedBodyErrors = validatePrMetadata({
+    title: 'docs(pr): require chinese pull request body',
+    body: `## Summary
+
+新增 PR 正文中文校验。
+
+## Why
+
+Keep review metadata readable.
+
+ADR: N/A - docs only.
+Spec: N/A - no runtime contract.
+
+## Test plan
+
+- [x] Tests: validator self-test.
+
+## Review notes
+
+- Independent agent review: N/A - fixture.
+- Deep review: N/A - no architecture change.
+
+## Out of scope
+
+- Merge automation.
+`,
+  });
+  if (!mixedBodyErrors.some((error) => error.includes('## Why'))) {
+    throw new Error('mixed-language fixture did not fail the section Chinese check');
+  }
+
+  const technicalChineseBodyErrors = validatePrMetadata({
+    title: 'docs(pr): require chinese pull request body',
+    body: `## Summary
+
+新增 PR metadata 校验，要求正文整体和必填段落都以中文为主。
+
+本 PR：
+- 更新 validatePrMetadata、validatePrBody 和 validatePrBodyLanguage。
+- 保留 ADR、Spec、Tests、Independent agent review、Deep review 等固定字段名。
+- 允许 docs/dev/process/code-review.md、scripts/validate-pr-metadata.mjs 等路径保留英文。
+
+## Why
+
+PR body 是 reviewer 判断范围和风险的入口。正文统一使用中文，同时允许 Conventional Commits、MCP tool name、GitHub Actions job name 等专有名词保留英文。
+
+ADR: N/A - 仅调整协作校验。
+Spec: N/A - 不涉及运行时契约。
+
+## Test plan
+
+- [x] Tests: validate-pr-metadata self-test 覆盖中文正文、英文正文和混合段落。
+- [x] node scripts/validate-pr-metadata.mjs --self-test - 通过。
+
+## Review notes
+
+- Independent agent review: N/A - fixture。
+- Deep review: N/A - 无架构变更。
+
+## Out of scope
+
+- 合并自动化。
+`,
+  });
+  if (technicalChineseBodyErrors.length > 0) {
+    throw new Error(`technical Chinese fixture failed: ${technicalChineseBodyErrors.join('; ')}`);
   }
 
   const nonPrTool = {


### PR DESCRIPTION
## Summary

明确新 topic 的分支基线，并补充 PR 正文语言要求：PR 正文必须以中文书写，标题仍按 Conventional Commits 保持现有格式。

本 PR：
- 在 `commit-and-branch.md` 定义新 topic 的分支前检查和同会话连续修复链例外。
- 在 `workflow.md` 只保留分支先行原则和 owner 链接，避免重复定义。
- 在 code review 流程中要求 PR 正文整体与各必填段落都以中文为主，固定英文 section 标题、字段名、命令、路径和专有名词可以保留英文。
- 更新 `validate-pr-metadata.mjs`，让 PR metadata check 校验中文正文要求。

## Why

之前流程已经要求从 `main` 新建分支，但没有把“同一会话内来了无关新 topic 时不能沿用当前 feature 分支”写清楚；PR 正文也没有明确语言要求，容易出现英文正文与中文项目规则混用。这个 PR 把两条协作规则都落到 owner 文档和同步校验里。

合入后，存量 open PR 如果正文主要是英文，也会被 PR metadata check 拦截；处理方式是按本模板把正文补成中文，标题不需要因此改成中文。

ADR: N/A - 仅调整协作流程和 PR metadata 校验，不涉及架构决策。
Spec: N/A - 仅调整流程文档和仓库校验脚本，不涉及运行时契约。

## Test plan

- [x] Tests: `scripts/validate-pr-metadata.mjs --self-test` 覆盖有效中文正文、英文正文拒绝、混合段落拒绝和技术性中文正文通过。
- [x] `node scripts/validate-pr-metadata.mjs --self-test` - 通过。
- [x] `node scripts/validate-pr-metadata.mjs --title "docs(workflow): require main-based branches for new topics" --body-file <本正文临时文件>` - 通过。
- [x] `node scripts/validate-pr-metadata.mjs --hook <模拟 update_pull_request JSON>` - 通过。
- [x] `node scripts/validate-pr-metadata.mjs --hook <仅更新 title 的模拟 JSON>` - 通过，确认标题更新不触发正文中文校验。
- [x] `git diff --check` - 通过。
- [x] Manual: N/A - 本 PR 不涉及运行时路径；已通过独立 review 检查文档锚点、术语和 SSOT。

## Review notes

- Independent agent review: Claude review 已完成。初审发现 topic 定义和 stacked PR 例外存在 SSOT 漂移；后续已将完整判据收敛到 `commit-and-branch.md`，closeout review 确认无剩余必改问题。本轮中文正文校验 review 发现整体比例过宽和存量 PR 迁移风险；已加强到 section 级校验，并在正文说明存量 PR 影响。
- Deep review: N/A - 流程文档和 metadata 校验的小范围变更，无架构级改动。

## Out of scope

- 增加分支自动化或 Git hook。
- 修改现有分支、worktree 或已打开 PR 的标题格式。
- 将 PR title 改成中文；标题仍沿用 Conventional Commits。
